### PR TITLE
fix(docs): correct invalid allOf catalog composition examples (#2219)

### DIFF
--- a/docs/public/concepts/catalogs.md
+++ b/docs/public/concepts/catalogs.md
@@ -150,9 +150,13 @@ A2UI Catalogs must be standalone (no references to external files) to simplify L
 
 While the final catalog must be freestanding, you may still author your catalogs modularly using JSON Schema `$ref` pointing to external documents during local development.
 
-To automate bundling and registering these external file references, this catalog registration process is called **"Linking"** and is consolidated under a single, multi-platform Node.js script (**`register-catalogs.js`**).
+To automate bundling and registering these external file references, this catalog registration process is called **"Linking"** and is performed by [`tools/build_catalog/assemble_catalog.py`](https://github.com/a2ui-project/a2ui/blob/main/tools/build_catalog/README.md). It resolves local and remote `$ref`s, merges multiple input catalogs, and emits a single freestanding catalog:
 
-This linking script is natively wrapped inside **Xcode Build Phases** (for iOS/macOS client builds) and **Gradle tasks** (for Android client builds) to compile, aggregate, and link static and dynamic schemas seamlessly during your application's build phase.
+```bash
+uv run tools/build_catalog/assemble_catalog.py <INPUTS ...> --output-name <OUTPUT_NAME>
+```
+
+Run this step as part of your application's build (for example, from an **Xcode Build Phase** for iOS/macOS clients or a **Gradle task** for Android clients) so that the catalog you ship is always fully linked.
 
 ### Composition & Imports
 
@@ -160,62 +164,67 @@ You do not have to define everything from scratch. You can define a catalog whic
 
 #### Example: Extending the Basic Catalog
 
-This catalog imports all elements from the Basic Catalog and adds a new `SuggestionChips` component.
+`components` is a map of component name to component schema, so a catalog cannot import another catalog's entire `components` map inline. Instead, declare only the components you add, and pull in the whole Basic Catalog at link time with `--extend-basic-catalog`.
 
 ```json
 {
   "$id": "https://github.com/.../hello_world_with_all_basic/v1/catalog.json",
   "catalogId": "https://github.com/.../hello_world_with_all_basic/v1/catalog.json",
   "components": {
-    "allOf": [
-      {"$ref": "basic_catalog_definition.json#/components"},
-      {
-        "SuggestionChips": {
-          "type": "object",
-          "description": "A list of suggested prompts",
-          "properties": {
-            "suggestions": {
-              "type": "array",
-              "description": "The suggested prompts."
-            }
-          },
-          "required": ["suggestions"]
+    "SuggestionChips": {
+      "type": "object",
+      "description": "A list of suggested prompts",
+      "properties": {
+        "suggestions": {
+          "type": "array",
+          "description": "The suggested prompts."
         }
-      }
-    ]
+      },
+      "required": ["suggestions"]
+    }
   }
 }
 ```
 
-**Make sure to link and resolve external references during compilation using your platform's Xcode Build Phase or Gradle task (running `register-catalogs.js`).**
+Link it with:
+
+```bash
+uv run tools/build_catalog/assemble_catalog.py hello_world_with_all_basic.json \
+  --output-name hello_world_with_all_basic --extend-basic-catalog
+```
+
+The assembled catalog contains every Basic Catalog component plus `SuggestionChips`.
 
 #### Example: Cherry-picking Components
 
-This catalog imports only `Text` from the Basic Catalog to build a simple Popup surface.
+To import individual components, add a `$ref` under the component's own name in the `components` map. This catalog imports only `Text` from the Basic Catalog to build a simple Popup surface.
 
 ```json
 {
   "$id": "https://github.com/.../hello_world_with_some_basic/v1/catalog.json",
   "catalogId": "https://github.com/.../hello_world_with_some_basic/v1/catalog.json",
   "components": {
-    "allOf": [
-      {"$ref": "catalogs/basic/catalog.json#/components/Text"},
-      {
-        "Popup": {
-          "type": "object",
-          "description": "A modal overlay that displays an icon and text.",
-          "properties": {
-            "text": {"$ref": "common_types.json#/$defs/ComponentId"}
-          },
-          "required": ["text"]
-        }
-      }
-    ]
+    "Text": {"$ref": "basic_catalog.json#/components/Text"},
+    "Popup": {
+      "type": "object",
+      "description": "A modal overlay that displays an icon and text.",
+      "properties": {
+        "text": {"$ref": "common_types.json#/$defs/ComponentId"}
+      },
+      "required": ["text"]
+    }
   }
 }
 ```
 
-**Make sure to link and resolve external references during compilation using your platform's Xcode Build Phase or Gradle task (running `register-catalogs.js`).**
+Link it with:
+
+```bash
+uv run tools/build_catalog/assemble_catalog.py hello_world_with_some_basic.json \
+  --output-name hello_world_with_some_basic
+```
+
+The assembled catalog contains `Text` and `Popup`, with the referenced schemas inlined under `$defs`.
 
 ### Implementing Renderers
 

--- a/tools/build_catalog/README.md
+++ b/tools/build_catalog/README.md
@@ -84,24 +84,21 @@ uv run tools/build_catalog/assemble_catalog.py my_catalog.json --output-name ext
 ```json
 {
   "$id": "sample_popup_catalog",
+  "catalogId": "sample_popup_catalog",
   "components": {
-    "allOf": [
-      {
-        "$ref": "basic_catalog.json#/components/Text"
-      },
-      {
-        "Popup": {
-          "type": "object",
-          "description": "A modal overlay that displays an icon and text.",
-          "properties": {
-            "text": {
-              "$ref": "common_types.json#/$defs/ComponentId"
-            }
-          },
-          "required": ["text"]
+    "Text": {
+      "$ref": "basic_catalog.json#/components/Text"
+    },
+    "Popup": {
+      "type": "object",
+      "description": "A modal overlay that displays an icon and text.",
+      "properties": {
+        "text": {
+          "$ref": "common_types.json#/$defs/ComponentId"
         }
-      }
-    ]
+      },
+      "required": ["text"]
+    }
   }
 }
 ```


### PR DESCRIPTION
Fixes #2219

## Problem

`docs/public/concepts/catalogs.md` documents catalog composition with an `allOf` array placed directly under `components`:

```json
"components": {
  "allOf": [
    {"$ref": "basic_catalog_definition.json#/components"},
    {"SuggestionChips": { ... }}
  ]
}
```

Per `specification/v1_0/json/catalog_definition.json`, `components` is an object whose `additionalProperties` must each be a `ComponentDefinition` (a JSON Schema). `allOf` is therefore read as a *component named `allOf`* whose schema is an array — which is not a valid schema.

This is not just cosmetically wrong. Running the documented input through the repo's own linker, `tools/build_catalog/assemble_catalog.py`, produces a broken catalog:

```
components keys: ['allOf']
$defs.anyComponent: {"oneOf": [{"$ref": "#/components/allOf"}], "discriminator": {"propertyName": "component"}}
```

Neither `Text` nor `Popup` survives. The assembler's `_merge_categories` copies `source["components"]` keys verbatim, so `allOf` becomes the only "component" in the output and `anyComponent` points at an array.

Two secondary issues in the same examples:

1. The cherry-picking example referenced `catalogs/basic/catalog.json#/components/Text`. `_process_ref` special-cases any ref whose filename is `catalog.json` and rewrites it to the assembled catalog root, so this collapses to a self-referential `{"$ref": "#/components/Text"}` instead of importing the Basic Catalog's `Text`. Verified:

   ```
   components.Text -> {"$ref": "#/components/Text"}
   ```

   The name the assembler actually intercepts is `basic_catalog.json` (see `INTERCEPT_MAP`).

2. The surrounding "Catalog Linking" section pointed readers at a Node.js script, `register-catalogs.js`, wrapped in Xcode Build Phases / Gradle tasks. That script does not exist anywhere in the repository — `register-catalogs` appears only in this one doc file. The tool that actually performs linking is `tools/build_catalog/assemble_catalog.py`.

## Changes

**`docs/public/concepts/catalogs.md`**

- Rewrote both composition examples to use valid `components` syntax.
  - *Extending the Basic Catalog*: a catalog cannot inline another catalog's whole `components` map, so the example now declares only the new component and pulls in the Basic Catalog at link time via `--extend-basic-catalog`.
  - *Cherry-picking Components*: imports are now `$ref`s keyed under each component's own name, and the ref target is `basic_catalog.json#/components/Text`.
- Added the concrete `assemble_catalog.py` invocation under each example, replacing the `register-catalogs.js` instruction lines.
- Updated the "Catalog Linking" section to name the real tool. The Xcode Build Phase / Gradle task guidance is kept as advice on *where* to run the linking step, rather than a claim that a wrapper ships today.

**`tools/build_catalog/README.md`**

- The tool's own README carried the identical invalid `allOf`-under-`components` example. Corrected it to the same valid form and added the required `catalogId`.

## Verification

Both corrected forms were run through `assemble_catalog.py`:

```
$ uv run tools/build_catalog/assemble_catalog.py hello_world_with_some_basic.json \
    --output-name hello_world_with_some_basic
components: ['Text', 'Popup']
anyComponent: {"oneOf": [{"$ref": "#/components/Popup"}, {"$ref": "#/components/Text"}], ...}
$defs: [... 'basic_catalog_Text', 'common_types_ComponentId', 'theme']
```

```
$ uv run tools/build_catalog/assemble_catalog.py hello_world_with_all_basic.json \
    --output-name hello_world_with_all_basic --extend-basic-catalog
components: ['Text', 'Image', 'Icon', 'Video', 'AudioPlayer', 'Row', 'Column', 'List',
             'Card', 'Tabs', 'Modal', 'Divider', 'Button', 'TextField', 'CheckBox',
             'ChoicePicker', 'Slider', 'DateTimeInput', 'SuggestionChips']
```

The corrected examples also validate against the `components` shape defined in `specification/v1_0/json/catalog_definition.json`, while the previous ones do not.

`npx prettier --check` passes on both edited files.

## Note for reviewers

Item 2 above (`register-catalogs.js` → `assemble_catalog.py`) is adjacent to the filed issue. I included it because those instruction lines are attached directly to the two examples being fixed, and leaving them would have pointed readers at a nonexistent tool for making the corrected examples work. Happy to split it into a separate PR if you'd prefer to keep this one strictly scoped.
