### PR TITLE
spec(v1_0): restore `svgPath` and `DataBinding` support for `Icon.name`

### DIFF
--- a/specification/v1_0/catalogs/basic/catalog.json
+++ b/specification/v1_0/catalogs/basic/catalog.json
@@ -162,12 +162,15 @@
                 {
                   "type": "object",
                   "properties": {
-                    "path": {
+                    "svgPath": {
                       "type": "string"
                     }
                   },
-                  "required": ["path"],
+                  "required": ["svgPath"],
                   "additionalProperties": false
+                },
+                {
+                  "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DataBinding"
                 }
               ]
             },

--- a/specification/v1_0/catalogs/basic/catalog.json
+++ b/specification/v1_0/catalogs/basic/catalog.json
@@ -163,7 +163,7 @@
                   "type": "object",
                   "properties": {
                     "svgPath": {
-                      "type": "string"
+                      "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString"
                     }
                   },
                   "required": ["svgPath"],

--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -32,7 +32,6 @@ Version 1.0 differs from 0.9 in the following ways:
 - Added `placeholder` prop to the `TextField` component schema.
 - Added a `steps` property to the `Slider` component schema to snap values to discrete intervals.
 - Added an optional `instructions` field to the `Catalog` schema (`catalogs/basic/catalog.json`) to embed Markdown guidelines/rules directly, replacing the external `rules.txt` file.
-- Renamed `svgPath` to `path` in the custom SVG icon definition object schema.
 - Renamed `$defs/theme` to `$defs/surfaceProperties` in the basic catalog.
 
 ### 2.3. Server-to-client messages
@@ -86,7 +85,7 @@ This section outlines the steps required to migrate existing applications and co
 - Rename the `$defs/theme` catalog definition to `$defs/surfaceProperties` and remove the `primaryColor` field.
 - Ensure all generated catalog entity names conform to UAX #31 identifier rules.
 - Do not include `callableFrom` or `returnType` properties in wire-level `FunctionCall` payloads. Set static `callableFrom` and `returnType` metadata in catalog function definitions where needed.
-- Update custom SVG icon definitions in `Icon` components to rename `svgPath` to `path`. Update `Video`, `TextField`, and `Slider` components to support optional `posterUrl`, `placeholder`, and `steps` properties.
+- Update `Video`, `TextField`, and `Slider` components to support optional `posterUrl`, `placeholder`, and `steps` properties.
 - Explicitly set values to `null` in `updateDataModel` messages to delete keys at specified paths. Do not omit keys or send undefined to indicate deletion.
 
 ### For renderers and clients

--- a/specification/v1_0/test/cases/icon_checks.json
+++ b/specification/v1_0/test/cases/icon_checks.json
@@ -1,0 +1,122 @@
+{
+  "schema": "server_to_client.json",
+  "tests": [
+    {
+      "description": "Icon: Valid standard icon string",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "icon_std",
+              "component": "Icon",
+              "name": "star"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Icon: Valid custom SVG icon with literal svgPath string",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "icon_custom_literal",
+              "component": "Icon",
+              "name": {
+                "svgPath": "M10 10 H 90 V 90 H 10 Z"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Icon: Valid custom SVG icon with data bound svgPath path",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "icon_custom_bound",
+              "component": "Icon",
+              "name": {
+                "svgPath": {
+                  "path": "/custom/svg/path"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Icon: Valid data bound Icon.name",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "icon_name_bound",
+              "component": "Icon",
+              "name": {
+                "path": "/dynamic/icon/name"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Icon: Invalid custom SVG icon with type mismatch on svgPath (should fail)",
+      "valid": false,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "icon_invalid_type",
+              "component": "Icon",
+              "name": {
+                "svgPath": 12345
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Icon: Invalid custom SVG icon with extra fields in svgPath binding (should fail)",
+      "valid": false,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "icon_invalid_extra",
+              "component": "Icon",
+              "name": {
+                "svgPath": {
+                  "path": "/custom/svg/path",
+                  "extra": 1
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This change resolves the unintended loss of data-binding support for the Icon component in v1.0.

- In the v1.0 basic catalog schema, restored the custom SVG path key name to svgPath (porting the fix from PR #1347), reverting the accidental rename to path.

- Restored DataBinding to the oneOf definition of Icon.name so that icon names can continue to be dynamically data-bound.

- Removed custom SVG svgPath -> path rename instructions from evolution_guide.md.
