### PR TITLE
feat(lit): add native lit container component sample to explorer

### DIFF
--- a/renderers/lit/a2ui_explorer/src/custom-grid.ts
+++ b/renderers/lit/a2ui_explorer/src/custom-grid.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html, css, nothing} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {z} from 'zod';
+import {A2uiLitElement} from '@a2ui/lit/v0_9';
+import {
+  ComponentApi,
+  DynamicStringSchema,
+  ChildListSchema,
+  WebComponentImplementation,
+} from '@a2ui/web_core/v0_9';
+
+export const customGridApi = {
+  name: 'CustomGrid',
+  schema: z.object({
+    title: DynamicStringSchema.optional(),
+    description: DynamicStringSchema.optional(),
+    children: ChildListSchema.optional(),
+  }),
+} satisfies ComponentApi;
+
+/**
+ * A custom container component written in Lit.
+ * Demonstrates a 2x2 grid layout capable of instantiating up to four child
+ * components (either native custom components or universal web components).
+ */
+@customElement('a2ui-custom-grid')
+export class CustomGridElement extends A2uiLitElement<typeof customGridApi> {
+  static override styles = css`
+    .custom-grid-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 16px;
+      border: 2px dashed #4f46e5;
+      border-radius: 12px;
+      background-color: #f8fafc;
+      color: #1e293b;
+      box-sizing: border-box;
+      width: 100%;
+    }
+
+    .grid-header {
+      border-bottom: 1px solid #e2e8f0;
+      padding-bottom: 8px;
+    }
+
+    .grid-title {
+      margin: 0;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #312e81;
+    }
+
+    .grid-description {
+      margin: 4px 0 0;
+      font-size: 0.85rem;
+      color: #64748b;
+    }
+
+    .custom-grid-container {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: repeat(2, 1fr);
+      gap: 16px;
+      min-height: 240px;
+    }
+
+    @media (max-width: 600px) {
+      .custom-grid-container {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+      }
+    }
+
+    .grid-cell {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      background-color: #ffffff;
+      padding: 12px;
+      min-height: 100px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    }
+
+    .grid-cell.empty-cell {
+      border-style: dashed;
+      background-color: #f1f5f9;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .cell-badge {
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6366f1;
+      margin-bottom: 8px;
+    }
+
+    .cell-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .empty-placeholder {
+      color: #94a3b8;
+      font-size: 0.8rem;
+      font-style: italic;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .custom-grid-wrapper {
+        background-color: #1e293b;
+        color: #f8fafc;
+        border-color: #818cf8;
+      }
+
+      .grid-header {
+        border-bottom-color: #334155;
+      }
+
+      .grid-title {
+        color: #c7d2fe;
+      }
+
+      .grid-description {
+        color: #cbd5e1;
+      }
+
+      .grid-cell {
+        background-color: #0f172a;
+        border-color: #475569;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+      }
+
+      .grid-cell.empty-cell {
+        background-color: #1e293b;
+      }
+
+      .cell-badge {
+        color: #a5b4fc;
+      }
+    }
+  `;
+
+  protected readonly api = customGridApi;
+
+  override render() {
+    const props = this.controller?.props;
+    if (!props) return nothing;
+
+    const title = props.title;
+    const description = props.description;
+    const children = (props.children ?? []) as string[];
+    const slots = [
+      children[0] ?? null,
+      children[1] ?? null,
+      children[2] ?? null,
+      children[3] ?? null,
+    ];
+
+    return html`
+      <div class="custom-grid-wrapper">
+        ${title
+          ? html`
+              <div class="grid-header">
+                <h3 class="grid-title">${title}</h3>
+                ${description ? html`<p class="grid-description">${description}</p>` : nothing}
+              </div>
+            `
+          : nothing}
+        <div class="custom-grid-container">
+          ${slots.map(
+            (child, index) => html`
+              <div class="grid-cell ${child ? 'has-content' : 'empty-cell'}">
+                <div class="cell-badge">Slot ${index + 1}</div>
+                ${child
+                  ? html` <div class="cell-content">${this.renderNode(child)}</div> `
+                  : html`
+                      <div class="empty-placeholder">
+                        <span>Empty child</span>
+                      </div>
+                    `}
+              </div>
+            `,
+          )}
+        </div>
+      </div>
+    `;
+  }
+}
+
+export const customGridComponent: WebComponentImplementation<typeof customGridApi.schema> = {
+  name: customGridApi.name,
+  tagName: 'a2ui-custom-grid',
+  schema: customGridApi.schema,
+};

--- a/renderers/lit/a2ui_explorer/src/custom-slider.ts
+++ b/renderers/lit/a2ui_explorer/src/custom-slider.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html, css, nothing} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {z} from 'zod';
+import {A2uiLitElement} from '@a2ui/lit/v0_9';
+import {
+  ComponentApi,
+  DynamicStringSchema,
+  DynamicNumberSchema,
+  WebComponentImplementation,
+} from '@a2ui/web_core/v0_9';
+
+export const customSliderApi = {
+  name: 'CustomSlider',
+  schema: z.object({
+    label: DynamicStringSchema.optional(),
+    value: DynamicNumberSchema.optional(),
+    min: DynamicNumberSchema.optional(),
+    max: DynamicNumberSchema.optional(),
+  }),
+} satisfies ComponentApi;
+
+/**
+ * A custom component demonstrating external component registration in Lit.
+ */
+@customElement('a2ui-custom-slider')
+export class CustomSliderComponent extends A2uiLitElement<typeof customSliderApi> {
+  static override styles = css`
+    .custom-slider-container {
+      padding: 10px;
+      border: 1px dashed #3b82f6;
+      border-radius: 6px;
+      background: rgba(59, 130, 246, 0.05);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    label {
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: #3b82f6;
+    }
+    input[type='range'] {
+      width: 100%;
+      cursor: pointer;
+    }
+  `;
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  protected readonly api = customSliderApi;
+
+  override render() {
+    const props = this.controller?.props;
+    if (!props) return nothing;
+
+    const label = props.label ?? 'Value';
+    const value = props.value ?? 0;
+    const min = props.min ?? 0;
+    const max = props.max ?? 100;
+
+    return html`
+      <div class="custom-slider-container">
+        <label>${label}: ${value}</label>
+        <input
+          type="range"
+          min="${min}"
+          max="${max}"
+          .value="${String(value)}"
+          @input="${(e: Event) => props.setValue?.(Number((e.target as HTMLInputElement).value))}"
+        />
+      </div>
+    `;
+  }
+}
+
+export const customSliderComponent: WebComponentImplementation<typeof customSliderApi.schema> = {
+  name: customSliderApi.name,
+  tagName: 'a2ui-custom-slider',
+  schema: customSliderApi.schema,
+};

--- a/renderers/lit/a2ui_explorer/src/demo-catalog.ts
+++ b/renderers/lit/a2ui_explorer/src/demo-catalog.ts
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
-import {setDefaultMarkdownRenderer} from '@a2ui/web_core/v0_9';
-import {renderMarkdown} from '@a2ui/markdown-it';
-import './local-gallery.js';
+import {Catalog} from '@a2ui/web_core/v0_9';
+import {basicCatalog} from '@a2ui/lit/v0_9';
+import {customSliderComponent} from './custom-slider.js';
+import {customGridComponent} from './custom-grid.js';
 
-setDefaultMarkdownRenderer(renderMarkdown);
+/**
+ * A catalog specific to the demo, extending the basic catalog with custom components.
+ */
+export const demoCatalog = new Catalog(
+  basicCatalog.id,
+  [...Array.from(basicCatalog.components.values()), customSliderComponent, customGridComponent],
+  Array.from(basicCatalog.functions.values()),
+);

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -18,8 +18,9 @@ import {LitElement, html, nothing} from 'lit';
 import {provide} from '@lit/context';
 import {customElement, state} from 'lit/decorators.js';
 import {MessageProcessor, A2uiMessage, A2uiClientAction} from '@a2ui/web_core/v0_9';
-import {basicCatalog, Context} from '@a2ui/lit/v0_9';
+import {Context} from '@a2ui/lit/v0_9';
 import {renderMarkdown} from '@a2ui/markdown-it';
+import {demoCatalog} from './demo-catalog.js';
 import {getDemoItems, DemoItem} from './examples';
 import {appStyles} from './local-gallery.css';
 
@@ -40,7 +41,7 @@ export class LocalGallery extends LitElement {
   @provide({context: Context.markdown})
   private markdownRenderer = renderMarkdown;
 
-  private processor = new MessageProcessor([basicCatalog], (action: A2uiClientAction) => {
+  private processor = new MessageProcessor([demoCatalog], (action: A2uiClientAction) => {
     this.log(`Action dispatched: ${action.surfaceId}`, action);
     this.actionLog.push(action);
   });

--- a/renderers/lit/a2ui_explorer/tests/utils/test-utils.ts
+++ b/renderers/lit/a2ui_explorer/tests/utils/test-utils.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+import {setDefaultMarkdownRenderer} from '@a2ui/web_core/v0_9';
+import {renderMarkdown} from '@a2ui/markdown-it';
 import {LocalGallery} from '../../src/local-gallery';
 
 import {ReactiveElement} from 'lit';
+
+setDefaultMarkdownRenderer(renderMarkdown);
 
 /**
  * Mounts the <local-gallery> element on the specified example.

--- a/renderers/lit/a2ui_explorer/tests/v0_9/37_native-grid.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/37_native-grid.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  loadExample,
+  getSurface,
+  getDeepTextContent,
+  querySelectorAllDeep,
+  whenSettled,
+} from '../utils/test-utils';
+import {LocalGallery} from '../../src/local-gallery';
+
+describe('Example: Native Lit Grid', () => {
+  let gallery: LocalGallery;
+  let surface: HTMLElement;
+
+  beforeEach(async () => {
+    gallery = await loadExample('37_native-grid.json');
+    surface = getSurface(gallery);
+  });
+
+  afterEach(() => {
+    gallery?.remove();
+  });
+
+  it('should render the native container component and header content', () => {
+    const textContent = getDeepTextContent(surface);
+    expect(textContent).toContain('Native Container Component Showcase');
+    expect(textContent).toContain('Interactive 4x4 Component Grid');
+    expect(querySelectorAllDeep(surface, 'a2ui-custom-grid').length).toBeGreaterThan(0);
+  });
+
+  it('should instantiate custom component children (CustomSlider)', () => {
+    const textContent = getDeepTextContent(surface);
+    expect(textContent).toContain('Master Volume (Native)');
+    expect(textContent).toContain('Brightness Level (Native)');
+
+    const customSliders = querySelectorAllDeep(surface, 'a2ui-custom-slider');
+    expect(customSliders.length).toBe(2);
+  });
+
+  it('should instantiate universal web component children (Card, Text, Button)', () => {
+    const textContent = getDeepTextContent(surface);
+    expect(textContent).toContain('Universal Web Component: Text & Card');
+    expect(textContent).toContain('Universal Button Action');
+
+    expect(querySelectorAllDeep(surface, 'a2ui-card, a2ui-basic-card').length).toBeGreaterThan(0);
+    expect(querySelectorAllDeep(surface, 'a2ui-button, a2ui-basic-button').length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('should update reactive data binding across native and universal components', async () => {
+    const slider = querySelectorAllDeep(
+      surface,
+      'a2ui-custom-slider input[type="range"]',
+    )[0] as HTMLInputElement;
+    expect(slider).toBeTruthy();
+
+    slider.value = '80';
+    slider.dispatchEvent(new Event('input'));
+    await whenSettled(gallery);
+
+    const textContent = getDeepTextContent(surface);
+    expect(textContent).toContain('Vol: 80% | Bright: 30%');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a native Lit custom container component sample to the Lit Explorer app (aligning with the Angular implementation in [#2274](https://github.com/a2ui-project/a2ui/pull/2274) and React implementation in [#2283](https://github.com/a2ui-project/a2ui/pull/2283)).

### Key Changes:

- **Lit Explorer Native Container & Custom Component Sample**:
  - **`custom-grid.ts`**: Implemented a native Lit container component (`<a2ui-custom-grid>`) showcasing a 2x2 grid layout that renders and hosts both native custom components and standard universal Web Components (Card, Column, Text, Button) via dynamic child slot rendering.
  - **`custom-slider.ts`**: Implemented a native Lit slider component (`<a2ui-custom-slider>`) demonstrating two-way dynamic data binding (`DynamicNumberSchema`, `DynamicStringSchema`).
  - **`demo-catalog.ts`**: Extended `basicCatalog` with `customSliderComponent` and `customGridComponent` for the explorer demo.
  - **`37_native-grid.test.ts`**: Added integration tests verifying rendering of native container, native slider child elements, universal Web Component children, and reactive data model updates.
  - **Markdown Setup**: Configured global markdown renderer with `setDefaultMarkdownRenderer` in `main.ts` and test utils.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for new or changed code.
- [x] My PR title respects the semantic release format.
- [x] I updated `CHANGELOG.md` with notes describing my changes.

Related to #1270
