### PR TITLE
spec(v1_0): require `value` in `updateDataModel` and enforce explicit `null` deletion

### DIFF
--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -263,7 +263,7 @@ This message is used to send or update the data that populates the UI components
 
 - `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to. This must be globally unique for the renderer's lifetime.
 - `path` (string, optional): A JSON Pointer to the location in the data model to update. Defaults to `/`.
-- `value` (any, optional): The new value for the specified path. If omitted, the key at `path` is removed.
+- `value` (any, required): The new value for the specified path. To delete the key/value at `path`, set `value` explicitly to `null`.
 
 **Example:**
 
@@ -862,7 +862,7 @@ The `updateDataModel` message replaces the value at the specified `path` with th
 
 - `surfaceId` (string, required): The ID of the surface to update.
 - `path` (string, optional): A JSON Pointer to the location in the data model to update. Defaults to `/`.
-- `value` (any, optional): The new value for the specified path. If omitted, the key at `path` is removed.
+- `value` (any, required): The new value for the specified path. To delete the key/value at `path`, set `value` explicitly to `null`.
 
 **Examples:**
 
@@ -886,7 +886,8 @@ _Remove a field:_
   "version": "v1.0",
   "updateDataModel": {
     "surfaceId": "surface_123",
-    "path": "/user/tempData"
+    "path": "/user/tempData",
+    "value": null
   }
 }
 ```

--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -62,7 +62,7 @@ Version 1.0 differs from 0.9 in the following ways:
 
 ### 2.7. Data encoding
 
-- Standardized data deletion behavior in `updateDataModel`. Setting a path's value to `null` deletes the key at that path. Removing or omitting keys in `updateDataModel` is no longer used for deletion.
+- Standardized data deletion behavior in `updateDataModel` by making the `value` property required. Setting a path's value to `null` deletes the key at that path. Omitting the `value` property is now a schema validation error.
 - Removed `callableFrom` and `returnType` properties and validation constraints from `FunctionCall` and dynamic value schemas in `common_types.json`, deferring boundary checking and return type validation entirely to runtime execution.
 - Added built-in `@index` function (with optional `offset` parameter) under `FunctionCall` to retrieve the iteration index during list template rendering. Reserved the `@` prefix for core system context evaluations.
 
@@ -87,7 +87,7 @@ This section outlines the steps required to migrate existing applications and co
 - Ensure all generated catalog entity names conform to UAX #31 identifier rules.
 - Do not include `callableFrom` or `returnType` properties in wire-level `FunctionCall` payloads. Set static `callableFrom` and `returnType` metadata in catalog function definitions where needed.
 - Update custom SVG icon definitions in `Icon` components to rename `svgPath` to `path`. Update `Video`, `TextField`, and `Slider` components to support optional `posterUrl`, `placeholder`, and `steps` properties.
-- Explicitly set values to `null` in `updateDataModel` messages to delete keys at specified paths. Do not omit keys or send undefined to indicate deletion.
+- Explicitly set values to `null` in `updateDataModel` messages to delete keys at specified paths. The `value` property is now required, and omitting it is a schema validation error.
 
 ### For renderers and clients
 

--- a/specification/v1_0/json/server_to_client.json
+++ b/specification/v1_0/json/server_to_client.json
@@ -107,8 +107,7 @@
               "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
             },
             "value": {
-              "description": "The data to be updated in the data model. To delete the key/value at 'path', set 'value' explicitly to null.",
-              "additionalProperties": true
+              "description": "The data to be updated in the data model. To delete the key/value at 'path', set 'value' explicitly to null."
             }
           },
           "required": ["surfaceId", "value"],

--- a/specification/v1_0/json/server_to_client.json
+++ b/specification/v1_0/json/server_to_client.json
@@ -107,11 +107,11 @@
               "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
             },
             "value": {
-              "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
+              "description": "The data to be updated in the data model. To delete the key/value at 'path', set 'value' explicitly to null.",
               "additionalProperties": true
             }
           },
-          "required": ["surfaceId"],
+          "required": ["surfaceId", "value"],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
This change resolves the specification inconsistency where the evolution guide and actual schema/protocol spec disagreed on deletion semantics.

- Modified server_to_client.json schema to make the value property of UpdateDataModelMessage required.

- Updated a2ui_protocol.md and evolution_guide.md documentation to specify that omitting the value property is a validation error, and setting value explicitly to null is the only mechanism to delete keys at a target path.

- Updated the field removal example to use value: null.

Fixes https://github.com/a2ui-project/a2ui/issues/1915
