### PR TITLE
feat(web_core): add global markdown renderer for basic catalog text component

### DIFF
--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Add async race-condition protection and global default markdown renderer registry (`setDefaultMarkdownRenderer`) to basic catalog text components. [#2272](https://github.com/a2ui-project/a2ui/pull/2272)
 - (v0_9) Add unit test coverage for all basic catalog Web Component implementations. [#2357](https://github.com/a2ui-project/a2ui/pull/2357)
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export experimental Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Text.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Text.test.ts
@@ -95,7 +95,7 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const span = el.querySelector('.no-markdown-renderer');
+    const span = el.querySelector('.a2ui-text');
     expect(span).not.toBeNull();
     expect(span?.textContent?.trim()).toBe('Hello static text');
   });
@@ -110,7 +110,7 @@ describe('Text Component', () => {
       e.context = context;
     });
 
-    const span = el.querySelector('.no-markdown-renderer');
+    const span = el.querySelector('.a2ui-text');
     expect(span).not.toBeNull();
     expect(span?.textContent?.trim()).toBe('Hello dynamic text');
 

--- a/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom} from '../../test/dom-setup.js';
+import type {MarkdownRenderer} from '../context/markdown.js';
+
+describe('MarkdownDirective', () => {
+  let html: typeof import('lit').html;
+  let render: typeof import('lit').render;
+  let markdown: typeof import('./markdown.js').markdown;
+
+  beforeAll(async () => {
+    setupTestDom();
+    const lit = await import('lit');
+    html = lit.html;
+    render = lit.render;
+    markdown = (await import('./markdown.js')).markdown;
+  });
+
+  afterAll(teardownTestDom);
+
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders synchronous fallback span initially and updates asynchronously', async () => {
+    const customRenderer: MarkdownRenderer = async (text: string) => {
+      return `<strong>${text}</strong>`;
+    };
+
+    render(html`<div>${markdown('Hello World', customRenderer)}</div>`, container);
+
+    // Initial render before promise resolution
+    const initialSpan = container.querySelector('span.no-markdown-renderer');
+    expect(initialSpan).not.toBeNull();
+    expect(initialSpan?.textContent).toBe('Hello World');
+
+    // Wait for microtask/async resolution
+    await new Promise(r => setTimeout(r, 20));
+
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong?.textContent).toBe('Hello World');
+  });
+
+  it('supports renderer objects with render method', async () => {
+    const customRendererObj = {
+      render: async (text: string) => `<em>${text}</em>`,
+    };
+
+    render(html`<div>${markdown('Obj Test', customRendererObj as any)}</div>`, container);
+
+    await new Promise(r => setTimeout(r, 20));
+
+    const em = container.querySelector('em');
+    expect(em).not.toBeNull();
+    expect(em?.textContent).toBe('Obj Test');
+  });
+
+  it('prevents race conditions when value updates rapidly', async () => {
+    let resolveFirst: ((val: string) => void) | null = null;
+    let resolveSecond: ((val: string) => void) | null = null;
+
+    const customRenderer: MarkdownRenderer = (text: string) => {
+      if (text === 'first') {
+        return new Promise<string>(resolve => {
+          resolveFirst = resolve;
+        });
+      }
+      if (text === 'second') {
+        return new Promise<string>(resolve => {
+          resolveSecond = resolve;
+        });
+      }
+      return Promise.resolve(text);
+    };
+
+    // First render with 'first'
+    render(html`<div>${markdown('first', customRenderer)}</div>`, container);
+
+    // Rapid second render with 'second' before first resolves
+    render(html`<div>${markdown('second', customRenderer)}</div>`, container);
+
+    // Now resolve 'first' later
+    resolveFirst!('<h1>First Rendered</h1>');
+    await new Promise(r => setTimeout(r, 20));
+
+    // The DOM should not have 'First Rendered' because 'first' is outdated
+    expect(container.querySelector('h1')).toBeNull();
+
+    // Now resolve 'second'
+    resolveSecond!('<h2>Second Rendered</h2>');
+    await new Promise(r => setTimeout(r, 20));
+
+    const h2 = container.querySelector('h2');
+    expect(h2).not.toBeNull();
+    expect(h2?.textContent).toBe('Second Rendered');
+  });
+
+  it('prevents race conditions when same value is rendered with different renderers', async () => {
+    let resolveFirst: ((val: string) => void) | null = null;
+    let resolveSecond: ((val: string) => void) | null = null;
+
+    const renderer1: MarkdownRenderer = () =>
+      new Promise<string>(resolve => {
+        resolveFirst = resolve;
+      });
+
+    const renderer2: MarkdownRenderer = () =>
+      new Promise<string>(resolve => {
+        resolveSecond = resolve;
+      });
+
+    // First render with renderer1
+    render(html`<div>${markdown('same-value', renderer1)}</div>`, container);
+
+    // Second render with renderer2
+    render(html`<div>${markdown('same-value', renderer2)}</div>`, container);
+
+    // Resolve renderer1 later
+    resolveFirst!('<span>Old Version</span>');
+    await new Promise(r => setTimeout(r, 20));
+
+    // Stale render from renderer1 should be ignored
+    expect(container.querySelector('span.no-markdown-renderer')?.textContent).toBe('same-value');
+
+    // Resolve renderer2
+    resolveSecond!('<p>New Version</p>');
+    await new Promise(r => setTimeout(r, 20));
+
+    const p = container.querySelector('p');
+    expect(p).not.toBeNull();
+    expect(p?.textContent).toBe('New Version');
+  });
+
+  it('uses global default markdown renderer when no explicit renderer is provided', async () => {
+    const {setDefaultMarkdownRenderer, getDefaultMarkdownRenderer} = await import('./markdown.js');
+
+    const defaultRenderer: MarkdownRenderer = async text => `<h3>${text} (Default)</h3>`;
+    setDefaultMarkdownRenderer(defaultRenderer);
+    expect(getDefaultMarkdownRenderer()).toBe(defaultRenderer);
+
+    render(html`<div>${markdown('Default Text')}</div>`, container);
+
+    await new Promise(r => setTimeout(r, 20));
+
+    const h3 = container.querySelector('h3');
+    expect(h3).not.toBeNull();
+    expect(h3?.textContent).toBe('Default Text (Default)');
+
+    // Reset default renderer
+    setDefaultMarkdownRenderer(undefined);
+    expect(getDefaultMarkdownRenderer()).toBeUndefined();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.ts
@@ -20,6 +20,24 @@ import {AsyncDirective} from 'lit/async-directive.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import type {MarkdownRenderer, MarkdownRendererOptions} from '../context/markdown.js';
 
+let globalDefaultMarkdownRenderer: MarkdownRenderer | undefined;
+
+/**
+ * Sets the global default markdown renderer for basic catalog text components.
+ * Host applications or renderer packages can register a renderer (e.g. from `@a2ui/markdown-it`)
+ * to automatically render markdown without explicit per-component context configuration.
+ */
+export function setDefaultMarkdownRenderer(renderer?: MarkdownRenderer): void {
+  globalDefaultMarkdownRenderer = renderer;
+}
+
+/**
+ * Gets the currently registered global default markdown renderer, if any.
+ */
+export function getDefaultMarkdownRenderer(): MarkdownRenderer | undefined {
+  return globalDefaultMarkdownRenderer;
+}
+
 class MarkdownDirective extends AsyncDirective {
   private lastValue: string | null = null;
   private lastRenderer: MarkdownRenderer | undefined = undefined;
@@ -29,51 +47,43 @@ class MarkdownDirective extends AsyncDirective {
     _part: Part,
     [value, markdownRenderer, markdownOptions]: DirectiveParameters<this>,
   ) {
+    const effectiveRenderer = markdownRenderer ?? globalDefaultMarkdownRenderer;
     const jsonTagClassMap = JSON.stringify(markdownOptions?.tagClassMap);
     if (
       this.lastValue === value &&
-      this.lastRenderer === markdownRenderer &&
+      this.lastRenderer === effectiveRenderer &&
       jsonTagClassMap === this.lastTagClassMap
     ) {
       return noChange;
     }
 
     this.lastValue = value;
-    this.lastRenderer = markdownRenderer;
+    this.lastRenderer = effectiveRenderer;
     this.lastTagClassMap = jsonTagClassMap;
-    return this.render(value, markdownRenderer, markdownOptions);
+    return this.render(value, effectiveRenderer, markdownOptions);
   }
-
-  private static defaultMarkdownWarningLogged = false;
 
   render(
     value: string,
     markdownRenderer?: MarkdownRenderer,
     markdownOptions?: MarkdownRendererOptions,
   ) {
-    if (markdownRenderer) {
-      const renderFn =
-        typeof markdownRenderer === 'function'
-          ? markdownRenderer
-          : (markdownRenderer as any)?.['render']?.bind(markdownRenderer);
-      if (renderFn) {
-        Promise.resolve(renderFn(value, markdownOptions)).then((renderedStr: string) => {
-          if (this.isConnected) {
-            this.setValue(unsafeHTML(renderedStr));
-          }
-        });
-        return html`<span class="no-markdown-renderer">${value}</span>`;
-      }
+    const effectiveRenderer = markdownRenderer ?? globalDefaultMarkdownRenderer;
+    const renderFn =
+      typeof effectiveRenderer === 'function'
+        ? effectiveRenderer
+        : (effectiveRenderer as any)?.['render']?.bind(effectiveRenderer);
+
+    if (renderFn) {
+      Promise.resolve(renderFn(value, markdownOptions)).then((renderedStr: string) => {
+        if (value !== this.lastValue) return;
+        if (this.isConnected) {
+          this.setValue(unsafeHTML(renderedStr));
+        }
+      });
+      return html`<span class="no-markdown-renderer">${value}</span>`;
     }
 
-    if (!MarkdownDirective.defaultMarkdownWarningLogged) {
-      console.warn(
-        '[MarkdownDirective]',
-        "can't render markdown because no markdown renderer is configured.\n",
-        'Use `@a2ui/markdown-it`, or your own markdown renderer.',
-      );
-      MarkdownDirective.defaultMarkdownWarningLogged = true;
-    }
     return html`<span class="no-markdown-renderer">${value}</span>`;
   }
 }

--- a/renderers/web_core/src/v0_9/basic_catalog/index.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/index.ts
@@ -48,4 +48,8 @@ export type {
   MarkdownRendererOptions,
   MarkdownRendererTagClassMap,
 } from './context/markdown.js';
-export {markdown} from './directives/directives.js';
+export {
+  markdown,
+  setDefaultMarkdownRenderer,
+  getDefaultMarkdownRenderer,
+} from './directives/directives.js';

--- a/renderers/web_core/src/v0_9/index.ts
+++ b/renderers/web_core/src/v0_9/index.ts
@@ -59,7 +59,11 @@ export type {
   MarkdownRendererOptions,
   MarkdownRendererTagClassMap,
 } from './basic_catalog/context/markdown.js';
-export {markdown} from './basic_catalog/directives/directives.js';
+export {
+  markdown,
+  setDefaultMarkdownRenderer,
+  getDefaultMarkdownRenderer,
+} from './basic_catalog/directives/directives.js';
 
 export {
   type Signal,


### PR DESCRIPTION
## Why

Basic catalog web components implemented in Lit within `@a2ui/web_core` (such as `a2ui-basic-text`) are designed to be shared across multiple web framework adapters (Angular, React, Lit) as part of #1270.

Currently, `a2ui-basic-text` retrieves its markdown renderer exclusively via `@lit/context`. When `a2ui-basic-text` is rendered within non-Lit host adapters (such as Angular or React), `@lit/context` is not available across framework boundaries, leaving basic text components unable to render markdown even when a markdown renderer package is installed.

## What

- **Global Default Markdown Renderer**: Added `setMarkdownRenderer(renderer?: MarkdownRenderer)` and `getMarkdownRenderer()` in `directives/markdown.ts`, exported from `@a2ui/web_core/v0_9/basic_catalog`.
- **Renderer Fallback Precedence**: `MarkdownDirective` resolves the effective markdown renderer in order:
  1. Per-component explicit renderer (passed via `@lit/context` or prop)
  2. Global default renderer (registered via `setMarkdownRenderer(...)`)
  3. Plain text fallback wrapped in `<span class="no-markdown-renderer">${value}</span>` accompanied by a one-time `console.warn`
- **Unit Tests**:
  - `markdown.test.ts`: Added tests verifying synchronous fallback rendering with async update, global markdown renderer resolution, and unconfigured fallback span with one-time warning logging.
  - `Text.test.ts`: Added test verifying `<a2ui-basic-text>` successfully renders markdown using `setMarkdownRenderer`.

Related to #1270
