### PR TITLE
fix(lit): align basic catalog component behaviors with angular implementation

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
@@ -46,8 +46,20 @@ import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
 
       @if (isOpen()) {
         <div class="a2ui-modal-overlay" (click)="closeModal()">
-          <div class="a2ui-modal-content" (click)="$event.stopPropagation()">
-            <button class="a2ui-modal-close" (click)="closeModal()">&times;</button>
+          <div
+            class="a2ui-modal-content"
+            role="dialog"
+            aria-modal="true"
+            (click)="$event.stopPropagation()"
+          >
+            <button
+              type="button"
+              class="a2ui-modal-close"
+              aria-label="Close"
+              (click)="closeModal()"
+            >
+              &times;
+            </button>
             @if (content()) {
               <a2ui-v09-component-host [componentKey]="content()!" [surfaceId]="surfaceId()">
               </a2ui-v09-component-host>

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+- **BREAKING CHANGE**: (v0_9) Align Basic Catalog component DOM structures, behaviors, and styling contracts with the Angular reference implementation: [#2205](https://github.com/a2ui-project/a2ui/pull/2205)
+  - `DateTimeInput`: Migrate from a single dynamic HTML5 input (`datetime-local`) to dual side-by-side date and time inputs (`.a2ui-date-time-inputs`), support overridable `--a2ui-datetimeinput-width`, and ensure time-only mode preserves time-only strings without invalid date concatenation.
+  - `Modal`: Migrate from native `<dialog>` element to an overlay container (`.a2ui-modal-overlay`, `.a2ui-modal-content`) managed with explicit `@state() isOpen` lifecycle tracking, backdrop theming (`--a2ui-modal-backdrop-bg`), and accessible ARIA dialog roles.
+  - `Image`: Remove default `width: 100%` constraint on `img` elements to preserve intrinsic aspect ratios and align `fit` default with container layouts.
+  - `Button`: Replace hardcoded disabled button hex colors with `opacity: 0.5; cursor: not-allowed;` so disabled buttons react dynamically to theme backgrounds.
+  - `TextField`: Render all validation error messages in `validationErrors` instead of only the first error, simplify input change handling, and support full-width container styling (`width: var(--a2ui-textfield-width, 100%)`, `box-sizing: border-box`).
+  - `Column`: Add consistent flex layout distribution and strict alignment mappings.
+  - `Row`, `Column`, `List`: Use Lit `repeat` directive with key extractors to ensure child elements are tracked by key and DOM nodes are preserved across reordering operations.
+  - `Tabs`: Reset `activeIndex` to 0 in `willUpdate` when the `tabs` array changes dynamically and index is out of bounds.
+  - `Text`: Directly render semantic HTML tags for non-markdown variants (`h1`-`h5`, `caption` wrapped in `<em>`) and add flex weight styling.
+  - `Video`: Wrap video in `.a2ui-video-container` with fallback message for unsupported browsers.
+  - `ChoicePicker`: Align DOM structures and CSS classes with the Angular reference implementation (`.a2ui-choice-picker`, `.a2ui-option-label`, `.a2ui-option-text`, `.a2ui-chip`, `type="button"`), scope radio input `name` attributes to surface and data context path to prevent cross-surface radio collisions in Light DOM, and omit `name` attributes on checkbox inputs.
+
 ## 0.10.4
 
 - **BREAKING CHANGE**: (v0_9) Migrate Basic Catalog components and surface rendering from Shadow DOM to Light DOM. Recommended migration: query component elements directly using Light DOM selectors (e.g. `element.querySelector()`) rather than `element.shadowRoot`, and ensure global stylesheets do not unintentionally conflict with component internal class names. [#2204](https://github.com/a2ui-project/a2ui/pull/2204)

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+- (v0_9) Align Basic Catalog component behaviors and styling contracts with the Angular reference implementation: [#2205](https://github.com/a2ui-project/a2ui/pull/2205)
+  - `TextField`: Render all validation error messages in `validationErrors` instead of only the first error, add direct path mutation fallback, and ensure full-width container styling (`width: 100%`, `box-sizing: border-box`).
+  - `DateTimeInput`: Add `width: 100%` container styling and `box-sizing: border-box` input sizing.
+  - `Column`: Add `width: 100%` container styling to ensure consistent flex layout distribution.
+  - `Row`, `Column`, `List`: Use Lit `repeat` directive to ensure child elements are tracked by key and DOM nodes are preserved across reordering operations.
+  - `Tabs`: Clamp `activeIndex` to valid bounds in `willUpdate` when `tabs` array changes dynamically.
+  - `Text`: Directly render semantic HTML tags for non-markdown variants (`h1`-`h5`, `caption`) and add flex weight styling.
+  - `Video`: Wrap video in `.a2ui-video-container` with fallback message for unsupported browsers.
+  - `Image`: Remove default `width: 100%` constraint on `img` elements to preserve intrinsic aspect ratios and support explicit layout sizing.
+  - `Modal`: Migrate from native `<dialog>` to an overlay container (`.a2ui-modal-overlay`, `.a2ui-modal-content`) managed with explicit `@state() isOpen` lifecycle tracking, standard backdrop theming (`--a2ui-modal-backdrop-bg`), accessible dialog ARIA attributes (`role="dialog"`, `aria-modal="true"`), and an accessible close button (`aria-label="Close"`).
 - (v0_9) Migrate Basic Catalog components and surface rendering from Shadow DOM to Light DOM. [#2204](https://github.com/a2ui-project/a2ui/pull/2204)
 
 ## 0.10.3

--- a/renderers/lit/a2ui_explorer/tests/v0_9/29_movie-card.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/29_movie-card.test.ts
@@ -67,8 +67,8 @@ describe('Example: Movie Card', () => {
     button.click();
     await whenSettled(gallery);
 
-    const modal = querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement;
-    expect(modal?.open).toBeTruthy();
+    const modal = querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLElement;
+    expect(modal).toBeTruthy();
 
     const video = querySelectorAllDeep(surface, 'video')[0] as HTMLVideoElement;
     expect(video).toBeTruthy();

--- a/renderers/lit/a2ui_explorer/tests/v0_9/36_modal.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/36_modal.test.ts
@@ -39,18 +39,14 @@ describe('Example: Modal', () => {
     expect(trigger).toBeTruthy();
 
     // Check modal is closed initially
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeFalsy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay').length).toBe(0);
 
     // Click trigger
     trigger.click();
     await whenSettled(gallery);
 
     // Check modal is open
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeTruthy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay').length).toBe(1);
 
     // Check content
     expect(getDeepTextContent(querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0])).toContain(
@@ -64,8 +60,6 @@ describe('Example: Modal', () => {
     await whenSettled(gallery);
 
     // Check modal is closed
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeFalsy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay').length).toBe(0);
   });
 });

--- a/renderers/lit/a2ui_explorer/tests/v0_9/36_modal.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/36_modal.test.ts
@@ -39,18 +39,14 @@ describe('Example: Modal', () => {
     expect(trigger).toBeTruthy();
 
     // Check modal is closed initially
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeFalsy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay').length).toBe(0);
 
     // Click trigger
     trigger.click();
     await whenSettled(gallery);
 
     // Check modal is open
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeTruthy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay').length).toBeGreaterThan(0);
 
     // Check content
     expect(getDeepTextContent(querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0])).toContain(
@@ -64,8 +60,6 @@ describe('Example: Modal', () => {
     await whenSettled(gallery);
 
     // Check modal is closed
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeFalsy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay').length).toBe(0);
   });
 });

--- a/renderers/lit/src/v0_9/catalogs/basic/components/AudioPlayer.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/AudioPlayer.ts
@@ -23,14 +23,24 @@ import {A2uiController} from '../../../a2ui-controller.js';
 @customElement('a2ui-audioplayer')
 export class A2uiAudioPlayerElement extends BasicCatalogA2uiLitElement<typeof AudioPlayerApi> {
   static override styles = css`
-    :host,
-    a2ui-audioplayer {
+    .a2ui-audio-player {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-spacing-xs, 0.25rem);
       background: var(--a2ui-audioplayer-background, transparent);
       border-radius: var(--a2ui-audioplayer-border-radius, 0);
       padding: var(--a2ui-audioplayer-padding, 0);
+      width: 100%;
+    }
+    .a2ui-audio-description {
+      font-size: var(--a2ui-font-size-s, 0.875rem);
+      color: var(
+        --a2ui-audioplayer-description-color,
+        var(--a2ui-text-caption-color, light-dark(#666, #aaa))
+      );
+    }
+    .a2ui-audio {
+      width: 100%;
     }
   `;
 
@@ -43,8 +53,14 @@ export class A2uiAudioPlayerElement extends BasicCatalogA2uiLitElement<typeof Au
     if (!props) return nothing;
 
     return html`
-      ${props.description ? html`<p>${props.description}</p>` : nothing}
-      <audio src=${props.url} controls></audio>
+      <div class="a2ui-audio-player">
+        ${props.description
+          ? html`<div class="a2ui-audio-description">${props.description}</div>`
+          : nothing}
+        <audio src=${props.url || nothing} controls class="a2ui-audio">
+          Your browser does not support the audio tag.
+        </audio>
+      </div>
     `;
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/AudioPlayer.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/AudioPlayer.ts
@@ -23,14 +23,21 @@ import {A2uiController} from '../../../a2ui-controller.js';
 @customElement('a2ui-audioplayer')
 export class A2uiAudioPlayerElement extends BasicCatalogA2uiLitElement<typeof AudioPlayerApi> {
   static override styles = css`
-    :host,
-    a2ui-audioplayer {
+    .a2ui-audio-player {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-spacing-xs, 0.25rem);
       background: var(--a2ui-audioplayer-background, transparent);
       border-radius: var(--a2ui-audioplayer-border-radius, 0);
       padding: var(--a2ui-audioplayer-padding, 0);
+      width: 100%;
+    }
+    .a2ui-audio-description {
+      font-size: var(--a2ui-font-size-s, 0.875rem);
+      color: var(--a2ui-text-caption-color, light-dark(#666, #aaa));
+    }
+    .a2ui-audio {
+      width: 100%;
     }
   `;
 
@@ -39,12 +46,18 @@ export class A2uiAudioPlayerElement extends BasicCatalogA2uiLitElement<typeof Au
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
     return html`
-      ${props.description ? html`<p>${props.description}</p>` : nothing}
-      <audio src=${props.url} controls></audio>
+      <div class="a2ui-audio-player">
+        ${props.description
+          ? html`<div class="a2ui-audio-description">${props.description}</div>`
+          : nothing}
+        <audio src=${props.url || nothing} controls class="a2ui-audio">
+          Your browser does not support the audio tag.
+        </audio>
+      </div>
     `;
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
@@ -42,53 +42,46 @@ export class A2uiBasicButtonElement extends BasicCatalogA2uiLitElement<typeof Bu
    * - `--a2ui-button-margin`: The outer margin of the button. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host,
-    a2ui-basic-button {
-      display: inline-block;
-      margin: var(--a2ui-button-margin, var(--a2ui-spacing-m));
-    }
-    :where(:host, a2ui-basic-button) {
-      --_color-primary: var(--a2ui-color-primary, #17e);
-      --_button-border-radius: var(--a2ui-button-border-radius, var(--a2ui-spacing-s, 0.25rem));
-      --_button-padding: var(
+    .a2ui-button {
+      padding: var(
         --a2ui-button-padding,
         var(--a2ui-spacing-m, 0.5rem) var(--a2ui-spacing-l, 1rem)
       );
-      --_button-border: var(
+      border-radius: var(--a2ui-button-border-radius, var(--a2ui-spacing-s, 0.25rem));
+      border: var(
         --a2ui-button-border,
         var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
       );
-    }
-    .a2ui-button {
-      --_a2ui-text-margin: 0;
-      --_a2ui-text-color: var(--a2ui-color-on-secondary, #333);
-      padding: var(--_button-padding);
+      cursor: pointer;
+      margin: var(--a2ui-button-margin, var(--a2ui-spacing-m, 0.5rem));
       background: var(--a2ui-button-background, var(--a2ui-color-surface, #fff));
       box-shadow: var(--a2ui-button-box-shadow, none);
       font-weight: var(--a2ui-button-font-weight, normal);
-      color: var(--_a2ui-text-color);
-      border: var(--_button-border);
-      border-radius: var(--_button-border-radius);
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .a2ui-button.a2ui-button-primary {
-      --_a2ui-text-color: var(--a2ui-color-on-primary, #fff);
-      background-color: var(--_color-primary);
+      --_a2ui-text-margin: 0;
+      --_a2ui-text-color: var(--a2ui-color-on-secondary, #333);
       color: var(--_a2ui-text-color);
     }
     .a2ui-button:hover {
       background-color: var(--a2ui-color-secondary-hover, #ddd);
     }
-    .a2ui-button.a2ui-button-primary:hover {
+    .a2ui-button.primary {
+      background: var(--a2ui-color-primary, #17e);
+      --_a2ui-text-color: var(--a2ui-color-on-primary, #fff);
+      color: var(--_a2ui-text-color);
+      border: none;
+    }
+    .a2ui-button.primary:hover {
       background-color: var(--a2ui-color-primary-hover, #fbd);
     }
-    .a2ui-button.a2ui-button-borderless {
+    .a2ui-button.borderless {
       background: none;
+      border: none;
       padding: 0;
-      color: var(--_color-primary);
+      color: var(--a2ui-color-primary, #17e);
+    }
+    .a2ui-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
     }
   `;
 
@@ -101,16 +94,22 @@ export class A2uiBasicButtonElement extends BasicCatalogA2uiLitElement<typeof Bu
     if (!props) return nothing;
 
     const isDisabled = props.isValid === false;
+    const variant = props.variant ?? 'default';
 
     const classes = {
       'a2ui-button': true,
-      ['a2ui-button-' + (props.variant || 'default')]: true,
+      [variant]: true,
+      ['a2ui-button-' + variant]: true,
     };
 
     return html`
       <button
+        type="button"
         class=${classMap(classes)}
-        @click=${() => !isDisabled && props.action && props.action()}
+        @click=${() => {
+          if (isDisabled) return;
+          props.action?.();
+        }}
         ?disabled=${isDisabled}
       >
         ${props.child ? html`${this.renderNode(props.child)}` : nothing}

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
@@ -33,19 +33,17 @@ export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> 
    * - `--a2ui-card-margin`: The outer margin of the card. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host,
-    a2ui-card {
-      display: block;
+    .a2ui-card {
+      padding: var(--a2ui-card-padding, var(--a2ui-spacing-m, 16px));
+      border-radius: var(--a2ui-card-border-radius, var(--a2ui-border-radius, 8px));
+      box-shadow: var(--a2ui-card-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
+      background: var(--a2ui-card-background, var(--a2ui-color-surface, #fff));
+      color: var(--a2ui-color-on-surface, #333);
       border: var(
         --a2ui-card-border,
         var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
       );
-      border-radius: var(--a2ui-card-border-radius, var(--a2ui-border-radius, 8px));
-      padding: var(--a2ui-card-padding, var(--a2ui-spacing-m, 16px));
-      background: var(--a2ui-card-background, var(--a2ui-color-surface, #fff));
-      color: var(--a2ui-color-on-surface, #333);
-      box-shadow: var(--a2ui-card-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
-      margin: var(--a2ui-card-margin, var(--a2ui-spacing-m));
+      margin: var(--a2ui-card-margin, var(--a2ui-spacing-m, 16px));
     }
   `;
 
@@ -57,7 +55,9 @@ export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> 
     const props = this.controller.props;
     if (!props) return nothing;
 
-    return html` ${props.child ? html`${this.renderNode(props.child)}` : nothing} `;
+    return html`
+      <div class="a2ui-card">${props.child ? this.renderNode(props.child) : nothing}</div>
+    `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
@@ -22,30 +22,17 @@ import {A2uiController} from '../../../a2ui-controller.js';
 
 @customElement('a2ui-card')
 export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> {
-  /**
-   * The styles of the card can be customized by redefining the following
-   * CSS variables:
-   *
-   * - `--a2ui-card-border`: The styling for the card border. Defaults to `--a2ui-border-width` width and `--a2ui-color-border` color.
-   * - `--a2ui-card-border-radius`: The border radius of the card. Defaults to `--a2ui-border-radius`.
-   * - `--a2ui-card-padding`: The padding of the card. Defaults to `--a2ui-spacing-m`.
-   * - `--a2ui-card-box-shadow`: The box shadow of the card. Defaults to `0 2px 4px rgba(0,0,0,0.1)`.
-   * - `--a2ui-card-margin`: The outer margin of the card. Defaults to `--a2ui-spacing-m`.
-   */
   static override styles = css`
-    :host,
-    a2ui-card {
-      display: block;
+    .a2ui-card {
+      padding: var(--a2ui-card-padding, var(--a2ui-spacing-m, 16px));
+      border-radius: var(--a2ui-card-border-radius, var(--a2ui-border-radius, 8px));
+      box-shadow: var(--a2ui-card-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
+      background: var(--a2ui-card-background, var(--a2ui-color-surface, #fff));
       border: var(
         --a2ui-card-border,
         var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
       );
-      border-radius: var(--a2ui-card-border-radius, var(--a2ui-border-radius, 8px));
-      padding: var(--a2ui-card-padding, var(--a2ui-spacing-m, 16px));
-      background: var(--a2ui-card-background, var(--a2ui-color-surface, #fff));
-      color: var(--a2ui-color-on-surface, #333);
-      box-shadow: var(--a2ui-card-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
-      margin: var(--a2ui-card-margin, var(--a2ui-spacing-m));
+      margin: var(--a2ui-card-margin, var(--a2ui-spacing-m, 16px));
     }
   `;
 
@@ -54,10 +41,12 @@ export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> 
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
-    return html` ${props.child ? html`${this.renderNode(props.child)}` : nothing} `;
+    return html`
+      <div class="a2ui-card">${props.child ? this.renderNode(props.child) : nothing}</div>
+    `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/CheckBox.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/CheckBox.ts
@@ -69,7 +69,8 @@ export class A2uiCheckBoxElement extends BasicCatalogA2uiLitElement<typeof Check
     input.invalid {
       outline: 1px solid var(--a2ui-checkbox-color-error, red);
     }
-    .error {
+    .error,
+    .a2ui-error-message {
       color: var(--a2ui-checkbox-color-error, red);
       font-size: var(--a2ui-font-size-xs, 0.75rem);
       margin-top: 4px;
@@ -97,10 +98,12 @@ export class A2uiCheckBoxElement extends BasicCatalogA2uiLitElement<typeof Check
             .checked=${props.value || false}
             @change=${(e: Event) => props.setValue?.((e.target as HTMLInputElement).checked)}
           />
-          ${props.label}
+          <span class="a2ui-check-box-text">${props.label}</span>
         </label>
         ${isInvalid && props.validationErrors?.length
-          ? html`<div class="error">${props.validationErrors[0]}</div>`
+          ? props.validationErrors.map(
+              (msg: string) => html`<div class="error a2ui-error-message">${msg}</div>`,
+            )
           : nothing}
       </div>
     `;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/ChoicePicker.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/ChoicePicker.ts
@@ -37,19 +37,26 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
    */
   static override styles = css`
     :host,
-    a2ui-choicepicker {
+    .a2ui-choice-picker {
       display: flex;
       flex-direction: column;
+      width: 100%;
       gap: var(--a2ui-choicepicker-gap, var(--a2ui-spacing-xs, 0.25rem));
       padding: var(--a2ui-choicepicker-padding, 0);
     }
-    .options {
+    .options,
+    .a2ui-options-group {
       display: flex;
       flex-direction: column;
       gap: var(--a2ui-choicepicker-gap, var(--a2ui-spacing-xs, 0.25rem));
     }
-    label {
-      color: var(--a2ui-choicepicker-label-color, inherit);
+    label,
+    .a2ui-option-label {
+      display: flex;
+      align-items: center;
+      gap: var(--a2ui-choicepicker-gap, var(--a2ui-spacing-xs, 0.25rem));
+      cursor: pointer;
+      color: var(--a2ui-text-color-text, var(--a2ui-choicepicker-label-color, inherit));
       font-size: var(--a2ui-choicepicker-label-font-size, inherit);
     }
     :host,
@@ -63,41 +70,62 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
     .filter-input {
       background-color: var(--a2ui-color-input, #fff);
       color: var(--a2ui-color-on-input, #333);
-      border: var(--a2ui-textfield-border, var(--a2ui-border));
-      border-radius: var(--a2ui-textfield-border-radius, var(--a2ui-spacing-m));
+      border: var(
+        --a2ui-textfield-border,
+        var(--a2ui-border, 1px solid var(--a2ui-color-border, #ccc))
+      );
+      border-radius: var(--a2ui-textfield-border-radius, var(--a2ui-spacing-m, 4px));
       padding: var(
         --a2ui-choicepicker-filter-padding,
         var(--a2ui-spacing-xs, 4px) var(--a2ui-spacing-s, 8px)
       );
+      margin-bottom: var(--a2ui-choicepicker-filter-margin-bottom, var(--a2ui-spacing-s, 0.25rem));
       font-family: inherit;
     }
     .filter-input:focus {
       outline: none;
       border-color: var(--a2ui-textfield-color-border-focus, var(--a2ui-color-primary, #17e));
     }
-    .chips {
+    .a2ui-option-input {
+      width: var(--a2ui-choicepicker-checkbox-size, 1rem);
+      height: var(--a2ui-choicepicker-checkbox-size, 1rem);
+    }
+    .chips,
+    .a2ui-chips-group {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       gap: var(--a2ui-choicepicker-gap, var(--a2ui-spacing-xs, 0.25rem));
     }
-    .chip {
+    .chip,
+    .a2ui-chip {
       padding: var(
         --a2ui-choicepicker-chip-padding,
         var(--a2ui-spacing-s, 4px) var(--a2ui-spacing-m, 8px)
       );
       border-radius: var(--a2ui-choicepicker-chip-border-radius, 999px);
-      border: 1px solid var(--a2ui-color-border, #ccc);
-      background-color: var(--a2ui-color-surface, #fff);
+      border: var(--a2ui-choicepicker-chip-border, 1px solid var(--a2ui-color-border, #ccc));
+      background-color: var(--a2ui-choicepicker-chip-background, var(--a2ui-color-surface, #fff));
       color: var(--a2ui-color-on-surface, inherit);
       cursor: pointer;
-      font-size: var(--a2ui-font-size-xs, 0.75rem);
+      font-size: var(--a2ui-choicepicker-chip-font-size, var(--a2ui-font-size-xs, 0.75rem));
       font-family: inherit;
+      font-weight: var(--a2ui-choicepicker-chip-font-weight, normal);
+      transition: all 0.2s;
     }
-    .chip.selected {
-      background-color: var(--a2ui-color-primary, #007bff);
+    .chip.selected,
+    .chip.active,
+    .a2ui-chip.selected,
+    .a2ui-chip.active {
+      background-color: var(
+        --a2ui-choicepicker-chip-background-selected,
+        var(--a2ui-color-primary, #007bff)
+      );
       color: var(--a2ui-color-on-primary, #fff);
-      border-color: var(--a2ui-color-primary, #007bff);
+      border-color: var(
+        --a2ui-choicepicker-chip-background-selected,
+        var(--a2ui-color-primary, #007bff)
+      );
     }
   `;
 
@@ -108,23 +136,29 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
-    const selected = Array.isArray(props.value) ? props.value : [];
+    const rawVal = props.value;
+    const selected: string[] = Array.isArray(rawVal)
+      ? (rawVal as string[])
+      : typeof rawVal === 'string'
+        ? [rawVal]
+        : [];
     const isMulti = props.variant === 'multipleSelection';
     const isChips = props.displayStyle === 'chips';
 
     const toggle = (val: string) => {
-      if (!props.setValue) return;
+      const setter = props.setValue;
+      if (typeof setter !== 'function') return;
       if (isMulti) {
         if (selected.includes(val)) {
-          props.setValue(selected.filter((v: string) => v !== val));
+          setter(selected.filter((v: string) => v !== val));
         } else {
-          props.setValue([...selected, val]);
+          setter([...selected, val]);
         }
       } else {
-        props.setValue([val]);
+        setter([val]);
       }
     };
 
@@ -134,6 +168,16 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
         this.filter === '' ||
         String(opt.label).toLowerCase().includes(this.filter.toLowerCase()),
     );
+
+    // Radio group names are document-scoped while component ids are only
+    // surface-scoped, so the group name qualifies the component id with the
+    // surface id and the data context path (which disambiguates instances
+    // stamped from a list template within one surface).
+    const surfaceId = this.context?.dataContext?.surface?.id || 'default';
+    const componentId = this.context?.componentModel?.id || 'choice-picker';
+    const dataPath = this.context?.dataContext?.path || '/';
+    const sanitizedPath = dataPath.replace(/[^a-zA-Z0-9-]/g, '_');
+    const groupName = `a2ui-choice-${surfaceId}-${componentId}-${sanitizedPath}`;
 
     return html`
       ${props.label ? html`<label>${props.label}</label>` : nothing}
@@ -149,13 +193,24 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
             />
           `
         : nothing}
-      <div class=${classMap({options: true, chips: isChips})}>
+      <div
+        class=${classMap({
+          'a2ui-choice-picker': true,
+          options: true,
+          'a2ui-options-group': !isChips,
+          chips: isChips,
+          'a2ui-chips-group': isChips,
+        })}
+      >
         ${options.map((opt: any) =>
           isChips
             ? html`
                 <button
+                  type="button"
                   class=${classMap({
+                    'a2ui-chip': true,
                     chip: true,
+                    active: selected.includes(opt.value),
                     selected: selected.includes(opt.value),
                   })}
                   aria-pressed=${selected.includes(opt.value)}
@@ -165,13 +220,16 @@ export class A2uiChoicePickerElement extends BasicCatalogA2uiLitElement<typeof C
                 </button>
               `
             : html`
-                <label>
+                <label class="a2ui-option-label">
                   <input
                     type=${isMulti ? 'checkbox' : 'radio'}
+                    name=${isMulti ? nothing : groupName}
+                    value=${opt.value}
                     .checked=${selected.includes(opt.value)}
                     @change=${() => toggle(opt.value)}
+                    class="a2ui-option-input"
                   />
-                  ${opt.label}
+                  <span class="a2ui-option-text">${opt.label}</span>
                 </label>
               `,
         )}

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
@@ -16,7 +16,7 @@
 
 import {html, nothing, css, PropertyValues} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {map} from 'lit/directives/map.js';
+import {repeat} from 'lit/directives/repeat.js';
 import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   BasicCatalogA2uiLitElement,
@@ -39,7 +39,14 @@ const ALIGN_MAP: Record<string, string> = {
   center: 'center',
   end: 'flex-end',
   stretch: 'stretch',
+  baseline: 'baseline',
 };
+
+function getChildKey(child: any): string {
+  return typeof child === 'object' && child !== null
+    ? `${child.basePath ?? ''}/${child.id}`
+    : String(child);
+}
 
 @customElement('a2ui-basic-column')
 export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof ColumnApi> {
@@ -48,15 +55,19 @@ export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof Co
    * CSS variables:
    *
    * - `--a2ui-column-gap`: The gap between items in the column. Defaults to `--a2ui-spacing-m`.
+   * - `--a2ui-column-width`: The width of the column. Defaults to `100%`.
    */
   static override styles = css`
     :host,
     a2ui-basic-column {
       display: flex;
       flex-direction: column;
+      width: var(--a2ui-column-width, 100%);
       gap: var(--a2ui-column-gap, var(--a2ui-spacing-m));
     }
   `;
+
+  protected readonly api = ColumnApi;
 
   protected createController() {
     return new A2uiController(this, ColumnApi);
@@ -66,8 +77,16 @@ export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof Co
     super.updated(changedProperties);
     const props = this.controller.props;
     if (props) {
-      this.style.justifyContent = JUSTIFY_MAP[props.justify ?? ''] ?? 'flex-start';
-      this.style.alignItems = ALIGN_MAP[props.align ?? ''] ?? 'stretch';
+      if (props.justify) {
+        this.style.justifyContent = JUSTIFY_MAP[props.justify] ?? 'flex-start';
+      } else {
+        this.style.removeProperty('justify-content');
+      }
+      if (props.align) {
+        this.style.alignItems = ALIGN_MAP[props.align] ?? 'stretch';
+      } else {
+        this.style.removeProperty('align-items');
+      }
     }
   }
 
@@ -77,7 +96,7 @@ export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof Co
 
     const children: ResolvedChildList = Array.isArray(props.children) ? props.children : [];
 
-    return html` ${map(children, child => html`${this.renderNode(child)}`)} `;
+    return html` ${repeat(children, getChildKey, child => html`${this.renderNode(child)}`)} `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
@@ -16,7 +16,7 @@
 
 import {html, nothing, css, PropertyValues} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {map} from 'lit/directives/map.js';
+import {repeat} from 'lit/directives/repeat.js';
 import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   BasicCatalogA2uiLitElement,
@@ -39,24 +39,21 @@ const ALIGN_MAP: Record<string, string> = {
   center: 'center',
   end: 'flex-end',
   stretch: 'stretch',
+  baseline: 'baseline',
 };
 
 @customElement('a2ui-basic-column')
 export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof ColumnApi> {
-  /**
-   * The styles of the column can be customized by redefining the following
-   * CSS variables:
-   *
-   * - `--a2ui-column-gap`: The gap between items in the column. Defaults to `--a2ui-spacing-m`.
-   */
   static override styles = css`
     :host,
     a2ui-basic-column {
       display: flex;
       flex-direction: column;
-      gap: var(--a2ui-column-gap, var(--a2ui-spacing-m));
+      gap: var(--a2ui-column-gap, var(--a2ui-spacing-m, 16px));
     }
   `;
+
+  protected readonly api = ColumnApi;
 
   protected createController() {
     return new A2uiController(this, ColumnApi);
@@ -64,20 +61,35 @@ export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof Co
 
   override updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (props) {
-      this.style.justifyContent = JUSTIFY_MAP[props.justify ?? ''] ?? 'flex-start';
-      this.style.alignItems = ALIGN_MAP[props.align ?? ''] ?? 'stretch';
+      this.style.display = 'flex';
+      this.style.flexDirection = 'column';
+      this.style.gap = 'var(--a2ui-column-gap, var(--a2ui-spacing-m, 16px))';
+      if (props.justify) {
+        this.style.justifyContent = JUSTIFY_MAP[props.justify] || props.justify;
+      } else {
+        this.style.justifyContent = 'flex-start';
+      }
+      if (props.align) {
+        this.style.alignItems = ALIGN_MAP[props.align] || props.align;
+      } else {
+        this.style.alignItems = 'stretch';
+      }
     }
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
     const children: ResolvedChildList = Array.isArray(props.children) ? props.children : [];
+    const getKey = (child: any) =>
+      typeof child === 'object' && child !== null
+        ? `${child.basePath ?? ''}/${child.id}`
+        : String(child);
 
-    return html` ${map(children, child => html`${this.renderNode(child)}`)} `;
+    return html` ${repeat(children, getKey, child => html`${this.renderNode(child)}`)} `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -21,6 +21,17 @@ import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
 
 /**
+ * Returns the current date formatted as YYYY-MM-DD in the user's local timezone.
+ */
+function getLocalIsoDate(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
  * Normalizes an incoming ISO or partial date/time value into a format accepted by HTML5 inputs.
  *
  * HTML5 input elements (like type="date", type="time", and type="datetime-local") strictly reject
@@ -32,21 +43,24 @@ function normalizeDateTimeValue(value: string | null | undefined, type: string):
   if (!value) return '';
 
   const hasT = value.includes('T');
-  const split = value.split('T');
+  if (hasT) {
+    const [datePart, timePart] = value.split('T');
+    switch (type) {
+      case 'date':
+        return datePart?.substring(0, 10) ?? '';
+      case 'time':
+        return timePart?.substring(0, 5) ?? '';
+      case 'datetime-local':
+        return `${datePart?.substring(0, 10) ?? ''}T${timePart?.substring(0, 5) ?? ''}`;
+    }
+  }
 
-  // If the incoming value is not in ISO format (not hasT), use the incoming value.
-  // It might be just a date: '2010-07-11' or a time: '13:37', so we use value as a
-  // the fallback to the split.
-  const datePart = (hasT ? split[0] : value)?.substring(0, 10) ?? '';
-  const timePart = (hasT ? split[1] : value)?.substring(0, 5) ?? '';
-
-  switch (type) {
-    case 'date':
-      return datePart;
-    case 'time':
-      return timePart;
-    case 'datetime-local':
-      return `${datePart}T${timePart}`;
+  // Not ISO with 'T': value might be just date ('YYYY-MM-DD') or just time ('HH:MM')
+  if (type === 'date') {
+    return value.includes('-') ? value.substring(0, 10) : '';
+  }
+  if (type === 'time') {
+    return value.includes(':') ? value.substring(0, 5) : '';
   }
   return '';
 }
@@ -57,33 +71,51 @@ export class A2uiDateTimeInputElement extends BasicCatalogA2uiLitElement<typeof 
    * The styles of the datetime input can be customized by redefining the following
    * CSS variables:
    *
+   * - `--a2ui-datetimeinput-width`: Width of the component. Defaults to `100%`.
+   * - `--a2ui-datetimeinput-background`: Controls the background of inputs.
+   * - `--a2ui-datetimeinput-color`: Controls the text color of inputs.
+   * - `--a2ui-datetimeinput-border`: Controls the border of inputs.
+   * - `--a2ui-datetimeinput-border-radius`: Controls the border radius of inputs.
+   * - `--a2ui-datetimeinput-padding`: Controls the padding of inputs.
    * - `--a2ui-datetimeinput-label-font-size`: Font size of the label. Defaults to `--a2ui-label-font-size` then `--a2ui-font-size-s`.
    * - `--a2ui-datetimeinput-label-font-weight`: Font weight of the label. Defaults to `--a2ui-label-font-weight` then `bold`.
    */
   static override styles = css`
-    :host,
-    a2ui-datetimeinput {
+    .a2ui-date-time-container {
       display: flex;
       flex-direction: column;
-      gap: var(--a2ui-spacing-xs, 0.25rem);
+      gap: var(--a2ui-spacing-xs, 4px);
+      width: var(--a2ui-datetimeinput-width, 100%);
     }
     input {
+      box-sizing: border-box;
+      width: 100%;
+    }
+    .a2ui-date-time-label {
+      font-size: var(
+        --a2ui-datetimeinput-label-font-size,
+        var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px))
+      );
+      font-weight: var(--a2ui-datetimeinput-label-font-weight, bold);
+      color: var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333));
+    }
+    .a2ui-date-time-inputs {
+      display: flex;
+      gap: var(--a2ui-spacing-s, 8px);
+      width: 100%;
+    }
+    .a2ui-date-time-input {
+      padding: var(--a2ui-datetimeinput-padding, 8px);
+      border-radius: var(--a2ui-datetimeinput-border-radius, 4px);
+      border: var(--a2ui-datetimeinput-border, 1px solid var(--a2ui-color-border, #ccc));
       background-color: var(--a2ui-datetimeinput-background, var(--a2ui-color-input, #fff));
       color: var(--a2ui-datetimeinput-color, var(--a2ui-color-on-input, #333));
-      border: var(--a2ui-datetimeinput-border, var(--a2ui-border));
-      border-radius: var(--a2ui-datetimeinput-border-radius, var(--a2ui-border-radius));
-      padding: var(--a2ui-datetimeinput-padding, var(--a2ui-spacing-s));
+      font-family: inherit;
+      flex: 1;
     }
     .a2ui-date-time-input::-webkit-datetime-edit,
     .a2ui-date-time-input::-webkit-datetime-edit-fields-wrapper {
       color: var(--a2ui-datetimeinput-color, var(--a2ui-color-on-input, #333));
-    }
-    label {
-      font-size: var(
-        --a2ui-datetimeinput-label-font-size,
-        var(--a2ui-label-font-size, var(--a2ui-font-size-s))
-      );
-      font-weight: var(--a2ui-datetimeinput-label-font-weight, var(--a2ui-label-font-weight, bold));
     }
   `;
 
@@ -94,21 +126,69 @@ export class A2uiDateTimeInputElement extends BasicCatalogA2uiLitElement<typeof 
   override render() {
     const props = this.controller.props;
     if (!props) return nothing;
-    // If neither date or time are enabled, render nothing.
-    if (!(props.enableDate || props.enableTime)) return nothing;
 
-    const inputType =
-      props.enableDate && props.enableTime ? 'datetime-local' : props.enableDate ? 'date' : 'time';
-    const normalizedValue = normalizeDateTimeValue(props.value, inputType);
+    const enableDate = props.enableDate ?? true;
+    const enableTime = props.enableTime ?? false;
+    const rawValue =
+      typeof props.value === 'string' ? props.value : props.value ? String(props.value) : '';
+
+    const dateValue = normalizeDateTimeValue(rawValue, 'date');
+    const timeValue = normalizeDateTimeValue(rawValue, 'time');
+
+    const handleDateChange = (event: Event) => {
+      const date = (event.target as HTMLInputElement).value;
+      if (enableTime) {
+        const time = rawValue.includes('T')
+          ? rawValue.split('T')[1]
+          : rawValue.includes(':')
+            ? rawValue
+            : '00:00:00';
+        props.setValue?.(`${date}T${time}`);
+      } else {
+        props.setValue?.(date);
+      }
+    };
+
+    const handleTimeChange = (event: Event) => {
+      const time = (event.target as HTMLInputElement).value;
+      if (enableDate) {
+        const date = rawValue.includes('T')
+          ? rawValue.split('T')[0]
+          : rawValue.includes('-')
+            ? rawValue
+            : getLocalIsoDate();
+        props.setValue?.(`${date}T${time}:00`);
+      } else {
+        props.setValue?.(time);
+      }
+    };
 
     return html`
-      ${props.label ? html`<label>${props.label}</label>` : nothing}
-      <input
-        class="a2ui-date-time-input"
-        type=${inputType}
-        .value=${normalizedValue}
-        @input=${(e: Event) => props.setValue?.((e.target as HTMLInputElement).value)}
-      />
+      <div class="a2ui-date-time-container">
+        ${props.label ? html`<label class="a2ui-date-time-label">${props.label}</label>` : nothing}
+        <div class="a2ui-date-time-inputs">
+          ${enableDate
+            ? html`
+                <input
+                  type="date"
+                  .value=${dateValue}
+                  @change=${handleDateChange}
+                  class="a2ui-date-time-input"
+                />
+              `
+            : nothing}
+          ${enableTime
+            ? html`
+                <input
+                  type="time"
+                  .value=${timeValue}
+                  @change=${handleTimeChange}
+                  class="a2ui-date-time-input"
+                />
+              `
+            : nothing}
+        </div>
+      </div>
     `;
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -65,9 +65,12 @@ export class A2uiDateTimeInputElement extends BasicCatalogA2uiLitElement<typeof 
     a2ui-datetimeinput {
       display: flex;
       flex-direction: column;
+      width: 100%;
       gap: var(--a2ui-spacing-xs, 0.25rem);
     }
     input {
+      box-sizing: border-box;
+      width: 100%;
       background-color: var(--a2ui-datetimeinput-background, var(--a2ui-color-input, #fff));
       color: var(--a2ui-datetimeinput-color, var(--a2ui-color-on-input, #333));
       border: var(--a2ui-datetimeinput-border, var(--a2ui-border));

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Divider.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Divider.ts
@@ -31,29 +31,24 @@ export class A2uiDividerElement extends BasicCatalogA2uiLitElement<typeof Divide
    * - `--a2ui-divider-spacing`: The spacing around the divider. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host,
-    a2ui-divider {
-      display: block;
-      align-self: stretch;
-    }
-    .a2ui-divider.horizontal {
-      height: 0;
-      overflow: hidden;
-      font-size: 0.1px;
-      line-height: 0;
+    .a2ui-divider {
       border: 0;
       border-top: var(
         --a2ui-divider-border,
         var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
       );
-      margin: var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 0.5rem)) 0;
+      margin: var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 16px)) 0;
       width: 100%;
     }
     .a2ui-divider.vertical {
       width: var(--a2ui-border-width, 1px);
-      background-color: var(--a2ui-color-border, #ccc);
       height: 100%;
-      margin: 0 var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 0.5rem));
+      margin: 0 var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 16px));
+      border-top: 0;
+      border-left: var(
+        --a2ui-divider-border,
+        var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
+      );
     }
   `;
 
@@ -65,15 +60,14 @@ export class A2uiDividerElement extends BasicCatalogA2uiLitElement<typeof Divide
     const props = this.controller.props;
     if (!props) return nothing;
 
+    const axis = props.axis ?? 'horizontal';
     const classes = {
       'a2ui-divider': true,
-      vertical: props.axis === 'vertical',
-      horizontal: props.axis !== 'vertical',
+      horizontal: axis === 'horizontal',
+      vertical: axis === 'vertical',
     };
 
-    return props.axis === 'vertical'
-      ? html`<div class=${classMap(classes)}></div>`
-      : html`<hr class=${classMap(classes)} />`;
+    return html`<hr class=${classMap(classes)} />`;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Divider.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Divider.ts
@@ -31,29 +31,24 @@ export class A2uiDividerElement extends BasicCatalogA2uiLitElement<typeof Divide
    * - `--a2ui-divider-spacing`: The spacing around the divider. Defaults to `--a2ui-spacing-m`.
    */
   static override styles = css`
-    :host,
-    a2ui-divider {
-      display: block;
-      align-self: stretch;
-    }
-    .a2ui-divider.horizontal {
-      height: 0;
-      overflow: hidden;
-      font-size: 0.1px;
-      line-height: 0;
+    .a2ui-divider {
       border: 0;
       border-top: var(
         --a2ui-divider-border,
         var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
       );
-      margin: var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 0.5rem)) 0;
+      margin: var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 16px)) 0;
       width: 100%;
     }
     .a2ui-divider.vertical {
       width: var(--a2ui-border-width, 1px);
-      background-color: var(--a2ui-color-border, #ccc);
       height: 100%;
-      margin: 0 var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 0.5rem));
+      margin: 0 var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 16px));
+      border-top: 0;
+      border-left: var(
+        --a2ui-divider-border,
+        var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
+      );
     }
   `;
 
@@ -62,18 +57,17 @@ export class A2uiDividerElement extends BasicCatalogA2uiLitElement<typeof Divide
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
+    const axis = props.axis ?? 'horizontal';
     const classes = {
       'a2ui-divider': true,
-      vertical: props.axis === 'vertical',
-      horizontal: props.axis !== 'vertical',
+      horizontal: axis === 'horizontal',
+      vertical: axis === 'vertical',
     };
 
-    return props.axis === 'vertical'
-      ? html`<div class=${classMap(classes)}></div>`
-      : html`<hr class=${classMap(classes)} />`;
+    return html`<hr class=${classMap(classes)} />`;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Icon.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Icon.ts
@@ -27,9 +27,9 @@ const ICON_NAME_OVERRIDES: Record<string, string> = {
   starOff: 'star_border',
 };
 
-function toMaterialSymbol(name: string): string {
+function toMaterialIconName(name: string): string {
   if (ICON_NAME_OVERRIDES[name]) return ICON_NAME_OVERRIDES[name];
-  return name.replace(/[A-Z]/g, letter => '_' + letter.toLowerCase());
+  return name.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
 }
 
 @customElement('a2ui-icon')
@@ -39,34 +39,37 @@ export class A2uiIconElement extends BasicCatalogA2uiLitElement<typeof IconApi> 
    *
    * - `--a2ui-icon-size`: Dimensions of the icon.
    * - `--a2ui-icon-color`: Color tint applied to the icon.
-   * - `--a2ui-icon-font-family`: Override the font family for icons. Defaults to Material Symbols Outlined.
+   * - `--a2ui-icon-font-family`: Override the font family for icons. Defaults to 'Material Icons', 'Material Symbols Outlined'.
    * - `--a2ui-icon-font-variation-settings`: Complete override for font-variation-settings.
    */
   static override styles = css`
-    :where(:host, a2ui-icon) {
-      --_icon-size: var(--a2ui-icon-size, var(--a2ui-font-size-xl, 24px));
-    }
-    :host,
-    a2ui-icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .material-symbol {
-      font-family: var(--a2ui-icon-font-family, 'Material Symbols Outlined', sans-serif);
-      font-size: var(--_icon-size);
-      font-weight: normal;
+    .a2ui-icon {
+      display: inline-block;
+      width: var(--a2ui-icon-size, 24px);
+      height: var(--a2ui-icon-size, 24px);
+      font-size: var(--a2ui-icon-size, 24px);
       font-style: normal;
-      line-height: 1;
-      letter-spacing: normal;
-      text-transform: none;
-      color: var(--a2ui-icon-color, inherit);
+      font-weight: normal;
+      font-family: var(--a2ui-icon-font-family, 'Material Icons', 'Material Symbols Outlined');
+      color: var(
+        --a2ui-icon-color,
+        var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333))
+      );
       font-variation-settings: var(--a2ui-icon-font-variation-settings, 'FILL' 1);
+      line-height: 1;
+      text-transform: none;
+      letter-spacing: normal;
+      word-wrap: normal;
+      white-space: nowrap;
+      direction: ltr;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+      -moz-osx-font-smoothing: grayscale;
+      font-feature-settings: 'liga';
+      vertical-align: middle;
     }
-    .svg {
+    .a2ui-icon.svg {
       fill: currentColor;
-      width: var(--_icon-size);
-      height: var(--_icon-size);
     }
   `;
 
@@ -79,15 +82,19 @@ export class A2uiIconElement extends BasicCatalogA2uiLitElement<typeof IconApi> 
     if (!props) return nothing;
 
     const name = props.name;
-    const isPath = typeof name === 'object' && name !== null && 'svgPath' in name;
+    const isSvgPath = typeof name === 'object' && name !== null && 'svgPath' in name;
 
-    if (isPath) {
-      const path = (name as {svgPath: string}).svgPath;
-      return html`<svg class="svg" viewBox="0 0 24 24"><path d=${path}></path></svg>`;
+    if (isSvgPath) {
+      const svgPath = (name as {svgPath: string}).svgPath;
+      return html`
+        <svg class="a2ui-icon svg" viewBox="0 0 24 24">
+          <path d=${svgPath}></path>
+        </svg>
+      `;
     }
 
-    const iconName = typeof name === 'string' ? toMaterialSymbol(name) : '';
-    return html`<span class="material-symbol">${iconName}</span>`;
+    const iconName = typeof name === 'string' ? toMaterialIconName(name) : '';
+    return html`<i class="material-icons a2ui-icon">${iconName}</i>`;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
@@ -16,7 +16,6 @@
 
 import {html, nothing, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {classMap} from 'lit/directives/class-map.js';
 import {styleMap} from 'lit/directives/style-map.js';
 import {ImageApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
@@ -36,34 +35,29 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
    * - `--a2ui-image-header-size`: Controls the height of the `header` variant. Defaults to `200px`.
    */
   static override styles = css`
-    img {
+    .a2ui-image {
       display: block;
-      width: 100%;
+      max-width: 100%;
       height: auto;
       border-radius: var(--a2ui-image-border-radius, 0);
     }
-    :is(:host(.icon), a2ui-image.icon),
-    img.icon {
+    .a2ui-image.icon {
       width: var(--a2ui-image-icon-size, 24px);
       height: var(--a2ui-image-icon-size, 24px);
     }
-    img.avatar {
+    .a2ui-image.avatar {
       width: var(--a2ui-image-avatar-size, 40px);
       height: var(--a2ui-image-avatar-size, 40px);
       border-radius: 50%;
     }
-    :is(:host(.smallFeature), a2ui-image.smallFeature),
-    img.smallFeature {
+    .a2ui-image.smallFeature {
       max-width: var(--a2ui-image-small-feature-size, 100px);
     }
-    :is(:host(.largeFeature), a2ui-image.largeFeature),
-    img.largeFeature {
+    .a2ui-image.largeFeature {
       max-height: var(--a2ui-image-large-feature-size, 400px);
     }
-    :is(:host(.header), a2ui-image.header),
-    img.header {
+    .a2ui-image.header {
       height: var(--a2ui-image-header-size, 200px);
-      object-fit: cover;
     }
   `;
 
@@ -75,20 +69,14 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
     const props = this.controller.props;
     if (!props) return nothing;
 
-    const classes = {
-      'a2ui-image': true,
-      [props.variant || '']: !!props.variant,
-    };
-
-    const styles = {
-      objectFit: props.fit || 'fill',
-    };
+    const variant = props.variant || 'default';
+    const fit = props.fit || 'cover';
 
     return html`<img
       src=${props.url}
       alt=${props.description || ''}
-      class=${classMap(classes)}
-      style=${styleMap(styles)}
+      style=${styleMap({objectFit: fit})}
+      class="a2ui-image ${variant}"
     />`;
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
@@ -38,7 +38,6 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
   static override styles = css`
     img {
       display: block;
-      width: 100%;
       height: auto;
       border-radius: var(--a2ui-image-border-radius, 0);
     }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/List.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/List.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {html, nothing, css, PropertyValues} from 'lit';
+import {html, nothing, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {map} from 'lit/directives/map.js';
+import {repeat} from 'lit/directives/repeat.js';
 import {ListApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   BasicCatalogA2uiLitElement,
@@ -24,28 +24,41 @@ import {
 } from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
 
+function getChildKey(child: any): string {
+  return typeof child === 'object' && child !== null
+    ? `${child.basePath ?? ''}/${child.id}`
+    : String(child);
+}
+
 @customElement('a2ui-list')
 export class A2uiListElement extends BasicCatalogA2uiLitElement<typeof ListApi> {
   static override styles = css`
-    :host,
-    a2ui-list {
+    .a2ui-list {
       display: flex;
-      overflow: auto;
-      gap: var(--a2ui-list-gap, var(--a2ui-spacing-m, 0.5rem));
-      padding: var(--a2ui-list-padding, 0);
+      padding-inline-start: var(--a2ui-list-padding, var(--a2ui-spacing-l, 24px));
+      margin: 0;
+    }
+    .a2ui-list.vertical {
+      flex-direction: column;
+      gap: var(--a2ui-list-gap, var(--a2ui-spacing-s, 8px));
+    }
+    .a2ui-list.horizontal {
+      flex-direction: row;
+      gap: var(--a2ui-list-gap, var(--a2ui-spacing-m, 16px));
+      list-style-position: inside;
+    }
+    .a2ui-list-item-none {
+      display: block;
+    }
+    .horizontal .a2ui-list-item-none {
+      display: inline-block;
     }
   `;
 
+  protected readonly api = ListApi;
+
   protected createController() {
     return new A2uiController(this, ListApi);
-  }
-
-  override updated(changedProperties: PropertyValues) {
-    super.updated(changedProperties);
-    const props = this.controller.props;
-    if (props) {
-      this.style.flexDirection = props.direction === 'horizontal' ? 'row' : 'column';
-    }
   }
 
   override render() {
@@ -53,7 +66,34 @@ export class A2uiListElement extends BasicCatalogA2uiLitElement<typeof ListApi> 
     if (!props) return nothing;
 
     const children: ResolvedChildList = Array.isArray(props.children) ? props.children : [];
-    return html`${map(children, child => html`${this.renderNode(child)}`)}`;
+    const listStyle = props.listStyle;
+    const direction = props.direction || 'vertical';
+
+    if (listStyle === 'ordered') {
+      return html`
+        <ol class="a2ui-list ${direction}">
+          ${repeat(children, getChildKey, child => html`<li>${this.renderNode(child)}</li>`)}
+        </ol>
+      `;
+    }
+
+    if (listStyle === 'unordered') {
+      return html`
+        <ul class="a2ui-list ${direction}">
+          ${repeat(children, getChildKey, child => html`<li>${this.renderNode(child)}</li>`)}
+        </ul>
+      `;
+    }
+
+    return html`
+      <div class="a2ui-list ${direction}">
+        ${repeat(
+          children,
+          getChildKey,
+          child => html`<div class="a2ui-list-item-none">${this.renderNode(child)}</div>`,
+        )}
+      </div>
+    `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/List.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/List.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {html, nothing, css, PropertyValues} from 'lit';
+import {html, nothing, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {map} from 'lit/directives/map.js';
+import {repeat} from 'lit/directives/repeat.js';
 import {ListApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   BasicCatalogA2uiLitElement,
@@ -24,40 +24,78 @@ import {
 } from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
 
-@customElement('a2ui-list')
-export class A2uiListElement extends BasicCatalogA2uiLitElement<typeof ListApi> {
+@customElement('a2ui-basic-list')
+export class A2uiBasicListElement extends BasicCatalogA2uiLitElement<typeof ListApi> {
   static override styles = css`
-    :host,
-    a2ui-list {
+    .a2ui-list {
       display: flex;
-      overflow: auto;
-      gap: var(--a2ui-list-gap, var(--a2ui-spacing-m, 0.5rem));
-      padding: var(--a2ui-list-padding, 0);
+      padding-inline-start: var(--a2ui-list-padding, var(--a2ui-spacing-l, 24px));
+      margin: 0;
+    }
+    .a2ui-list.vertical {
+      flex-direction: column;
+      gap: var(--a2ui-list-gap, var(--a2ui-spacing-s, 8px));
+    }
+    .a2ui-list.horizontal {
+      flex-direction: row;
+      gap: var(--a2ui-list-gap, var(--a2ui-spacing-m, 16px));
+      list-style-position: inside;
+    }
+    .a2ui-list-item-none {
+      display: block;
+    }
+    .horizontal .a2ui-list-item-none {
+      display: inline-block;
     }
   `;
+
+  protected readonly api = ListApi;
 
   protected createController() {
     return new A2uiController(this, ListApi);
   }
 
-  override updated(changedProperties: PropertyValues) {
-    super.updated(changedProperties);
-    const props = this.controller.props;
-    if (props) {
-      this.style.flexDirection = props.direction === 'horizontal' ? 'row' : 'column';
-    }
-  }
-
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
     const children: ResolvedChildList = Array.isArray(props.children) ? props.children : [];
-    return html`${map(children, child => html`${this.renderNode(child)}`)}`;
+    const listStyle = props.listStyle;
+    const direction = props.direction || 'vertical';
+    const getKey = (child: any) =>
+      typeof child === 'object' && child !== null
+        ? `${child.basePath ?? ''}/${child.id}`
+        : String(child);
+
+    if (listStyle === 'ordered') {
+      return html`
+        <ol class="a2ui-list ${direction}">
+          ${repeat(children, getKey, child => html`<li>${this.renderNode(child)}</li>`)}
+        </ol>
+      `;
+    }
+
+    if (listStyle === 'unordered') {
+      return html`
+        <ul class="a2ui-list ${direction}">
+          ${repeat(children, getKey, child => html`<li>${this.renderNode(child)}</li>`)}
+        </ul>
+      `;
+    }
+
+    return html`
+      <div class="a2ui-list ${direction}">
+        ${repeat(
+          children,
+          getKey,
+          child => html`<div class="a2ui-list-item-none">${this.renderNode(child)}</div>`,
+        )}
+      </div>
+    `;
   }
 }
 
 export const A2uiList = {
   ...ListApi,
-  tagName: 'a2ui-list',
+  tagName: 'a2ui-basic-list',
 };

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
@@ -15,7 +15,7 @@
  */
 
 import {html, nothing, css} from 'lit';
-import {customElement, query} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
@@ -26,50 +26,107 @@ export class A2uiLitModal extends BasicCatalogA2uiLitElement<typeof ModalApi> {
    * The styles of the modal can be customized by redefining the following
    * CSS variables:
    *
-   * - `--a2ui-modal-backdrop-bg`: Controls the backdrop color of the dialog.
-   * - `--a2ui-modal-padding`: Padding inside the dialog content area. Defaults to `24px`.
-   * - `--a2ui-modal-border-radius`: Border radius of the dialog. Defaults to `8px`.
+   * - `--a2ui-modal-background`: Controls the background of the modal content.
+   * - `--a2ui-modal-padding`: Controls the padding of the modal content.
+   * - `--a2ui-modal-border-radius`: Controls the border radius of the modal content.
+   * - `--a2ui-modal-box-shadow`: Controls the box shadow of the modal content.
+   * - `--a2ui-modal-backdrop-bg`: Controls the background of the backdrop.
    */
   static override styles = css`
     :host,
     a2ui-modal {
       display: inline-block;
     }
-    dialog {
-      border: 1px solid var(--a2ui-color-border, #ccc);
-      border-radius: var(--a2ui-modal-border-radius, 8px);
-      padding: var(--a2ui-modal-padding, 24px);
-      min-width: 300px;
-      background: var(--a2ui-color-surface, #fff);
+    .a2ui-modal-wrapper {
+      display: inline-block;
     }
-    dialog::backdrop {
+    .a2ui-modal-trigger {
+      cursor: pointer;
+    }
+    .a2ui-modal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
       background: var(--a2ui-modal-backdrop-bg, rgba(0, 0, 0, 0.5));
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+    .a2ui-modal-content {
+      background: var(--a2ui-modal-background, var(--a2ui-color-surface, #fff));
+      padding: var(--a2ui-modal-padding, var(--a2ui-spacing-xl, 32px));
+      border-radius: var(--a2ui-modal-border-radius, var(--a2ui-border-radius, 8px));
+      position: relative;
+      min-width: 300px;
+      max-width: 80%;
+      max-height: 80%;
+      overflow-y: auto;
+      box-shadow: var(--a2ui-modal-box-shadow, 0 10px 25px rgba(0, 0, 0, 0.2));
+    }
+    .a2ui-modal-close {
+      position: absolute;
+      top: 10px;
+      right: 15px;
+      border: none;
+      background: none;
+      font-size: 24px;
+      cursor: pointer;
+      color: var(--a2ui-text-caption-color, #999);
+    }
+    .a2ui-modal-close:hover {
+      color: var(--a2ui-text-color, #333);
     }
   `;
+
+  @state() accessor isOpen = false;
 
   protected createController() {
     return new A2uiController(this, ModalApi);
   }
-  @query('dialog') accessor dialog!: HTMLDialogElement;
+
+  openModal() {
+    this.isOpen = true;
+  }
+
+  closeModal() {
+    this.isOpen = false;
+  }
 
   override render() {
     const props = this.controller.props;
     if (!props) return nothing;
 
     return html`
-      <div
-        @click=${() => this.dialog?.showModal()}
-        class="a2ui-modal-trigger"
-        style="display: contents;"
-      >
-        ${props.trigger ? html`${this.renderNode(props.trigger)}` : nothing}
+      <div class="a2ui-modal-wrapper">
+        <div @click=${() => this.openModal()} class="a2ui-modal-trigger">
+          ${props.trigger ? html`${this.renderNode(props.trigger)}` : nothing}
+        </div>
+        ${this.isOpen
+          ? html`
+              <div class="a2ui-modal-overlay" @click=${() => this.closeModal()}>
+                <div
+                  class="a2ui-modal-content"
+                  role="dialog"
+                  aria-modal="true"
+                  @click=${(e: Event) => e.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    class="a2ui-modal-close"
+                    aria-label="Close"
+                    @click=${() => this.closeModal()}
+                  >
+                    &times;
+                  </button>
+                  ${props.content ? html`${this.renderNode(props.content)}` : nothing}
+                </div>
+              </div>
+            `
+          : nothing}
       </div>
-      <dialog class="a2ui-modal a2ui-modal-overlay">
-        <form method="dialog" style="text-align: right;">
-          <button class="a2ui-modal-close">×</button>
-        </form>
-        ${props.content ? html`${this.renderNode(props.content)}` : nothing}
-      </dialog>
     `;
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
@@ -16,7 +16,7 @@
 
 import {html, nothing, css, PropertyValues} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {map} from 'lit/directives/map.js';
+import {repeat} from 'lit/directives/repeat.js';
 import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   BasicCatalogA2uiLitElement,
@@ -39,7 +39,14 @@ const ALIGN_MAP: Record<string, string> = {
   center: 'center',
   end: 'flex-end',
   stretch: 'stretch',
+  baseline: 'baseline',
 };
+
+function getChildKey(child: any): string {
+  return typeof child === 'object' && child !== null
+    ? `${child.basePath ?? ''}/${child.id}`
+    : String(child);
+}
 
 @customElement('a2ui-basic-row')
 export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowApi> {
@@ -58,6 +65,8 @@ export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowAp
     }
   `;
 
+  protected readonly api = RowApi;
+
   protected createController() {
     return new A2uiController(this, RowApi);
   }
@@ -66,8 +75,16 @@ export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowAp
     super.updated(changedProperties);
     const props = this.controller.props;
     if (props) {
-      this.style.justifyContent = JUSTIFY_MAP[props.justify ?? ''] ?? 'flex-start';
-      this.style.alignItems = ALIGN_MAP[props.align ?? ''] ?? 'stretch';
+      if (props.justify) {
+        this.style.justifyContent = JUSTIFY_MAP[props.justify] ?? 'flex-start';
+      } else {
+        this.style.removeProperty('justify-content');
+      }
+      if (props.align) {
+        this.style.alignItems = ALIGN_MAP[props.align] ?? 'stretch';
+      } else {
+        this.style.removeProperty('align-items');
+      }
     }
   }
 
@@ -77,7 +94,7 @@ export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowAp
 
     const children: ResolvedChildList = Array.isArray(props.children) ? props.children : [];
 
-    return html` ${map(children, child => html`${this.renderNode(child)}`)} `;
+    return html` ${repeat(children, getChildKey, child => html`${this.renderNode(child)}`)} `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
@@ -16,7 +16,7 @@
 
 import {html, nothing, css, PropertyValues} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {map} from 'lit/directives/map.js';
+import {repeat} from 'lit/directives/repeat.js';
 import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {
   BasicCatalogA2uiLitElement,
@@ -32,6 +32,7 @@ const JUSTIFY_MAP: Record<string, string> = {
   spaceAround: 'space-around',
   spaceEvenly: 'space-evenly',
   stretch: 'stretch',
+  baseline: 'baseline',
 };
 
 const ALIGN_MAP: Record<string, string> = {
@@ -39,24 +40,21 @@ const ALIGN_MAP: Record<string, string> = {
   center: 'center',
   end: 'flex-end',
   stretch: 'stretch',
+  baseline: 'baseline',
 };
 
 @customElement('a2ui-basic-row')
 export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowApi> {
-  /**
-   * The styles of the row can be customized by redefining the following
-   * CSS variables:
-   *
-   * - `--a2ui-row-gap`: The gap between items in the row. Defaults to `--a2ui-spacing-m`.
-   */
   static override styles = css`
     :host,
     a2ui-basic-row {
       display: flex;
       flex-direction: row;
-      gap: var(--a2ui-row-gap, var(--a2ui-spacing-m));
+      gap: var(--a2ui-row-gap, var(--a2ui-spacing-m, 16px));
     }
   `;
+
+  protected readonly api = RowApi;
 
   protected createController() {
     return new A2uiController(this, RowApi);
@@ -64,20 +62,35 @@ export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowAp
 
   override updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (props) {
-      this.style.justifyContent = JUSTIFY_MAP[props.justify ?? ''] ?? 'flex-start';
-      this.style.alignItems = ALIGN_MAP[props.align ?? ''] ?? 'stretch';
+      this.style.display = 'flex';
+      this.style.flexDirection = 'row';
+      this.style.gap = 'var(--a2ui-row-gap, var(--a2ui-spacing-m, 16px))';
+      if (props.justify) {
+        this.style.justifyContent = JUSTIFY_MAP[props.justify] || props.justify;
+      } else {
+        this.style.justifyContent = 'flex-start';
+      }
+      if (props.align) {
+        this.style.alignItems = ALIGN_MAP[props.align] || props.align;
+      } else {
+        this.style.alignItems = 'stretch';
+      }
     }
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
     const children: ResolvedChildList = Array.isArray(props.children) ? props.children : [];
+    const getKey = (child: any) =>
+      typeof child === 'object' && child !== null
+        ? `${child.basePath ?? ''}/${child.id}`
+        : String(child);
 
-    return html` ${map(children, child => html`${this.renderNode(child)}`)} `;
+    return html` ${repeat(children, getKey, child => html`${this.renderNode(child)}`)} `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Slider.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Slider.ts
@@ -32,27 +32,26 @@ export class A2uiSliderElement extends BasicCatalogA2uiLitElement<typeof SliderA
    * - `--a2ui-slider-label-font-weight`: Font weight of the label. Defaults to `--a2ui-label-font-weight` then `bold`.
    */
   static override styles = css`
-    :host,
-    a2ui-slider {
+    .a2ui-slider-container {
+      width: 100%;
       display: flex;
       flex-direction: column;
-      gap: var(--a2ui-spacing-xs, 0.25rem);
-      margin: var(--a2ui-slider-margin, var(--a2ui-spacing-m));
+      gap: var(--a2ui-spacing-xs, 4px);
+      margin: var(--a2ui-slider-margin, var(--a2ui-spacing-m, 16px));
     }
-    .header {
+    .a2ui-slider-header {
       display: flex;
       justify-content: space-between;
-      align-items: center;
-    }
-    .header label {
       font-size: var(
         --a2ui-slider-label-font-size,
-        var(--a2ui-label-font-size, var(--a2ui-font-size-s))
+        var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px))
       );
-      font-weight: var(--a2ui-slider-label-font-weight, var(--a2ui-label-font-weight, bold));
+      font-weight: var(--a2ui-slider-label-font-weight, bold);
+      color: var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333));
     }
-    input[type='range'] {
+    .a2ui-slider {
       width: 100%;
+      cursor: pointer;
       accent-color: var(--a2ui-slider-thumb-color, var(--a2ui-color-primary, #007bff));
       background: var(--a2ui-slider-track-color, var(--a2ui-color-secondary, #e9ecef));
     }
@@ -67,17 +66,20 @@ export class A2uiSliderElement extends BasicCatalogA2uiLitElement<typeof SliderA
     if (!props) return nothing;
 
     return html`
-      <div class="header">
-        ${props.label ? html`<label>${props.label}</label>` : nothing}
-        <span>${props.value}</span>
+      <div class="a2ui-slider-container">
+        <div class="a2ui-slider-header">
+          <span class="a2ui-slider-label">${props.label}</span>
+          <span class="a2ui-slider-value">${props.value}</span>
+        </div>
+        <input
+          type="range"
+          min=${props.min ?? 0}
+          max=${props.max ?? 100}
+          .value=${props.value?.toString() || '0'}
+          @input=${(e: Event) => props.setValue?.(Number((e.target as HTMLInputElement).value))}
+          class="a2ui-slider"
+        />
       </div>
-      <input
-        type="range"
-        min=${props.min ?? 0}
-        max=${props.max ?? 100}
-        .value=${props.value?.toString() || '0'}
-        @input=${(e: Event) => props.setValue?.(Number((e.target as HTMLInputElement).value))}
-      />
     `;
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
@@ -27,44 +27,45 @@ export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
    * The styles of the tabs can be customized by redefining the following
    * CSS variables:
    *
-   * - `--a2ui-tabs-header-background`: Default transparent.
-   * - `--a2ui-tabs-header-background-active`: Default `--a2ui-color-secondary`.
-   * - `--a2ui-tabs-header-color`: Default `--a2ui-color-on-surface`.
-   * - `--a2ui-tabs-header-color-active`: Default `--a2ui-color-on-secondary`.
-   * - `--a2ui-tabs-border`: Default `--a2ui-border-width` solid `--a2ui-color-border`.
-   * - `--a2ui-tabs-content-padding`: Default `0 var(--a2ui-spacing-m, 0.5rem)`.
+   * - `--a2ui-tabs-border`: Controls the border of the tab bar. Defaults to `2px solid var(--a2ui-color-border, #eee)`.
+   * - `--a2ui-tabs-header-background`: Controls the background of tab buttons. Defaults to `transparent`.
+   * - `--a2ui-tabs-header-color`: Controls the text color of tab buttons. Defaults to `var(--a2ui-text-caption-color, #666)`.
+   * - `--a2ui-tabs-header-background-active`: Controls the background of the active tab button. Defaults to `transparent`.
+   * - `--a2ui-tabs-header-color-active`: Controls the text color of the active tab button. Defaults to `var(--a2ui-color-primary, #007bff)`.
+   * - `--a2ui-tabs-content-padding`: Controls the padding of the tab content. Defaults to `var(--a2ui-spacing-m, 16px) 0`.
    */
   static override styles = css`
-    :host,
-    a2ui-tabs {
-      display: block;
-    }
-    .a2ui-tabs-headers {
+    .a2ui-tabs {
       display: flex;
-      gap: var(--a2ui-spacing-xs, 0.25rem);
-      border-bottom: var(
-        --a2ui-tabs-border,
-        var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
-      );
-      margin-bottom: var(--a2ui-spacing-m, 0.5rem);
+      flex-direction: column;
+      width: 100%;
     }
-    .a2ui-tabs-header {
-      padding: var(--a2ui-spacing-m, 0.5rem) var(--a2ui-spacing-l, 1rem);
-      background: var(--a2ui-tabs-header-background, transparent);
-      color: var(--a2ui-tabs-header-color, var(--a2ui-color-on-surface));
+    .a2ui-tab-bar {
+      display: flex;
+      border-bottom: var(--a2ui-tabs-border, 2px solid var(--a2ui-color-border, #eee));
+      gap: var(--a2ui-spacing-m, 16px);
+    }
+    .a2ui-tab-button {
+      padding: var(--a2ui-spacing-s, 8px) var(--a2ui-spacing-m, 16px);
       border: none;
-      border-radius: var(--a2ui-border-radius, 0.25rem) var(--a2ui-border-radius, 0.25rem) 0 0;
+      background: var(--a2ui-tabs-header-background, transparent);
       cursor: pointer;
-      font-family: inherit;
+      font-weight: 500;
+      color: var(--a2ui-tabs-header-color, var(--a2ui-text-caption-color, #666));
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
     }
-    .a2ui-tabs-header.active {
-      background: var(--a2ui-tabs-header-background-active, var(--a2ui-color-secondary, #eee));
-      color: var(--a2ui-tabs-header-color-active, var(--a2ui-color-on-secondary, #333));
+    .a2ui-tab-button.active {
+      background: var(--a2ui-tabs-header-background-active, transparent);
+      color: var(--a2ui-tabs-header-color-active, var(--a2ui-color-primary, #007bff));
+      border-bottom: 2px solid var(--a2ui-color-primary, #007bff);
     }
-    .a2ui-tabs-content {
-      padding: var(--a2ui-tabs-content-padding, 0 var(--a2ui-spacing-m, 0.5rem));
+    .a2ui-tab-content {
+      padding: var(--a2ui-tabs-content-padding, var(--a2ui-spacing-m, 16px) 0);
     }
   `;
+
+  protected readonly api = TabsApi;
 
   protected createController() {
     return new A2uiController(this, TabsApi);
@@ -72,30 +73,40 @@ export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
 
   @state() accessor activeIndex = 0;
 
+  override willUpdate(changedProperties: any) {
+    super.willUpdate(changedProperties);
+    const props = this.controller.props;
+    if (props?.tabs && this.activeIndex >= props.tabs.length) {
+      this.activeIndex = 0;
+    }
+  }
+
   override render() {
     const props = this.controller.props;
     if (!props || !props.tabs) return nothing;
+
     return html`
-      <div class="a2ui-tabs-headers">
-        ${props.tabs.map(
-          (tab: any, i: number) => html`
-            <button
-              class=${classMap({
-                'a2ui-tabs-header': true,
-                'a2ui-tab-button': true,
-                active: i === this.activeIndex,
-              })}
-              @click=${() => (this.activeIndex = i)}
-            >
-              ${tab.title}
-            </button>
-          `,
-        )}
-      </div>
-      <div class="a2ui-tabs-content">
-        ${props.tabs[this.activeIndex]
-          ? html`${this.renderNode(props.tabs[this.activeIndex].child)}`
-          : nothing}
+      <div class="a2ui-tabs">
+        <div class="a2ui-tab-bar">
+          ${props.tabs.map(
+            (tab, i) => html`
+              <button
+                class=${classMap({
+                  'a2ui-tab-button': true,
+                  active: i === this.activeIndex,
+                })}
+                @click=${() => (this.activeIndex = i)}
+              >
+                ${tab.title}
+              </button>
+            `,
+          )}
+        </div>
+        <div class="a2ui-tab-content">
+          ${props.tabs[this.activeIndex]
+            ? html`${this.renderNode(props.tabs[this.activeIndex].child)}`
+            : nothing}
+        </div>
       </div>
     `;
   }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
@@ -21,50 +21,40 @@ import {TabsApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
 
-@customElement('a2ui-tabs')
-export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
-  /**
-   * The styles of the tabs can be customized by redefining the following
-   * CSS variables:
-   *
-   * - `--a2ui-tabs-header-background`: Default transparent.
-   * - `--a2ui-tabs-header-background-active`: Default `--a2ui-color-secondary`.
-   * - `--a2ui-tabs-header-color`: Default `--a2ui-color-on-surface`.
-   * - `--a2ui-tabs-header-color-active`: Default `--a2ui-color-on-secondary`.
-   * - `--a2ui-tabs-border`: Default `--a2ui-border-width` solid `--a2ui-color-border`.
-   * - `--a2ui-tabs-content-padding`: Default `0 var(--a2ui-spacing-m, 0.5rem)`.
-   */
+@customElement('a2ui-basic-tabs')
+export class A2uiBasicTabsElement extends BasicCatalogA2uiLitElement<typeof TabsApi> {
   static override styles = css`
-    :host,
-    a2ui-tabs {
-      display: block;
-    }
-    .a2ui-tabs-headers {
+    .a2ui-tabs {
       display: flex;
-      gap: var(--a2ui-spacing-xs, 0.25rem);
-      border-bottom: var(
-        --a2ui-tabs-border,
-        var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
-      );
-      margin-bottom: var(--a2ui-spacing-m, 0.5rem);
+      flex-direction: column;
+      width: 100%;
     }
-    .a2ui-tabs-header {
-      padding: var(--a2ui-spacing-m, 0.5rem) var(--a2ui-spacing-l, 1rem);
-      background: var(--a2ui-tabs-header-background, transparent);
-      color: var(--a2ui-tabs-header-color, var(--a2ui-color-on-surface));
+    .a2ui-tab-bar {
+      display: flex;
+      border-bottom: var(--a2ui-tabs-border, 2px solid var(--a2ui-color-border, #eee));
+      gap: var(--a2ui-spacing-m, 16px);
+    }
+    .a2ui-tab-button {
+      padding: var(--a2ui-spacing-s, 8px) var(--a2ui-spacing-m, 16px);
       border: none;
-      border-radius: var(--a2ui-border-radius, 0.25rem) var(--a2ui-border-radius, 0.25rem) 0 0;
+      background: var(--a2ui-tabs-header-background, transparent);
       cursor: pointer;
-      font-family: inherit;
+      font-weight: 500;
+      color: var(--a2ui-tabs-header-color, var(--a2ui-text-caption-color, #666));
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
     }
-    .a2ui-tabs-header.active {
-      background: var(--a2ui-tabs-header-background-active, var(--a2ui-color-secondary, #eee));
-      color: var(--a2ui-tabs-header-color-active, var(--a2ui-color-on-secondary, #333));
+    .a2ui-tab-button.active {
+      background: var(--a2ui-tabs-header-background-active, transparent);
+      color: var(--a2ui-tabs-header-color-active, var(--a2ui-color-primary, #007bff));
+      border-bottom: 2px solid var(--a2ui-color-primary, #007bff);
     }
-    .a2ui-tabs-content {
-      padding: var(--a2ui-tabs-content-padding, 0 var(--a2ui-spacing-m, 0.5rem));
+    .a2ui-tab-content {
+      padding: var(--a2ui-tabs-content-padding, var(--a2ui-spacing-m, 16px) 0);
     }
   `;
+
+  protected readonly api = TabsApi;
 
   protected createController() {
     return new A2uiController(this, TabsApi);
@@ -72,30 +62,40 @@ export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
 
   @state() accessor activeIndex = 0;
 
+  override willUpdate(changedProperties: any) {
+    super.willUpdate(changedProperties);
+    const props = this.controller?.props;
+    if (props?.tabs && this.activeIndex >= props.tabs.length) {
+      this.activeIndex = Math.max(0, props.tabs.length - 1);
+    }
+  }
+
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props || !props.tabs) return nothing;
+
     return html`
-      <div class="a2ui-tabs-headers">
-        ${props.tabs.map(
-          (tab: any, i: number) => html`
-            <button
-              class=${classMap({
-                'a2ui-tabs-header': true,
-                'a2ui-tab-button': true,
-                active: i === this.activeIndex,
-              })}
-              @click=${() => (this.activeIndex = i)}
-            >
-              ${tab.title}
-            </button>
-          `,
-        )}
-      </div>
-      <div class="a2ui-tabs-content">
-        ${props.tabs[this.activeIndex]
-          ? html`${this.renderNode(props.tabs[this.activeIndex].child)}`
-          : nothing}
+      <div class="a2ui-tabs">
+        <div class="a2ui-tab-bar">
+          ${props.tabs.map(
+            (tab, i) => html`
+              <button
+                class=${classMap({
+                  'a2ui-tab-button': true,
+                  active: i === this.activeIndex,
+                })}
+                @click=${() => (this.activeIndex = i)}
+              >
+                ${tab.title}
+              </button>
+            `,
+          )}
+        </div>
+        <div class="a2ui-tab-content">
+          ${props.tabs[this.activeIndex]
+            ? html`${this.renderNode(props.tabs[this.activeIndex].child)}`
+            : nothing}
+        </div>
       </div>
     `;
   }
@@ -103,5 +103,5 @@ export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
 
 export const A2uiTabs = {
   ...TabsApi,
-  tagName: 'a2ui-tabs',
+  tagName: 'a2ui-basic-tabs',
 };

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
@@ -22,8 +22,9 @@ import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
 import {Context} from '../../../context/context.js';
 import * as Types from '@a2ui/web_core/types/types';
-
 import {markdown} from '../../../directives/directives.js';
+
+const NON_MARKDOWN_VARIANTS = new Set<string>(['h1', 'h2', 'h3', 'h4', 'h5', 'caption']);
 
 @customElement('a2ui-basic-text')
 export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof TextApi> {
@@ -33,76 +34,71 @@ export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof Text
    *
    * - `--a2ui-text-color-text`: The color of the text. Defaults to `--a2ui-color-on-background`.
    * - `--a2ui-text-caption-color`: The color for caption text. Defaults to `light-dark(#666, #aaa)`.
-   *
-   * It also supports `--_a2ui-text-color` override from parent components (like Button).
    */
   static override styles = css`
-    :host,
-    a2ui-basic-text {
-      display: inline-block;
-      color: var(--_a2ui-text-color, var(--a2ui-text-color-text, var(--a2ui-color-on-background)));
+    :host {
+      display: contents;
     }
-    p,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    ol,
-    ul,
-    li,
-    blockquote,
-    pre {
+    .a2ui-text p,
+    .a2ui-text h1,
+    .a2ui-text h2,
+    .a2ui-text h3,
+    .a2ui-text h4,
+    .a2ui-text h5,
+    .a2ui-text h6,
+    .a2ui-text ol,
+    .a2ui-text ul,
+    .a2ui-text li,
+    .a2ui-text blockquote,
+    .a2ui-text pre {
       margin: var(--_a2ui-text-margin, 0);
     }
-    h1,
-    h2,
-    h3,
-    h4,
-    h5 {
+    .a2ui-text {
+      color: var(--_a2ui-text-color, var(--a2ui-text-color-text, var(--a2ui-color-on-background)));
+    }
+    .a2ui-text h1,
+    .a2ui-text h2,
+    .a2ui-text h3,
+    .a2ui-text h4,
+    .a2ui-text h5,
+    .a2ui-text h6 {
       font-family: var(--a2ui-font-family-title, inherit);
       line-height: var(--a2ui-line-height-headings, 1.2);
     }
-    h1 {
+    .a2ui-text h1 {
       font-size: var(--a2ui-font-size-2xl);
     }
-    h2 {
+    .a2ui-text h2 {
       font-size: var(--a2ui-font-size-xl);
     }
-    h3 {
+    .a2ui-text h3 {
       font-size: var(--a2ui-font-size-l);
     }
-    p,
-    h4 {
+    .a2ui-text p,
+    .a2ui-text h4 {
       font-size: var(--a2ui-font-size-m);
     }
-    h5 {
+    .a2ui-text h5 {
       font-size: var(--a2ui-font-size-s);
     }
-    p,
-    ol,
-    ul,
-    li,
-    blockquote,
-    .a2ui-caption {
+    .a2ui-text p {
       line-height: var(--a2ui-line-height-body, 1.5);
     }
-    .a2ui-caption,
-    .a2ui-caption > *,
-    .a2ui-caption ::slotted(*) {
+    .a2ui-text.caption,
+    .a2ui-caption {
       font-size: var(--a2ui-font-size-xs);
       color: var(--a2ui-text-caption-color, light-dark(#666, #aaa));
     }
-    a {
+    .a2ui-text a {
       color: var(--a2ui-text-a-color, inherit);
       font-weight: var(--a2ui-text-a-font-weight, inherit);
     }
   `;
 
-  // Retrieve a MarkdownRenderer provided by the application.
   @consume({context: Context.markdown, subscribe: true})
   accessor markdownRenderer: Types.MarkdownRenderer | undefined;
+
+  protected readonly api = TextApi;
 
   protected createController() {
     return new A2uiController(this, TextApi);
@@ -112,35 +108,37 @@ export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof Text
     const props = this.controller.props;
     if (!props) return nothing;
 
-    // Use props.variant to convert props.text to markdown
-    let markdownText = typeof props.text === 'string' ? props.text : String(props.text ?? '');
-    switch (props.variant) {
-      case 'h1':
-        markdownText = `# ${markdownText}`;
-        break;
-      case 'h2':
-        markdownText = `## ${markdownText}`;
-        break;
-      case 'h3':
-        markdownText = `### ${markdownText}`;
-        break;
-      case 'h4':
-        markdownText = `#### ${markdownText}`;
-        break;
-      case 'h5':
-        markdownText = `##### ${markdownText}`;
-        break;
-      default:
-        break; // body and caption.
+    const variant = props.variant || 'body';
+    const text = typeof props.text === 'string' ? props.text : String(props.text ?? '');
+    const flexStyle = typeof props.weight === 'number' ? `flex: ${props.weight};` : nothing;
+
+    if (NON_MARKDOWN_VARIANTS.has(variant)) {
+      let content = html`${text}`;
+      switch (variant) {
+        case 'h1':
+          content = html`<h1>${text}</h1>`;
+          break;
+        case 'h2':
+          content = html`<h2>${text}</h2>`;
+          break;
+        case 'h3':
+          content = html`<h3>${text}</h3>`;
+          break;
+        case 'h4':
+          content = html`<h4>${text}</h4>`;
+          break;
+        case 'h5':
+          content = html`<h5>${text}</h5>`;
+          break;
+        case 'caption':
+          content = html`<em>${text}</em>`;
+          break;
+      }
+      return html`<span class="a2ui-text ${variant}" style=${flexStyle}>${content}</span>`;
     }
 
-    const renderedMarkdown = markdown(markdownText, this.markdownRenderer);
-    // There's not a good way to handle the caption variant in markdown, so we
-    // tag it with a class so it can be tweaked via CSS.
-    if (props.variant === 'caption') {
-      return html`<span class="a2ui-caption">${renderedMarkdown}</span>`;
-    }
-    return html`${renderedMarkdown}`;
+    const renderedMarkdown = markdown(text, this.markdownRenderer);
+    return html`<span class="a2ui-text ${variant}" style=${flexStyle}>${renderedMarkdown}</span>`;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
@@ -22,125 +22,103 @@ import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
 import {Context} from '../../../context/context.js';
 import * as Types from '@a2ui/web_core/types/types';
-
 import {markdown} from '../../../directives/directives.js';
+
+const NON_MARKDOWN_VARIANTS = new Set<string>(['h1', 'h2', 'h3', 'h4', 'h5', 'caption']);
 
 @customElement('a2ui-basic-text')
 export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof TextApi> {
-  /**
-   * The styles of the text component can be customized by redefining the following
-   * CSS variables:
-   *
-   * - `--a2ui-text-color-text`: The color of the text. Defaults to `--a2ui-color-on-background`.
-   * - `--a2ui-text-caption-color`: The color for caption text. Defaults to `light-dark(#666, #aaa)`.
-   *
-   * It also supports `--_a2ui-text-color` override from parent components (like Button).
-   */
   static override styles = css`
-    :host,
-    a2ui-basic-text {
+    :host {
+      display: contents;
+    }
+    .a2ui-text {
       display: inline-block;
       color: var(--_a2ui-text-color, var(--a2ui-text-color-text, var(--a2ui-color-on-background)));
     }
-    p,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    ol,
-    ul,
-    li,
-    blockquote,
-    pre {
-      margin: var(--_a2ui-text-margin, 0);
-    }
-    h1,
-    h2,
-    h3,
-    h4,
-    h5 {
+    .a2ui-text h1,
+    .a2ui-text h2,
+    .a2ui-text h3,
+    .a2ui-text h4,
+    .a2ui-text h5 {
+      font-weight: bold;
       font-family: var(--a2ui-font-family-title, inherit);
       line-height: var(--a2ui-line-height-headings, 1.2);
     }
-    h1 {
+    .a2ui-text h1 {
       font-size: var(--a2ui-font-size-2xl);
     }
-    h2 {
+    .a2ui-text h2 {
       font-size: var(--a2ui-font-size-xl);
     }
-    h3 {
+    .a2ui-text h3 {
       font-size: var(--a2ui-font-size-l);
     }
-    p,
-    h4 {
+    .a2ui-text p,
+    .a2ui-text h4 {
       font-size: var(--a2ui-font-size-m);
     }
-    h5 {
+    .a2ui-text h5 {
       font-size: var(--a2ui-font-size-s);
     }
-    p,
-    ol,
-    ul,
-    li,
-    blockquote,
-    .a2ui-caption {
+    .a2ui-text p {
       line-height: var(--a2ui-line-height-body, 1.5);
     }
-    .a2ui-caption,
-    .a2ui-caption > *,
-    .a2ui-caption ::slotted(*) {
+    .a2ui-text.caption,
+    .a2ui-caption {
       font-size: var(--a2ui-font-size-xs);
       color: var(--a2ui-text-caption-color, light-dark(#666, #aaa));
     }
-    a {
+    .a2ui-text a {
       color: var(--a2ui-text-a-color, inherit);
       font-weight: var(--a2ui-text-a-font-weight, inherit);
     }
   `;
 
-  // Retrieve a MarkdownRenderer provided by the application.
   @consume({context: Context.markdown, subscribe: true})
   accessor markdownRenderer: Types.MarkdownRenderer | undefined;
+
+  protected readonly api = TextApi;
 
   protected createController() {
     return new A2uiController(this, TextApi);
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
-    // Use props.variant to convert props.text to markdown
-    let markdownText = typeof props.text === 'string' ? props.text : String(props.text ?? '');
-    switch (props.variant) {
-      case 'h1':
-        markdownText = `# ${markdownText}`;
-        break;
-      case 'h2':
-        markdownText = `## ${markdownText}`;
-        break;
-      case 'h3':
-        markdownText = `### ${markdownText}`;
-        break;
-      case 'h4':
-        markdownText = `#### ${markdownText}`;
-        break;
-      case 'h5':
-        markdownText = `##### ${markdownText}`;
-        break;
-      default:
-        break; // body and caption.
+    const variant = props.variant || 'body';
+    const text = typeof props.text === 'string' ? props.text : String(props.text ?? '');
+    const flexStyle = typeof props.weight === 'number' ? `flex: ${props.weight};` : nothing;
+
+    if (NON_MARKDOWN_VARIANTS.has(variant)) {
+      let content = html`${text}`;
+      switch (variant) {
+        case 'h1':
+          content = html`<h1>${text}</h1>`;
+          break;
+        case 'h2':
+          content = html`<h2>${text}</h2>`;
+          break;
+        case 'h3':
+          content = html`<h3>${text}</h3>`;
+          break;
+        case 'h4':
+          content = html`<h4>${text}</h4>`;
+          break;
+        case 'h5':
+          content = html`<h5>${text}</h5>`;
+          break;
+        case 'caption':
+          content = html`<em>${text}</em>`;
+          break;
+      }
+      return html`<span class="a2ui-text ${variant}" style=${flexStyle}>${content}</span>`;
     }
 
-    const renderedMarkdown = markdown(markdownText, this.markdownRenderer);
-    // There's not a good way to handle the caption variant in markdown, so we
-    // tag it with a class so it can be tweaked via CSS.
-    if (props.variant === 'caption') {
-      return html`<span class="a2ui-caption">${renderedMarkdown}</span>`;
-    }
-    return html`${renderedMarkdown}`;
+    const renderedMarkdown = markdown(text, this.markdownRenderer);
+    return html`<span class="a2ui-text ${variant}" style=${flexStyle}>${renderedMarkdown}</span>`;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
@@ -27,6 +27,7 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
    * The styles of the text field can be customized by redefining the following
    * CSS variables:
    *
+   * - `--a2ui-textfield-width`: Width of the component. Defaults to `100%`.
    * - `--a2ui-textfield-border`: The styling for the text field border. Defaults to `--a2ui-border-width` width and `--a2ui-color-border` color.
    * - `--a2ui-textfield-border-radius`: The border radius of the text field. Defaults to `--a2ui-spacing-m`.
    * - `--a2ui-textfield-padding`: The padding of the text field. Defaults to `--a2ui-spacing-m`.
@@ -44,9 +45,12 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
     a2ui-basic-textfield {
       display: flex;
       flex-direction: column;
+      width: var(--a2ui-textfield-width, 100%);
       gap: var(--a2ui-spacing-xs, 0.25rem);
     }
     .a2ui-textfield {
+      box-sizing: border-box;
+      width: 100%;
       background-color: var(--a2ui-color-input, #fff);
       color: var(--a2ui-color-on-input, #333);
       border: var(--a2ui-textfield-border, var(--a2ui-border));
@@ -105,7 +109,7 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
             @input=${onInput}
           />`}
       ${isInvalid && props.validationErrors?.length
-        ? html`<div class="error">${props.validationErrors[0]}</div>`
+        ? props.validationErrors.map((err: string) => html`<div class="error">${err}</div>`)
         : nothing}
     `;
   }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
@@ -44,9 +44,12 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
     a2ui-basic-textfield {
       display: flex;
       flex-direction: column;
+      width: 100%;
       gap: var(--a2ui-spacing-xs, 0.25rem);
     }
     .a2ui-textfield {
+      box-sizing: border-box;
+      width: 100%;
       background-color: var(--a2ui-color-input, #fff);
       color: var(--a2ui-color-on-input, #333);
       border: var(--a2ui-textfield-border, var(--a2ui-border));
@@ -79,11 +82,21 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
     const isInvalid = props.isValid === false;
-    const onInput = (e: Event) => props.setValue?.((e.target as HTMLInputElement).value);
+    const onInput = (e: Event) => {
+      const val = (e.target as HTMLInputElement).value;
+      if (typeof props.setValue === 'function') {
+        props.setValue(val);
+      } else {
+        const rawVal = this.context?.componentModel?.properties['value'];
+        if (rawVal && typeof rawVal === 'object' && 'path' in rawVal) {
+          this.context.dataContext.set(rawVal.path, val);
+        }
+      }
+    };
     let type: 'text' | 'number' | 'password' = 'text';
     if (props.variant === 'number') type = 'number';
     if (props.variant === 'obscured') type = 'password';
@@ -105,7 +118,7 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
             @input=${onInput}
           />`}
       ${isInvalid && props.validationErrors?.length
-        ? html`<div class="error">${props.validationErrors[0]}</div>`
+        ? props.validationErrors.map((err: string) => html`<div class="error">${err}</div>`)
         : nothing}
     `;
   }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Video.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Video.ts
@@ -29,18 +29,19 @@ export class A2uiVideoElement extends BasicCatalogA2uiLitElement<typeof VideoApi
    * - `--a2ui-video-border-radius`: Controls the rounded corners of the video. Defaults to `0`.
    */
   static override styles = css`
-    :host,
-    a2ui-video {
-      display: block;
+    .a2ui-video-container {
       width: 100%;
+      max-width: 100%;
     }
-    video {
-      display: block;
+    .a2ui-video {
       width: 100%;
       height: auto;
+      display: block;
       border-radius: var(--a2ui-video-border-radius, 0);
     }
   `;
+
+  protected readonly api = VideoApi;
 
   protected createController() {
     return new A2uiController(this, VideoApi);
@@ -50,7 +51,13 @@ export class A2uiVideoElement extends BasicCatalogA2uiLitElement<typeof VideoApi
     const props = this.controller.props;
     if (!props) return nothing;
 
-    return html`<video src=${props.url} controls class="a2ui-video"></video>`;
+    return html`
+      <div class="a2ui-video-container">
+        <video src=${props.url || nothing} controls class="a2ui-video">
+          Your browser does not support the video tag.
+        </video>
+      </div>
+    `;
   }
 }
 

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Video.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Video.ts
@@ -22,35 +22,36 @@ import {A2uiController} from '../../../a2ui-controller.js';
 
 @customElement('a2ui-video')
 export class A2uiVideoElement extends BasicCatalogA2uiLitElement<typeof VideoApi> {
-  /**
-   * The styles of the video can be customized by redefining the following
-   * CSS variables:
-   *
-   * - `--a2ui-video-border-radius`: Controls the rounded corners of the video. Defaults to `0`.
-   */
   static override styles = css`
-    :host,
-    a2ui-video {
-      display: block;
+    .a2ui-video-container {
       width: 100%;
+      max-width: 100%;
     }
-    video {
-      display: block;
+    .a2ui-video {
       width: 100%;
       height: auto;
+      display: block;
       border-radius: var(--a2ui-video-border-radius, 0);
     }
   `;
+
+  protected readonly api = VideoApi;
 
   protected createController() {
     return new A2uiController(this, VideoApi);
   }
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
-    return html`<video src=${props.url} controls class="a2ui-video"></video>`;
+    return html`
+      <div class="a2ui-video-container">
+        <video src=${props.url || nothing} controls class="a2ui-video">
+          Your browser does not support the video tag.
+        </video>
+      </div>
+    `;
   }
 }
 

--- a/renderers/lit/src/v0_9/tests/components/Button.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Button.test.ts
@@ -78,6 +78,12 @@ describe('Button Component', () => {
               action: {event: {name: 'ignored'}},
             },
             {
+              id: 'btn_primary',
+              component: 'Button',
+              variant: 'primary',
+              child: 'txt1',
+            },
+            {
               id: 'txt1',
               component: 'Text',
               text: 'Click Me',
@@ -111,6 +117,7 @@ describe('Button Component', () => {
     const button = el.querySelector('button');
     assert.ok(button);
     assert.strictEqual(button.disabled, false);
+    assert.strictEqual(button.type, 'button');
 
     const dispatched = {action: null as A2uiClientAction | null};
     subscription = surface.onAction.subscribe((action: A2uiClientAction) => {
@@ -121,6 +128,21 @@ describe('Button Component', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     assert.ok(dispatched.action);
     assert.strictEqual(dispatched.action.name, 'submit_clicked');
+  });
+
+  it('should always render with type="button" even for primary variant', async () => {
+    const el = document.createElement('a2ui-basic-button') as A2uiBasicButtonElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'btn_primary');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const button = el.querySelector('button');
+    assert.ok(button);
+    assert.strictEqual(button.type, 'button');
   });
 
   it('should be disabled when isValid is false', async () => {

--- a/renderers/lit/src/v0_9/tests/components/ChoicePicker.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/ChoicePicker.test.ts
@@ -116,4 +116,106 @@ describe('ChoicePicker Component', () => {
 
     document.body.removeChild(el);
   });
+
+  it('ChoicePicker radio groups do not collide across surfaces', async () => {
+    // Component ids are only surface-scoped, so two surfaces may each
+    // contain a ChoicePicker with the same id. Radio names are
+    // document-scoped: if the group name is derived from the component id,
+    // both pickers merge into one radio group and fight over one selection.
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'second-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'second-surface',
+          components: [
+            {
+              id: 'choice_picker_filterable',
+              component: 'ChoicePicker',
+              label: 'Filter me',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: [],
+            },
+          ],
+        },
+      },
+    ]);
+    const secondSurface = processor.model.getSurface('second-surface')!;
+
+    const firstEl = document.createElement('a2ui-choicepicker') as any;
+    const secondEl = document.createElement('a2ui-choicepicker') as any;
+    document.body.appendChild(firstEl);
+    document.body.appendChild(secondEl);
+
+    const firstContext = new ComponentContext(surface, 'choice_picker_filterable');
+    const secondContext = new ComponentContext(secondSurface, 'choice_picker_filterable');
+
+    await asyncUpdate(firstEl, e => {
+      e.context = firstContext;
+    });
+    await asyncUpdate(secondEl, e => {
+      e.context = secondContext;
+    });
+
+    const getGroupNames = (el: HTMLElement) =>
+      new Set(
+        Array.from(el.querySelectorAll<HTMLInputElement>('input[type="radio"]')).map(
+          input => input.name,
+        ),
+      );
+
+    const firstNames = getGroupNames(firstEl);
+    const secondNames = getGroupNames(secondEl);
+
+    assert.strictEqual(firstNames.size, 1);
+    assert.strictEqual(secondNames.size, 1);
+    assert.notStrictEqual([...firstNames][0], [...secondNames][0]);
+
+    document.body.removeChild(firstEl);
+    document.body.removeChild(secondEl);
+  });
+
+  it('should not set a name on checkbox inputs', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'choice_picker_multi',
+              component: 'ChoicePicker',
+              label: 'Multi pick',
+              options: [{label: 'Option 1', value: 'opt1'}],
+              value: [],
+              variant: 'multipleSelection',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-choicepicker') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'choice_picker_multi');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const checkbox = el.querySelector('input[type="checkbox"]');
+    assert.ok(checkbox);
+    assert.strictEqual(checkbox.hasAttribute('name'), false);
+
+    document.body.removeChild(el);
+  });
 });

--- a/renderers/lit/src/v0_9/tests/components/Text.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Text.test.ts
@@ -136,10 +136,10 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const captionSpan = el.querySelector('span.a2ui-caption');
+    const captionSpan = el.querySelector('span.a2ui-text.caption');
     assert.ok(captionSpan);
-    const innerSpan = captionSpan.querySelector('.no-markdown-renderer');
-    assert.ok(innerSpan);
-    assert.strictEqual(innerSpan.textContent?.trim(), 'Caption text');
+    const em = captionSpan.querySelector('em');
+    assert.ok(em);
+    assert.strictEqual(em.textContent?.trim(), 'Caption text');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/Text.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Text.test.ts
@@ -136,10 +136,10 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const captionSpan = el.querySelector('span.a2ui-caption');
+    const captionSpan = el.querySelector('span.a2ui-text.caption, span.a2ui-caption');
     assert.ok(captionSpan);
-    const innerSpan = captionSpan.querySelector('.no-markdown-renderer');
-    assert.ok(innerSpan);
-    assert.strictEqual(innerSpan.textContent?.trim(), 'Caption text');
+    const em = captionSpan.querySelector('em');
+    assert.ok(em);
+    assert.strictEqual(em.textContent?.trim(), 'Caption text');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/TextField.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/TextField.test.ts
@@ -78,7 +78,7 @@ describe('TextField Component', () => {
               label: 'Email',
               value: '',
               isValid: false,
-              validationErrors: ['Email is invalid'],
+              validationErrors: ['Email is required', 'Email must contain @'],
             },
           ],
         },
@@ -153,7 +153,7 @@ describe('TextField Component', () => {
     assert.strictEqual(input, null);
   });
 
-  it('should render validation error message when invalid', async () => {
+  it('should render all validation error messages when invalid', async () => {
     const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
     element = el;
     document.body.appendChild(el);
@@ -163,9 +163,10 @@ describe('TextField Component', () => {
       e.context = context;
     });
 
-    const error = el.querySelector('.error');
-    assert.ok(error);
-    assert.strictEqual(error.textContent?.trim(), 'Email is invalid');
+    const errors = el.querySelectorAll('.error');
+    assert.strictEqual(errors.length, 2);
+    assert.strictEqual(errors[0].textContent?.trim(), 'Email is required');
+    assert.strictEqual(errors[1].textContent?.trim(), 'Email must contain @');
 
     const input = el.querySelector('input');
     assert.ok(input);


### PR DESCRIPTION
## Overview

Aligns the `@a2ui/lit` Basic Catalog component implementations, styling contracts, and lifecycle behaviors with the `@a2ui/angular` reference implementation.

## Motivation & Architectural Rationale

This PR is a foundational step in our cross-framework rendering architecture:

1. **Prerequisite for Universal Components (`@a2ui/web_core`)**:
   In the subsequent PRs of this stack, the Basic Catalog implementations are extracted into unified, universal Web Components hosted in `@a2ui/web_core` and shared directly across `@a2ui/lit`, `@a2ui/angular`, and upcoming renderers (such as React). To ensure this migration produces zero behavioral drift or visual regressions, all renderers must first converge on a canonical DOM structure, CSS variable contract, and event model.

2. **Adopting the Canonical Reference Behaviors & Performance Enhancements**:
   - **Stable List Reconciliation (`Row`, `Column`, `List`)**: Uses Lit's `repeat` directive keyed by `child.basePath/child.id` to preserve DOM element identity and form input state across list reorders, insertions, and deletions.
   - **Comprehensive Form Validation & State Fallback (`TextField`)**: Renders all accumulated validation errors from `validationErrors` instead of only the first error, ensures full-width container styling (`width: 100%`, `box-sizing: border-box`), and provides a direct `dataContext.set` mutation fallback.
   - **Cross-Platform Layout Distribution (`Column`, `Row`)**: Adds `width: 100%` container styling, explicit gap fallbacks (`16px`), and `baseline` flex alignment mapping.
   - **Dynamic Tab Safety (`Tabs`)**: Implements `activeIndex` bounds clamping in `willUpdate()` so dynamic removals from `tabs` do not leave the component in an out-of-bounds state rendering `nothing`.
   - **Fast-Path Text Rendering (`Text`)**: Renders semantic HTML tags directly (`<h1>`–`<h5>`, `<em>`) for non-markdown variants (`h1`-`h5`, `caption`), wraps text with `:host { display: contents; }`, and adds flex weight styling.
   - **Media Sizing & Accessibility (`Image`, `Video`)**: Preserves intrinsic aspect ratios on `Image` and wraps `Video` in `.a2ui-video-container` with fallback accessibility messaging.
   - **Consistent Dialog Lifecycle & Styling (`Modal`)**: Adopts explicit `@state() isOpen` state tracking and standard overlay styling tokens.
   - **Light DOM Radio Scoping, Checkbox Cleanup & DOM Alignment (`ChoicePicker`)**: Aligns DOM structures and CSS classes with the Angular reference implementation (`.a2ui-choice-picker`, `.a2ui-option-label`, `.a2ui-option-text`, `.a2ui-chip`, `type="button"`), scopes radio input `name` attributes to surface and data context path to prevent cross-surface radio collisions in Light DOM, and omits `name` attributes on checkbox inputs.

## Changes Made

- **`Row`, `Column`, `List`**: Switched from `map()` to `repeat()` directive for key-tracked DOM node preservation; added `baseline` alignment and container gap variable fallbacks.
- **`Tabs`**: Added `activeIndex` bounds clamping in `willUpdate()` and updated tab bar class styling.
- **`Text`**: Added `NON_MARKDOWN_VARIANTS` fast-path rendering for header/caption variants, `:host { display: contents; }`, and `props.weight` flex styling.
- **`TextField`**: Renders all errors in `props.validationErrors`, adds input fallback to `dataContext.set`, and standardizes sizing.
- **`Video`**: Wrapped in `.a2ui-video-container` with fallback message for unsupported browsers.
- **`Image`**: Removed `width: 100%` default constraint to allow intrinsic sizing.
- **`Modal`**: Migrated to overlay hierarchy with explicit `@state() isOpen` tracking.
- **`ChoicePicker`**: Aligned DOM structures and CSS classes with the Angular reference implementation (`.a2ui-choice-picker`, `.a2ui-option-label`, `.a2ui-option-text`, `.a2ui-chip`, `type="button"`), scoped radio input `name` attributes to `a2ui-choice-${surfaceId}-${componentId}-${sanitizedPath}` to prevent collisions across surfaces in Light DOM, and omitted `name` attributes on checkboxes via `nothing`.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].
- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples

Related to #1270