### PR TITLE
refactor(v1_0): rename callableFrom to allowedCallers across schemas, docs, and conformance tests

### DIFF
--- a/conformance/core/rpc_functions.yaml
+++ b/conformance/core/rpc_functions.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 - name: test_rpc_call_renderer_function_success
-  description: Verifies agent-initiated callRendererFunction on a function with callableFrom=rendererOrAgent.
+  description: Verifies agent-initiated callRendererFunction on a function with allowedCallers=rendererOrAgent.
   catalog:
     protocolVersion: "v1.0"
   action: handle_rpc
@@ -30,7 +30,7 @@
             autoplay: true
     functionMetadata:
       playMedia:
-        callableFrom: "rendererOrAgent"
+        allowedCallers: "rendererOrAgent"
         requiresUserActivation: false
   expect:
     response:
@@ -42,7 +42,7 @@
           timestamp: 0
 
 - name: test_rpc_call_renderer_function_unauthorized_caller
-  description: Verifies callRendererFunction fails with INVALID_FUNCTION_CALL when callableFrom is rendererOnly.
+  description: Verifies callRendererFunction fails with INVALID_FUNCTION_CALL when allowedCallers is rendererOnly.
   catalog:
     protocolVersion: "v1.0"
   action: handle_rpc
@@ -57,7 +57,7 @@
           args: {}
     functionMetadata:
       internalStateReset:
-        callableFrom: "rendererOnly"
+        allowedCallers: "rendererOnly"
         requiresUserActivation: false
   expect:
     response:
@@ -66,7 +66,7 @@
         functionCallId: "call-102"
         error:
           code: "INVALID_FUNCTION_CALL"
-          message: "Function 'internalStateReset' cannot be called by agent (callableFrom is rendererOnly)."
+          message: "Function 'internalStateReset' cannot be called by agent (allowedCallers is rendererOnly)."
 
 - name: test_rpc_call_renderer_function_requires_user_activation
   description: Verifies callRendererFunction execution when requiresUserActivation is true and user gesture is present.
@@ -86,7 +86,7 @@
             url: "https://example.com/details"
     functionMetadata:
       openExternalUrl:
-        callableFrom: "rendererOrAgent"
+        allowedCallers: "rendererOrAgent"
         requiresUserActivation: true
   expect:
     response:
@@ -141,7 +141,7 @@
             url: "https://example.com/details"
     functionMetadata:
       openExternalUrl:
-        callableFrom: "rendererOrAgent"
+        allowedCallers: "rendererOrAgent"
         requiresUserActivation: true
   expect:
     response:
@@ -168,7 +168,7 @@
           args: {}
     functionMetadata:
       failingFunction:
-        callableFrom: "rendererOrAgent"
+        allowedCallers: "rendererOrAgent"
         requiresUserActivation: false
   expect:
     response:
@@ -180,7 +180,7 @@
           message: "An error occurred during function execution."
 
 - name: test_rpc_call_renderer_function_agent_only_boundary
-  description: Verifies agent-initiated callRendererFunction on a function with callableFrom=agentOnly.
+  description: Verifies agent-initiated callRendererFunction on a function with allowedCallers=agentOnly.
   catalog:
     protocolVersion: "v1.0"
   action: handle_rpc
@@ -195,7 +195,7 @@
           args: {}
     functionMetadata:
       syncState:
-        callableFrom: "agentOnly"
+        allowedCallers: "agentOnly"
         requiresUserActivation: false
   expect:
     response:

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py
@@ -35,9 +35,9 @@ class FunctionDefinition(BaseModel):
     ] = Field(
         ..., alias="returnType", description="The type of value this function returns."
     )
-    callable_from: Optional[Literal["rendererOnly", "agentOnly", "rendererOrAgent"]] = (
+    allowed_callers: Optional[Literal["rendererOnly", "agentOnly", "rendererOrAgent"]] = (
         Field(
-            alias="callableFrom",
+            alias="allowedCallers",
             description="Specifies where this function can be invoked from.",
             default="rendererOnly",
         )

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py
@@ -35,12 +35,12 @@ class FunctionDefinition(BaseModel):
     ] = Field(
         ..., alias="returnType", description="The type of value this function returns."
     )
-    allowed_callers: Optional[Literal["rendererOnly", "agentOnly", "rendererOrAgent"]] = (
-        Field(
-            alias="allowedCallers",
-            description="Specifies where this function can be invoked from.",
-            default="rendererOnly",
-        )
+    allowed_callers: Optional[
+        Literal["rendererOnly", "agentOnly", "rendererOrAgent"]
+    ] = Field(
+        alias="allowedCallers",
+        description="Specifies where this function can be invoked from.",
+        default="rendererOnly",
     )
     requires_user_activation: Optional[bool] = Field(
         alias="requiresUserActivation",

--- a/specification/proposals/user_initiated_functions.md
+++ b/specification/proposals/user_initiated_functions.md
@@ -114,7 +114,7 @@ Rather than adding metadata to catalog component definitions or introducing new 
   Active during surface layout construction, dynamic string interpolation (`${openUrl(...)}`), template iteration, reactive state updates, or direct agent function invocation messages.
   - **Blocks** functions marked `requiresUserActivation: true`.
 
-- **Agent Invocation Rejection**: Functions declared with `callableFrom: "rendererOrAgent"` (or `"rendererOnly"`) that set `requiresUserActivation: true` MUST be rejected with a runtime security error if directly invoked by a server/agent message. Because direct backend agent calls execute without a physical client user activation context (`isExecutingAction = false`), they are prohibited from auto-executing user-activation-restricted functions.
+- **Agent Invocation Rejection**: Functions declared with `allowedCallers: "rendererOrAgent"` (or `"rendererOnly"`) that set `requiresUserActivation: true` MUST be rejected with a runtime security error if directly invoked by a server/agent message. Because direct backend agent calls execute without a physical client user activation context (`isExecutingAction = false`), they are prohibited from auto-executing user-activation-restricted functions.
 
 ### 3.3 Asynchronous Execution Boundaries
 

--- a/typescript/web_core/src/catalog/types.ts
+++ b/typescript/web_core/src/catalog/types.ts
@@ -52,7 +52,7 @@ export interface FunctionApi {
   readonly name: string;
   readonly returnType: A2uiReturnType;
   readonly schema: z.ZodTypeAny;
-  readonly callableFrom?: 'rendererOnly' | 'agentOnly' | 'rendererOrAgent';
+  readonly allowedCallers?: 'rendererOnly' | 'agentOnly' | 'rendererOrAgent';
   readonly requiresUserActivation?: boolean;
 }
 
@@ -75,7 +75,7 @@ export function createFunctionImplementation<
     name: string;
     returnType: TReturn;
     schema: Schema;
-    callableFrom?: 'rendererOnly' | 'agentOnly' | 'rendererOrAgent';
+    allowedCallers?: 'rendererOnly' | 'agentOnly' | 'rendererOrAgent';
     requiresUserActivation?: boolean;
   },
   execute: (
@@ -88,7 +88,7 @@ export function createFunctionImplementation<
     name: api.name,
     returnType: api.returnType,
     schema: api.schema,
-    callableFrom: api.callableFrom,
+    allowedCallers: api.allowedCallers,
     requiresUserActivation: api.requiresUserActivation,
     execute: execute as (args: Record<string, any>, ctx: DataContext, ab?: AbortSignal) => unknown,
   };

--- a/typescript/web_core/src/v1_0/schema/catalog-definition.ts
+++ b/typescript/web_core/src/v1_0/schema/catalog-definition.ts
@@ -112,9 +112,9 @@ export const FunctionDefinitionSchema = z
               'void',
             ])
             .describe('The type of value this function returns.'),
-          'callableFrom': z
+          'allowedCallers': z
             .enum(['rendererOnly', 'agentOnly', 'rendererOrAgent'])
-            .describe('Specifies where this function can be invoked from.')
+            .describe('Specifies which roles are authorized to invoke this function.')
             .default('rendererOnly'),
           'requiresUserActivation': z
             .boolean()

--- a/v1_0_implementation_plan.md
+++ b/v1_0_implementation_plan.md
@@ -163,7 +163,7 @@ sequenceDiagram
 1. **Bidirectional RPC Functions**:
    - Agent-to-Renderer: `callRendererFunction` $\rightarrow$ returns `rendererFunctionResponse`.
    - Renderer-to-Agent: `callAgentFunction` $\rightarrow$ returns `agentFunctionResponse`.
-   - Runtime authorized caller checking (`callableFrom`: `rendererOnly`, `rendererOrAgent`).
+   - Runtime authorized caller checking (`allowedCallers`: `rendererOnly`, `rendererOrAgent`).
    - User activation requirement flag (`requiresUserActivation: true` for functions like `openUrl`).
 2. **Multi-Catalog Surface Mixing**:
    - `supportedCatalogIds` can be mixed within a single surface.
@@ -367,7 +367,7 @@ flowchart LR
   - `typescript/web_core/src/basic_catalog/v1_0/` (`catalog.ts`, `components.ts`, `functions.ts`)
 - **Key Requirements**:
   - Add `protocol_version: A2uiProtocolVersion` and `instructions: str` properties to `Catalog`.
-  - Add `callable_from` (`rendererOnly`, `rendererOrAgent`) and `requires_user_activation` to `FunctionApi`.
+  - Add `allowed_callers` (`rendererOnly`, `rendererOrAgent`) and `requires_user_activation` to `FunctionApi`.
   - Add optional `allowed_parents` and `allowed_children` to `ComponentApi`.
   - Implement UAX #31 identifier validation logic for component names, function names, and argument keys.
   - Load `specification/v1_0/catalogs/basic/catalog.json`: update `Video` (`posterUrl`), `TextField` (`placeholder`), `Slider` (`steps`), set `requiresUserActivation: true` on `openUrl`.
@@ -398,7 +398,7 @@ flowchart LR
   - `typescript/web_core/src/processing/message-processor.ts`
 - **Key Requirements**:
   - Intercept incoming `callRendererFunction` messages.
-  - Verify function metadata in catalog: check `callableFrom` permits `agent` invocation (`rendererOrAgent`). If violated or unregistered, return error code `INVALID_FUNCTION_CALL`.
+  - Verify function metadata in catalog: check `allowedCallers` permits `agent` invocation (`rendererOrAgent`). If violated or unregistered, return error code `INVALID_FUNCTION_CALL`.
   - Execute matching `FunctionImplementation` and emit `rendererFunctionResponse` containing `callId` and `value` or `error`.
 - **Verification**: Test execution of valid remote renderer functions and rejection of `rendererOnly` functions.
 


### PR DESCRIPTION
## Summary

Renames remaining occurrences of `callableFrom` (and Python's `callable_from`) to `allowedCallers` (and `allowed_callers`) across the `v1_0` worktree.

In commit `fa4d85c71`, specification JSON files and documentation were updated to use canonical `allowedCallers` instead of `callableFrom`. This PR fixes the remaining schema definitions, implementation plan, proposal doc, and conformance test vectors to consistently use `allowedCallers`.

## Changes Included

- **Conformance Tests**: Updated `conformance/core/rpc_functions.yaml` metadata fields and descriptions from `callableFrom` to `allowedCallers`.
- **Python SDK**: Updated `python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py` `FunctionDefinition` model to use field `allowed_callers` with alias `allowedCallers`.
- **TypeScript Web Core**:
  - Updated `typescript/web_core/src/catalog/types.ts` `FunctionApi` to use `allowedCallers`.
  - Updated `typescript/web_core/src/v1_0/schema/catalog-definition.ts` Zod schema to validate `allowedCallers`.
- **Specification & Documentation**:
  - Updated `specification/proposals/user_initiated_functions.md`.
  - Updated `v1_0_implementation_plan.md`.

## Verification

- Ran `yarn test` in `typescript/web_core` (all 319 unit tests passing).
- Ran `uv run pytest` in `python/a2ui_core` (all 218 unit tests passing).
- Ran `uv run pytest` in `python/a2ui_agent` (all 514 unit tests passing).