### PR TITLE
feat(lit): migrate basic catalog components to light DOM rendering

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- (v0_9) Migrate Basic Catalog components and surface rendering from Shadow DOM to Light DOM. [#2204](https://github.com/a2ui-project/a2ui/pull/2204)
+
 ## 0.10.3
 
 - Enable `inlineSources` in `tsconfig.json` to populate `sourcesContent` in sourcemaps.

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -70,7 +70,7 @@
       ]
     },
     "test:unit": {
-      "command": "node --test --enable-source-maps --test-reporter spec dist/src/0.8/*.test.js dist/src/v0_9/tests/*.test.js dist/src/v0_9/tests/**/*.test.js",
+      "command": "node --test --enable-source-maps --test-reporter spec dist/src/0.8/*.test.js dist/src/v0_9/tests/**/*.test.js",
       "dependencies": [
         "build"
       ]

--- a/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
@@ -15,6 +15,7 @@
  */
 
 import {ComponentApi, type ComponentId} from '@a2ui/web_core/v0_9';
+import {css, type CSSResult} from 'lit';
 import {A2uiLitElement} from '../../a2ui-lit-element.js';
 import {injectBasicCatalogStyles, computeColorVariant} from '@a2ui/web_core/v0_9/basic_catalog';
 
@@ -37,9 +38,117 @@ export type ResolvedChildList = ResolvedChildRef[];
 export abstract class BasicCatalogA2uiLitElement<
   Api extends ComponentApi,
 > extends A2uiLitElement<Api> {
+  /**
+   * Renders into the element's direct children (Light DOM) instead of a ShadowRoot.
+   */
+  override createRenderRoot() {
+    return this;
+  }
+
+  private adoptStyles() {
+    if (typeof document === 'undefined') return;
+    const root = this.getRootNode() as Document | ShadowRoot;
+
+    const constructor = this.constructor as typeof BasicCatalogA2uiLitElement & {
+      _processedSheet?: CSSStyleSheet;
+      _processedCss?: string;
+      _processedStyle?: CSSResult;
+      _adoptedRoots?: WeakSet<Node>;
+    };
+    const styles = constructor.styles;
+    if (!styles) return;
+
+    const tagName = this.tagName.toLowerCase();
+
+    if (!constructor._processedStyle) {
+      const styleList = Array.isArray(styles) ? styles : [styles];
+      const rawCss = styleList
+        .map(s =>
+          s && typeof s === 'object' && 'cssText' in s ? String((s as any).cssText) : String(s),
+        )
+        .join('\n');
+
+      // In Light DOM, replace :host selectors with the specific tagName
+      // and scope descendant selectors to avoid leaking styles to other components.
+      const baseCss = rawCss
+        .replace(/:where\(:host\)/g, `:where(${tagName})`)
+        .replace(/:host\(([^)]+)\)/g, `${tagName}$1`)
+        .replace(/:host/g, tagName);
+
+      let processedCss = baseCss;
+
+      try {
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(baseCss);
+
+        const scopeRule = (rule: CSSRule): string => {
+          if (typeof CSSStyleRule !== 'undefined' && rule instanceof CSSStyleRule) {
+            const scopedSelectors = rule.selectorText
+              .split(',')
+              .map(sel => {
+                sel = sel.trim();
+                if (
+                  sel === tagName ||
+                  sel.startsWith(tagName + ' ') ||
+                  sel.startsWith(tagName + '.') ||
+                  sel.startsWith(tagName + ':') ||
+                  sel.startsWith(tagName + '[') ||
+                  sel.startsWith(`:where(${tagName}`) ||
+                  sel.startsWith(`:is(${tagName}`)
+                ) {
+                  return sel;
+                }
+                return `${tagName} ${sel}`;
+              })
+              .join(', ');
+            return `${scopedSelectors} { ${rule.style.cssText} }`;
+          } else if (typeof CSSMediaRule !== 'undefined' && rule instanceof CSSMediaRule) {
+            const inner = Array.from(rule.cssRules).map(scopeRule).join('\n');
+            return `@media ${rule.conditionText} {\n${inner}\n}`;
+          }
+          return rule.cssText;
+        };
+
+        processedCss = Array.from(sheet.cssRules).map(scopeRule).join('\n');
+        const scopedSheet = new CSSStyleSheet();
+        scopedSheet.replaceSync(processedCss);
+        constructor._processedSheet = scopedSheet;
+      } catch {
+        // Fallback for environments lacking CSSStyleSheet support
+      }
+
+      constructor._processedCss = processedCss;
+      constructor._processedStyle = css([processedCss] as unknown as TemplateStringsArray);
+      constructor._adoptedRoots = new WeakSet();
+    }
+
+    const target =
+      typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot
+        ? root
+        : typeof document !== 'undefined'
+          ? document
+          : undefined;
+
+    if (target) {
+      if (!constructor._adoptedRoots) {
+        constructor._adoptedRoots = new WeakSet();
+      }
+      if (!constructor._adoptedRoots.has(target)) {
+        constructor._adoptedRoots.add(target);
+        if (constructor._processedSheet && (target as any).adoptedStyleSheets) {
+          (target as any).adoptedStyleSheets = [
+            ...(target as any).adoptedStyleSheets,
+            constructor._processedSheet,
+          ];
+        }
+      }
+    }
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     injectBasicCatalogStyles();
+    this.adoptStyles();
   }
 
   override willUpdate(changedProperties: Map<string, any>) {

--- a/renderers/lit/src/v0_9/catalogs/basic/components/AudioPlayer.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/AudioPlayer.ts
@@ -23,7 +23,8 @@ import {A2uiController} from '../../../a2ui-controller.js';
 @customElement('a2ui-audioplayer')
 export class A2uiAudioPlayerElement extends BasicCatalogA2uiLitElement<typeof AudioPlayerApi> {
   static override styles = css`
-    :host {
+    :host,
+    a2ui-audioplayer {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-spacing-xs, 0.25rem);

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
@@ -42,11 +42,12 @@ export class A2uiBasicButtonElement extends BasicCatalogA2uiLitElement<typeof Bu
    * - `--a2ui-button-margin`: The outer margin of the button. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-basic-button {
       display: inline-block;
       margin: var(--a2ui-button-margin, var(--a2ui-spacing-m));
     }
-    :where(:host) {
+    :where(:host, a2ui-basic-button) {
       --_color-primary: var(--a2ui-color-primary, #17e);
       --_button-border-radius: var(--a2ui-button-border-radius, var(--a2ui-spacing-s, 0.25rem));
       --_button-padding: var(

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
@@ -33,7 +33,8 @@ export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> 
    * - `--a2ui-card-margin`: The outer margin of the card. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-card {
       display: block;
       border: var(
         --a2ui-card-border,

--- a/renderers/lit/src/v0_9/catalogs/basic/components/CheckBox.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/CheckBox.ts
@@ -36,7 +36,8 @@ export class A2uiCheckBoxElement extends BasicCatalogA2uiLitElement<typeof Check
    * - `--a2ui-checkbox-label-font-weight`: Font weight of the label. Defaults to `--a2ui-label-font-weight` then `bold`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-checkbox {
       display: block;
     }
     .container {

--- a/renderers/lit/src/v0_9/catalogs/basic/components/ChoicePicker.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/ChoicePicker.ts
@@ -36,7 +36,8 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
    * - `--a2ui-choicepicker-chip-border-radius`: Border radius for chips. Defaults to `999px`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-choicepicker {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-choicepicker-gap, var(--a2ui-spacing-xs, 0.25rem));
@@ -51,7 +52,8 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
       color: var(--a2ui-choicepicker-label-color, inherit);
       font-size: var(--a2ui-choicepicker-label-font-size, inherit);
     }
-    :host > label {
+    :host,
+    a2ui-choicepicker > label {
       font-size: var(
         --a2ui-choicepicker-label-font-size,
         var(--a2ui-label-font-size, var(--a2ui-font-size-s))

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
@@ -50,7 +50,8 @@ export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof Co
    * - `--a2ui-column-gap`: The gap between items in the column. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-basic-column {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-column-gap, var(--a2ui-spacing-m));

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -61,7 +61,8 @@ export class A2uiDateTimeInputElement extends BasicCatalogA2uiLitElement<typeof 
    * - `--a2ui-datetimeinput-label-font-weight`: Font weight of the label. Defaults to `--a2ui-label-font-weight` then `bold`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-datetimeinput {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-spacing-xs, 0.25rem);

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Divider.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Divider.ts
@@ -31,7 +31,8 @@ export class A2uiDividerElement extends BasicCatalogA2uiLitElement<typeof Divide
    * - `--a2ui-divider-spacing`: The spacing around the divider. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-divider {
       display: block;
       align-self: stretch;
     }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Icon.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Icon.ts
@@ -43,10 +43,11 @@ export class A2uiIconElement extends BasicCatalogA2uiLitElement<typeof IconApi> 
    * - `--a2ui-icon-font-variation-settings`: Complete override for font-variation-settings.
    */
   static override styles = css`
-    :where(:host) {
+    :where(:host, a2ui-icon) {
       --_icon-size: var(--a2ui-icon-size, var(--a2ui-font-size-xl, 24px));
     }
-    :host {
+    :host,
+    a2ui-icon {
       display: inline-flex;
       align-items: center;
       justify-content: center;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
@@ -42,7 +42,7 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
       height: auto;
       border-radius: var(--a2ui-image-border-radius, 0);
     }
-    :host(.icon),
+    :is(:host(.icon), a2ui-image.icon),
     img.icon {
       width: var(--a2ui-image-icon-size, 24px);
       height: var(--a2ui-image-icon-size, 24px);
@@ -52,15 +52,15 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
       height: var(--a2ui-image-avatar-size, 40px);
       border-radius: 50%;
     }
-    :host(.smallFeature),
+    :is(:host(.smallFeature), a2ui-image.smallFeature),
     img.smallFeature {
       max-width: var(--a2ui-image-small-feature-size, 100px);
     }
-    :host(.largeFeature),
+    :is(:host(.largeFeature), a2ui-image.largeFeature),
     img.largeFeature {
       max-height: var(--a2ui-image-large-feature-size, 400px);
     }
-    :host(.header),
+    :is(:host(.header), a2ui-image.header),
     img.header {
       height: var(--a2ui-image-header-size, 200px);
       object-fit: cover;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/List.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/List.ts
@@ -27,7 +27,8 @@ import {A2uiController} from '../../../a2ui-controller.js';
 @customElement('a2ui-list')
 export class A2uiListElement extends BasicCatalogA2uiLitElement<typeof ListApi> {
   static override styles = css`
-    :host {
+    :host,
+    a2ui-list {
       display: flex;
       overflow: auto;
       gap: var(--a2ui-list-gap, var(--a2ui-spacing-m, 0.5rem));

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
@@ -31,7 +31,8 @@ export class A2uiLitModal extends BasicCatalogA2uiLitElement<typeof ModalApi> {
    * - `--a2ui-modal-border-radius`: Border radius of the dialog. Defaults to `8px`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-modal {
       display: inline-block;
     }
     dialog {

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
@@ -50,7 +50,8 @@ export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowAp
    * - `--a2ui-row-gap`: The gap between items in the row. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-basic-row {
       display: flex;
       flex-direction: row;
       gap: var(--a2ui-row-gap, var(--a2ui-spacing-m));

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Slider.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Slider.ts
@@ -32,7 +32,8 @@ export class A2uiSliderElement extends BasicCatalogA2uiLitElement<typeof SliderA
    * - `--a2ui-slider-label-font-weight`: Font weight of the label. Defaults to `--a2ui-label-font-weight` then `bold`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-slider {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-spacing-xs, 0.25rem);

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
@@ -35,7 +35,8 @@ export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
    * - `--a2ui-tabs-content-padding`: Default `0 var(--a2ui-spacing-m, 0.5rem)`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-tabs {
       display: block;
     }
     .a2ui-tabs-headers {

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
@@ -37,7 +37,8 @@ export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof Text
    * It also supports `--_a2ui-text-color` override from parent components (like Button).
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-basic-text {
       display: inline-block;
       color: var(--_a2ui-text-color, var(--a2ui-text-color-text, var(--a2ui-color-on-background)));
     }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
@@ -40,7 +40,8 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
    * - `--a2ui-color-on-input`: Text color.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-basic-textfield {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-spacing-xs, 0.25rem);

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Video.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Video.ts
@@ -29,7 +29,8 @@ export class A2uiVideoElement extends BasicCatalogA2uiLitElement<typeof VideoApi
    * - `--a2ui-video-border-radius`: Controls the rounded corners of the video. Defaults to `0`.
    */
   static override styles = css`
-    :host {
+    :host,
+    a2ui-video {
       display: block;
       width: 100%;
     }

--- a/renderers/lit/src/v0_9/tests/a2ui-surface.test.ts
+++ b/renderers/lit/src/v0_9/tests/a2ui-surface.test.ts
@@ -63,7 +63,7 @@ describe('A2uiSurface', () => {
     await asyncUpdate(el, e => document.body.appendChild(e as any));
 
     // Without surface, it should render nothing
-    assert.strictEqual(el.shadowRoot?.innerHTML, '<!---->');
+    assert.strictEqual((el.renderRoot as HTMLElement).innerHTML, '<!---->');
 
     document.body.removeChild(el);
   });
@@ -76,7 +76,7 @@ describe('A2uiSurface', () => {
       e.surface = surfaceModel;
     });
 
-    const html = el.shadowRoot?.innerHTML;
+    const html = (el.renderRoot as HTMLElement).innerHTML;
     assert.ok(html?.includes('Loading surface'), 'Should contain loading text');
 
     document.body.removeChild(el);
@@ -90,7 +90,7 @@ describe('A2uiSurface', () => {
       e.surface = surfaceModel;
     });
 
-    assert.ok(el.shadowRoot?.innerHTML?.includes('Loading surface'));
+    assert.ok((el.renderRoot as HTMLElement).innerHTML?.includes('Loading surface'));
 
     // Add root component
     await asyncUpdate(el, () => {
@@ -114,13 +114,13 @@ describe('A2uiSurface', () => {
     await el.updateComplete;
 
     // Wait for the child element (a2ui-text) to finish updating as well
-    const childEl = el.shadowRoot?.querySelector('a2ui-basic-text') as any;
+    const childEl = el.renderRoot.querySelector('a2ui-basic-text') as any;
     if (childEl && childEl.updateComplete) {
       await childEl.updateComplete;
     }
 
-    const html = el.shadowRoot?.innerHTML;
-    const childHtml = childEl?.shadowRoot?.innerHTML;
+    const html = (el.renderRoot as HTMLElement).innerHTML;
+    const childHtml = childEl?.innerHTML;
 
     assert.ok(!html?.includes('Loading surface'), 'Loading text should be gone');
     assert.ok(childHtml?.includes('Hello JSDOM'), 'Actual child HTML: ' + childHtml);

--- a/renderers/lit/src/v0_9/tests/basic-catalog-a2ui-lit-element.test.ts
+++ b/renderers/lit/src/v0_9/tests/basic-catalog-a2ui-lit-element.test.ts
@@ -17,43 +17,272 @@
 import {setupTestDom, teardownTestDom, asyncUpdate} from './dom-setup.js';
 import assert from 'node:assert';
 import {describe, it, beforeEach, after, before} from 'node:test';
+import {css} from 'lit';
 
-import {
-  ComponentContext,
-  MessageProcessor,
-  Catalog,
-  ComponentApi,
-  SurfaceModel,
-} from '@a2ui/web_core/v0_9';
+import {ComponentContext, MessageProcessor, ComponentApi, SurfaceModel} from '@a2ui/web_core/v0_9';
 import {LitComponentApi} from '../types.js';
 import {A2uiController} from '../a2ui-controller.js';
 
 describe('BasicCatalogA2uiLitElement', () => {
-  let basicCatalog: Catalog<LitComponentApi>;
+  let basicCatalog: any;
+  let module: typeof import('../catalogs/basic/basic-catalog-a2ui-lit-element.js');
 
   before(async () => {
     setupTestDom();
 
-    const module = await import('../catalogs/basic/basic-catalog-a2ui-lit-element.js');
+    module = await import('../catalogs/basic/basic-catalog-a2ui-lit-element.js');
     basicCatalog = (await import('../catalogs/basic/index.js')).basicCatalog;
 
-    // Create a mock A2uiLitElement for tests
+    function defineCustomElement(name: string, constructor: CustomElementConstructor) {
+      if (!customElements.get(name)) {
+        customElements.define(name, constructor);
+      }
+    }
+
     class TestBasicElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        :host {
+          display: block;
+        }
+      `;
+
       createController() {
-        const controllerMock = {
+        return {
           props: {},
           dispose: () => {},
         } as A2uiController<ComponentApi>;
-
-        return controllerMock;
       }
 
       override render() {
         return null;
       }
     }
+    defineCustomElement('test-basic-element', TestBasicElement);
 
-    customElements.define('test-basic-element', TestBasicElement);
+    class TestCssTransformElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        :host {
+          display: flex;
+        }
+        :where(:host) {
+          margin: 0;
+        }
+        :host(.active) {
+          background-color: blue;
+        }
+        :host([disabled]) {
+          opacity: 0.5;
+        }
+        :host:hover {
+          color: green;
+        }
+        .child-item {
+          padding: 8px;
+        }
+        button {
+          cursor: pointer;
+        }
+        div > span.highlight {
+          font-weight: bold;
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-css-transform-el', TestCssTransformElement);
+
+    class TestNoDoublePrefixElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        test-no-double-prefix-el {
+          display: inline-block;
+        }
+        test-no-double-prefix-el .inner {
+          color: red;
+        }
+        test-no-double-prefix-el.active {
+          color: yellow;
+        }
+        test-no-double-prefix-el:focus {
+          outline: none;
+        }
+        test-no-double-prefix-el[hidden] {
+          display: none;
+        }
+        :where(test-no-double-prefix-el) {
+          box-sizing: border-box;
+        }
+        :is(test-no-double-prefix-el, .other) {
+          color: purple;
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-no-double-prefix-el', TestNoDoublePrefixElement);
+
+    class TestCommaSelectorsElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        :host,
+        .item,
+        span > a {
+          color: cyan;
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-comma-selectors-el', TestCommaSelectorsElement);
+
+    class TestMediaQueryElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        @media (max-width: 600px) {
+          :host {
+            display: none;
+          }
+          .sidebar {
+            width: 100%;
+          }
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-media-query-el', TestMediaQueryElement);
+
+    const baseStyle = css`
+      :host {
+        color: black;
+      }
+    `;
+    const componentStyle = css`
+      .label {
+        font-size: 14px;
+      }
+    `;
+    class TestArrayStylesElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = [baseStyle, componentStyle];
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-array-styles-el', TestArrayStylesElement);
+
+    class TestNoStylesElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = undefined;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-no-styles-el', TestNoStylesElement);
+
+    class TestAdoptedSheetsElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        :host {
+          margin: 4px;
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-adopted-sheets-el', TestAdoptedSheetsElement);
+
+    class TestShadowHostedElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        :host {
+          padding: 12px;
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-shadow-hosted-el', TestShadowHostedElement);
+
+    class TestStyleFallbackElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      static override styles = css`
+        :host {
+          border: 1px solid black;
+        }
+      `;
+
+      createController() {
+        return {props: {}, dispose: () => {}} as A2uiController<ComponentApi>;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-style-tag-fallback-el', TestStyleFallbackElement);
+
+    class TestFlexWeightElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
+      mockProps: {weight?: number} = {};
+
+      setMockWeight(weight: number | undefined) {
+        this.mockProps = {weight};
+        this.requestUpdate();
+      }
+
+      createController() {
+        const controller = {
+          dispose: () => {},
+        } as any;
+        Object.defineProperty(controller, 'props', {
+          get: () => this.mockProps,
+        });
+        return controller;
+      }
+
+      override render() {
+        return null;
+      }
+    }
+    defineCustomElement('test-flex-weight-el', TestFlexWeightElement);
   });
 
   after(teardownTestDom);
@@ -92,6 +321,212 @@ describe('BasicCatalogA2uiLitElement', () => {
     surface = processor.model.getSurface('test-surface')!;
   });
 
+  it('should render into Light DOM by returning self from createRenderRoot', () => {
+    const el = document.createElement('test-basic-element') as any;
+    assert.strictEqual(el.createRenderRoot(), el);
+    assert.strictEqual(el.shadowRoot, null);
+  });
+
+  it('should transform :host, :where(:host), :host(...), and scope descendant selectors', () => {
+    const tagName = 'test-css-transform-el';
+    const el = document.createElement(tagName);
+    document.body.appendChild(el);
+
+    const constructor = el.constructor as any;
+    assert.ok(constructor._processedCss, 'Processed CSS should be generated');
+
+    const processed = constructor._processedCss;
+    // :host -> tagName
+    assert.match(processed, new RegExp(`${tagName} \\{[^}]*display: flex`));
+    // :where(:host) -> :where(tagName)
+    assert.match(processed, new RegExp(`:where\\(${tagName}\\) \\{[^}]*margin: 0`));
+    // :host(.active) -> tagName.active
+    assert.match(processed, new RegExp(`${tagName}\\.active \\{[^}]*background-color: blue`));
+    // :host([disabled]) -> tagName[disabled]
+    assert.match(processed, new RegExp(`${tagName}\\[disabled\\] \\{[^}]*opacity: 0\\.5`));
+    // :host:hover -> tagName:hover
+    assert.match(processed, new RegExp(`${tagName}:hover \\{[^}]*color: green`));
+    // Descendant selectors prefixed with tagName
+    assert.match(processed, new RegExp(`${tagName} \\.child-item \\{[^}]*padding: 8px`));
+    assert.match(processed, new RegExp(`${tagName} button \\{[^}]*cursor: pointer`));
+    assert.match(
+      processed,
+      new RegExp(`${tagName} div > span\\.highlight \\{[^}]*font-weight: bold`),
+    );
+
+    document.body.removeChild(el);
+  });
+
+  it('should not double-prefix selectors that already target the host tag or :where/:is', () => {
+    const tagName = 'test-no-double-prefix-el';
+    const el = document.createElement(tagName);
+    document.body.appendChild(el);
+
+    const processed = (el.constructor as any)._processedCss;
+    assert.ok(!processed.includes(`${tagName} ${tagName}`), 'Should not contain double tag prefix');
+    assert.match(processed, new RegExp(`${tagName} \\{[^}]*display: inline-block`));
+    assert.match(processed, new RegExp(`${tagName} \\.inner \\{[^}]*color: red`));
+    assert.match(processed, new RegExp(`${tagName}\\.active \\{[^}]*color: yellow`));
+    assert.match(processed, new RegExp(`${tagName}:focus \\{[^}]*outline: none`));
+    assert.match(processed, new RegExp(`${tagName}\\[hidden\\] \\{[^}]*display: none`));
+    assert.match(processed, new RegExp(`:where\\(${tagName}\\) \\{[^}]*box-sizing: border-box`));
+
+    document.body.removeChild(el);
+  });
+
+  it('should correctly scope comma-separated compound selectors', () => {
+    const tagName = 'test-comma-selectors-el';
+    const el = document.createElement(tagName);
+    document.body.appendChild(el);
+
+    const processed = (el.constructor as any)._processedCss;
+    assert.match(
+      processed,
+      new RegExp(`${tagName}, ${tagName} \\.item, ${tagName} span > a \\{[^}]*color: cyan`),
+    );
+
+    document.body.removeChild(el);
+  });
+
+  it('should scope inner rules inside @media queries recursively', () => {
+    const tagName = 'test-media-query-el';
+    const el = document.createElement(tagName);
+    document.body.appendChild(el);
+
+    const processed = (el.constructor as any)._processedCss;
+    assert.match(processed, /@media \(max-width: 600px\)/);
+    assert.match(processed, new RegExp(`${tagName} \\{[^}]*display: none`));
+    assert.match(processed, new RegExp(`${tagName} \\.sidebar \\{[^}]*width: 100%`));
+
+    document.body.removeChild(el);
+  });
+
+  it('should handle array of styles and CSSResult objects', () => {
+    const tagName = 'test-array-styles-el';
+    const el = document.createElement(tagName);
+    document.body.appendChild(el);
+
+    const processed = (el.constructor as any)._processedCss;
+    assert.match(processed, new RegExp(`${tagName} \\{[^}]*color: black`));
+    assert.match(processed, new RegExp(`${tagName} \\.label \\{[^}]*font-size: 14px`));
+
+    document.body.removeChild(el);
+  });
+
+  it('should handle element with no styles gracefully', () => {
+    const tagName = 'test-no-styles-el';
+    const el = document.createElement(tagName);
+    document.body.appendChild(el);
+
+    const constructor = el.constructor as any;
+    assert.strictEqual(constructor._processedSheet, undefined);
+    assert.strictEqual(constructor._processedCss, undefined);
+
+    document.body.removeChild(el);
+  });
+
+  it('should adopt CSSStyleSheet into document.adoptedStyleSheets and deduplicate across instances', () => {
+    const tagName = 'test-adopted-sheets-el';
+    const el1 = document.createElement(tagName);
+    const el2 = document.createElement(tagName);
+
+    document.body.appendChild(el1);
+    const countAfterFirst = (document as any).adoptedStyleSheets.length;
+
+    document.body.appendChild(el2);
+    const countAfterSecond = (document as any).adoptedStyleSheets.length;
+
+    assert.strictEqual(
+      countAfterFirst,
+      countAfterSecond,
+      'Should not add duplicate stylesheets for multiple instances of the same component',
+    );
+
+    const sheet = (el1.constructor as any)._processedSheet;
+    assert.ok(sheet, 'Processed stylesheet must be created');
+    assert.ok((document as any).adoptedStyleSheets.includes(sheet));
+
+    document.body.removeChild(el1);
+    document.body.removeChild(el2);
+  });
+
+  it('should adopt CSSStyleSheet into shadowRoot when hosted inside a shadow root', () => {
+    const tagName = 'test-shadow-hosted-el';
+    const hostContainer = document.createElement('div');
+    const shadowRoot = hostContainer.attachShadow({mode: 'open'});
+    (shadowRoot as any).adoptedStyleSheets = [];
+    document.body.appendChild(hostContainer);
+
+    const el = document.createElement(tagName);
+    shadowRoot.appendChild(el);
+
+    const sheet = (el.constructor as any)._processedSheet;
+    assert.ok(sheet, 'Processed stylesheet must be created');
+    assert.ok((shadowRoot as any).adoptedStyleSheets.includes(sheet));
+
+    document.body.removeChild(hostContainer);
+  });
+
+  it('should fallback to injecting a style tag when adoptedStyleSheets is unavailable', () => {
+    const tagName = 'test-style-tag-fallback-el';
+    // Temporarily remove adoptedStyleSheets to test fallback
+    const originalAdopted = (document as any).adoptedStyleSheets;
+    delete (document as any).adoptedStyleSheets;
+
+    try {
+      const el1 = document.createElement(tagName);
+      const el2 = document.createElement(tagName);
+
+      document.body.appendChild(el1);
+      const getStyleEls = () =>
+        Array.from(document.head.querySelectorAll('style')).filter(el =>
+          el.textContent?.includes(tagName),
+        );
+      assert.strictEqual(getStyleEls().length, 1, 'Should inject exactly one style element');
+      assert.match(
+        getStyleEls()[0].textContent || '',
+        new RegExp(`${tagName} \\{[^}]*border: 1px solid black`),
+      );
+
+      // Connect second element and verify deduplication
+      document.body.appendChild(el2);
+      assert.strictEqual(getStyleEls().length, 1, 'Should not inject duplicate style elements');
+
+      document.body.removeChild(el1);
+      document.body.removeChild(el2);
+    } finally {
+      (document as any).adoptedStyleSheets = originalAdopted;
+    }
+  });
+
+  it('should set style.flex when props.weight is defined and remove it when undefined', async () => {
+    const tagName = 'test-flex-weight-el';
+    const el = document.createElement(tagName) as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'root');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    await asyncUpdate(el, (e: any) => {
+      e.setMockWeight(2);
+    });
+    assert.strictEqual(el.style.flex, '2');
+
+    await asyncUpdate(el, (e: any) => {
+      e.setMockWeight(0.5);
+    });
+    assert.strictEqual(el.style.flex, '0.5');
+
+    await asyncUpdate(el, (e: any) => {
+      e.setMockWeight(undefined);
+    });
+    assert.strictEqual(el.style.flex, '');
+
+    document.body.removeChild(el);
+  });
+
   it('should apply primary color from theme', async () => {
     const el = document.createElement('test-basic-element');
     document.body.appendChild(el);
@@ -117,9 +552,6 @@ describe('BasicCatalogA2uiLitElement', () => {
     document.body.removeChild(el);
   });
 
-  // This test ensures that if the element's context changes to a surface without a
-  // theme, the CSS variable is removed. While surface themes are currently immutable
-  // after creation, this ensures robust cleanup behavior if elements are reused.
   it('should remove primary color when theme changes or is missing', async () => {
     const el = document.createElement('test-basic-element');
     document.body.appendChild(el);

--- a/renderers/lit/src/v0_9/tests/components/Button.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Button.test.ts
@@ -108,7 +108,7 @@ describe('Button Component', () => {
       e.context = context;
     });
 
-    const button = el.shadowRoot?.querySelector('button');
+    const button = el.querySelector('button');
     assert.ok(button);
     assert.strictEqual(button.disabled, false);
 
@@ -133,7 +133,7 @@ describe('Button Component', () => {
       e.context = context;
     });
 
-    const button = el.shadowRoot?.querySelector('button');
+    const button = el.querySelector('button');
     assert.ok(button);
     assert.strictEqual(button.disabled, true);
 

--- a/renderers/lit/src/v0_9/tests/components/CheckBox.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/CheckBox.test.ts
@@ -73,7 +73,7 @@ describe('CheckBox Component', () => {
       e.context = context;
     });
 
-    const errorDiv = el.shadowRoot.querySelector('.error');
+    const errorDiv = el.querySelector('.error');
     assert.ok(errorDiv);
     assert.strictEqual(errorDiv.textContent.trim(), 'This is required');
 

--- a/renderers/lit/src/v0_9/tests/components/ChoicePicker.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/ChoicePicker.test.ts
@@ -87,7 +87,7 @@ describe('ChoicePicker Component', () => {
       e.context = context;
     });
 
-    const buttons = el.shadowRoot.querySelectorAll('button.chip');
+    const buttons = el.querySelectorAll('button.chip');
     assert.strictEqual(buttons.length, 2);
     assert.strictEqual(buttons[0].textContent.trim(), 'Apple');
 
@@ -104,7 +104,7 @@ describe('ChoicePicker Component', () => {
     });
 
     // Initially 2 options + 1 main label = 3 labels
-    assert.strictEqual(el.shadowRoot.querySelectorAll('label').length, 3);
+    assert.strictEqual(el.querySelectorAll('label').length, 3);
 
     // Simulate input by setting state directly
     await asyncUpdate(el, e => {
@@ -112,7 +112,7 @@ describe('ChoicePicker Component', () => {
     });
 
     // Now only Apple should be visible + main label = 2 labels
-    assert.strictEqual(el.shadowRoot.querySelectorAll('label').length, 2);
+    assert.strictEqual(el.querySelectorAll('label').length, 2);
 
     document.body.removeChild(el);
   });

--- a/renderers/lit/src/v0_9/tests/components/Row.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Row.test.ts
@@ -110,7 +110,7 @@ describe('Row Component', () => {
     // Let's check shadow root has slot or elements.
     // Wait, row does: return html` ${map(children, child => html`${this.renderNode(child)}`)} `
     // It renders nodes inside its own shadow DOM directly.
-    const textElements = el.shadowRoot?.querySelectorAll('a2ui-basic-text') as
+    const textElements = el.querySelectorAll('a2ui-basic-text') as
       | NodeListOf<HTMLElement & {context?: ComponentContext}>
       | undefined;
     assert.ok(textElements);

--- a/renderers/lit/src/v0_9/tests/components/Text.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Text.test.ts
@@ -100,7 +100,7 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const span = el.shadowRoot?.querySelector('.no-markdown-renderer');
+    const span = el.querySelector('.no-markdown-renderer');
     assert.ok(span);
     assert.strictEqual(span.textContent?.trim(), 'Hello static text');
   });
@@ -115,7 +115,7 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const span = el.shadowRoot?.querySelector('.no-markdown-renderer');
+    const span = el.querySelector('.no-markdown-renderer');
     assert.ok(span);
     assert.strictEqual(span.textContent?.trim(), 'Hello dynamic text');
 
@@ -136,7 +136,7 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const captionSpan = el.shadowRoot?.querySelector('span.a2ui-caption');
+    const captionSpan = el.querySelector('span.a2ui-caption');
     assert.ok(captionSpan);
     const innerSpan = captionSpan.querySelector('.no-markdown-renderer');
     assert.ok(innerSpan);

--- a/renderers/lit/src/v0_9/tests/components/TextField.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/TextField.test.ts
@@ -105,11 +105,11 @@ describe('TextField Component', () => {
       e.context = context;
     });
 
-    const label = el.shadowRoot?.querySelector('label');
+    const label = el.querySelector('label');
     assert.ok(label);
     assert.strictEqual(label.textContent?.trim(), 'Username');
 
-    const input = el.shadowRoot?.querySelector('input');
+    const input = el.querySelector('input');
     assert.ok(input);
     assert.strictEqual(input.value, 'Bob');
   });
@@ -124,7 +124,7 @@ describe('TextField Component', () => {
       e.context = context;
     });
 
-    const input = el.shadowRoot?.querySelector('input');
+    const input = el.querySelector('input');
     assert.ok(input);
 
     input.value = 'Alice';
@@ -145,11 +145,11 @@ describe('TextField Component', () => {
       e.context = context;
     });
 
-    const textarea = el.shadowRoot?.querySelector('textarea');
+    const textarea = el.querySelector('textarea');
     assert.ok(textarea);
     assert.strictEqual(textarea.value, 'Initial Bio');
 
-    const input = el.shadowRoot?.querySelector('input');
+    const input = el.querySelector('input');
     assert.strictEqual(input, null);
   });
 
@@ -163,11 +163,11 @@ describe('TextField Component', () => {
       e.context = context;
     });
 
-    const error = el.shadowRoot?.querySelector('.error');
+    const error = el.querySelector('.error');
     assert.ok(error);
     assert.strictEqual(error.textContent?.trim(), 'Email is invalid');
 
-    const input = el.shadowRoot?.querySelector('input');
+    const input = el.querySelector('input');
     assert.ok(input);
     assert.ok(input.classList.contains('invalid'));
   });

--- a/renderers/lit/src/v0_9/tests/custom-catalogs.test.ts
+++ b/renderers/lit/src/v0_9/tests/custom-catalogs.test.ts
@@ -160,9 +160,9 @@ describe('Custom Catalogs Integration', () => {
     });
 
     // Validates that the minimal catalog surface spawned the classic a2ui-text node
-    assert.ok(el1.shadowRoot?.querySelector('a2ui-basic-text'));
+    assert.ok(el1.querySelector('a2ui-basic-text'));
 
     // Validates that the custom catalog surface dynamically spawned the custom node tag `<a2ui-customwidget>`
-    assert.ok(el2.shadowRoot?.querySelector('a2ui-customwidget'));
+    assert.ok(el2.querySelector('a2ui-customwidget'));
   });
 });

--- a/renderers/lit/src/v0_9/tests/dom-setup.ts
+++ b/renderers/lit/src/v0_9/tests/dom-setup.ts
@@ -44,6 +44,7 @@ export function setupTestDom() {
     const names = [
       'window',
       'document',
+      'Document',
       'HTMLElement',
       'customElements',
       'Element',
@@ -53,6 +54,10 @@ export function setupTestDom() {
       'requestAnimationFrame',
       'cancelAnimationFrame',
       'CSSStyleSheet',
+      'CSSStyleRule',
+      'CSSMediaRule',
+      'CSSRule',
+      'ShadowRoot',
     ];
 
     // Save originals once
@@ -85,6 +90,7 @@ export function setupTestDom() {
   applyGlobals({
     window: dom.window,
     document: dom.window.document,
+    Document: (dom.window as any).Document,
     HTMLElement: dom.window.HTMLElement,
     customElements: dom.window.customElements,
     Element: dom.window.Element,
@@ -92,6 +98,10 @@ export function setupTestDom() {
     Event: dom.window.Event,
     MutationObserver: dom.window.MutationObserver,
     CSSStyleSheet: dom.window.CSSStyleSheet,
+    CSSStyleRule: dom.window.CSSStyleRule,
+    CSSMediaRule: dom.window.CSSMediaRule,
+    CSSRule: dom.window.CSSRule,
+    ShadowRoot: (dom.window as any).ShadowRoot,
     requestAnimationFrame: (cb: FrameRequestCallback) => setTimeout(cb, 16),
     cancelAnimationFrame: (id: string | number | NodeJS.Timeout | undefined) =>
       clearTimeout(id as any),
@@ -99,16 +109,12 @@ export function setupTestDom() {
 }
 
 /**
- * Cleans up the JSDOM instance and restores the original Node.js globals.
+ * Cleans up the JSDOM instance between tests.
  */
 export function teardownTestDom() {
-  // Clear the document to prevent leaks between tests
   if (dom) {
     dom.window.document.body.innerHTML = '';
-    dom = null;
   }
-
-  applyGlobals(originalGlobals);
 }
 
 /**


### PR DESCRIPTION
## Overview

Migrates the Basic Catalog components in `@a2ui/lit` from Shadow DOM rendering to Light DOM rendering.

## Motivation: Why Light DOM over Shadow DOM?

1. **Universal Cross-Framework Interoperability**:
   - Shadow DOM encapsulation creates isolated boundaries that introduce friction when rendering components across different UI frameworks (Angular, React, Vue, Lit).
   - Light DOM allows these Web Components to function as truly universal building blocks that integrate seamlessly into any host framework's rendering tree (e.g., Angular's `CUSTOM_ELEMENTS_SCHEMA`, React JSX) without shadow boundaries obstructing layout flow or component composition.

2. **Unified Theming & Natural CSS Cascade**:
   - Shadow DOM boundaries prevent external CSS stylesheets, utility classes (e.g. Tailwind, Bootstrap), and host design system tokens from cascading into component templates unless explicitly pierced with `::part` or CSS custom properties.
   - Light DOM preserves the natural CSS cascade, allowing host applications to theme, style, and compose components effortlessly with global and contextual stylesheets while still benefiting from default adopted component styles.

3. **Seamless Form Participation & Accessibility**:
   - Input and button elements in Light DOM naturally associate with parent HTML `<form>` elements and standard browser form submission without requiring complex `ElementInternals` form-associated custom element plumbing.
   - Standard accessibility tools, screen readers, and DOM querying utilities (`querySelector`, end-to-end testing frameworks) can inspect and interact with the full component tree without having to pierce nested shadow roots.

4. **Cross-Renderer Structural Consistency**:
   - Other A2UI framework renderers (such as Angular and React) render their component trees directly into the Light DOM. Adopting Light DOM for Lit aligns the rendered DOM hierarchy, layout semantics, and styling behaviors across all A2UI renderer implementations.

## Key Changes

- **Light DOM Base Class**: Updates `BasicCatalogA2uiLitElement` to override `createRenderRoot()` to return `this`, rendering component markup directly into the host element.
- **Dynamic Style Adoption with Fallback**: Implements `adoptStyles()` to register component stylesheets via `adoptedStyleSheets` where available, with a `<style data-a2ui-tag>` injection fallback for environments lacking adopted stylesheet support (such as JSDOM).
- **CSS Selectors**: Adapts component `static styles` to match both `:host` and the custom element tag name (e.g. `:host, a2ui-basic-button`) in Light DOM.
- **Surface Component**: Configures `a2ui-surface` to render in Light DOM.
- **Test Alignment**: Updates Lit component unit tests and Explorer integration tests to query Light DOM elements directly instead of accessing `shadowRoot`.

Resolves #1270