### PR TITLE
test(web_core): add unit tests for basic catalog components

### DIFF
--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Add unit test coverage for all basic catalog Web Component implementations. [#2357](https://github.com/a2ui-project/a2ui/pull/2357)
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) The child-reference marker on `ComponentIdSchema` and `ChildListSchema` now lives in the schema's metadata, so `.describe()` and other schema-rebuilding methods no longer drop it. Hand-authored `REF:` descriptions are still recognized ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Add unit test coverage for all basic catalog Web Component implementations. [#2357](https://github.com/a2ui-project/a2ui/pull/2357)
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export experimental Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Add the node layer: `NodeResolver` resolves a surface's components and data into a live tree of read-only `ComponentNode`s, with dynamic properties resolved to `ResolvedBinding`/`WritableBinding` and distinct pending, unknown-type, and cyclic placeholder states ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).

--- a/renderers/web_core/src/v0_9/basic_catalog/components/AudioPlayer.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/AudioPlayer.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiAudioPlayerElement} from './AudioPlayer.js';
+
+describe('AudioPlayer Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./AudioPlayer.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiAudioPlayerElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'AudioPlayer',
+              url: 'http://example.com/audio.mp3',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and attach url correctly', async () => {
+    const el = document.createElement('a2ui-audioplayer') as A2uiAudioPlayerElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const audio = el.querySelector('audio');
+    assert.notStrictEqual(audio, null);
+    assert.strictEqual(audio?.getAttribute('src'), 'http://example.com/audio.mp3');
+    assert.strictEqual(audio?.classList.contains('a2ui-audio'), true);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/AudioPlayer.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/AudioPlayer.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('AudioPlayer Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./AudioPlayer.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'AudioPlayer',
+              url: 'http://example.com/audio.mp3',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and attach url correctly', async () => {
+    const el = document.createElement('a2ui-audioplayer');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const audio = el.querySelector('audio');
+    expect(audio).not.toBeNull();
+    expect(audio?.getAttribute('src')).toBe('http://example.com/audio.mp3');
+    expect(audio?.classList.contains('a2ui-audio')).toBeTrue();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Button.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Button.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+  A2uiClientAction,
+} from '../../index.js';
+import type {A2uiBasicButtonElement} from './Button.js';
+
+describe('Button Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    // Ensure components are registered
+    await import('./Button.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicButtonElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'btn1',
+              component: 'Button',
+              child: 'txt1',
+              action: {event: {name: 'submit_clicked'}},
+            },
+            {
+              id: 'btn_disabled',
+              component: 'Button',
+              child: 'txt1',
+              isValid: false,
+              action: {event: {name: 'ignored'}},
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Click Me',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and dispatch action on click', async () => {
+    const el = document.createElement('a2ui-basic-button') as A2uiBasicButtonElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'btn1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const button = el.querySelector('button');
+    assert.notStrictEqual(button, null);
+    assert.strictEqual(button?.disabled, false);
+
+    const dispatched = {action: null as A2uiClientAction | null};
+    subscription = surface.onAction.subscribe((action: A2uiClientAction) => {
+      dispatched.action = action;
+    });
+
+    button?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.notStrictEqual(dispatched.action, null);
+    assert.strictEqual(dispatched.action?.name, 'submit_clicked');
+  });
+
+  it('should be disabled when isValid is false', async () => {
+    const el = document.createElement('a2ui-basic-button') as A2uiBasicButtonElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'btn_disabled');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const button = el.querySelector('button');
+    assert.notStrictEqual(button, null);
+    assert.strictEqual(button?.disabled, true);
+
+    let dispatchedAction = false;
+    subscription = surface.onAction.subscribe(() => {
+      dispatchedAction = true;
+    });
+
+    button?.click();
+    assert.strictEqual(dispatchedAction, false);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Button.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Button.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+  A2uiClientAction,
+} from '../../index.js';
+import type {A2uiBasicButtonElement} from './Button.js';
+
+describe('Button Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    // Ensure components are registered
+    await import('./Button.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicButtonElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'btn1',
+              component: 'Button',
+              child: 'txt1',
+              action: {event: {name: 'submit_clicked'}},
+            },
+            {
+              id: 'btn_disabled',
+              component: 'Button',
+              child: 'txt1',
+              isValid: false,
+              action: {event: {name: 'ignored'}},
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Click Me',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and dispatch action on click', async () => {
+    const el = document.createElement('a2ui-basic-button') as A2uiBasicButtonElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'btn1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const button = el.querySelector('button');
+    expect(button).not.toBeNull();
+    expect(button?.disabled).toBe(false);
+
+    const dispatched = {action: null as A2uiClientAction | null};
+    subscription = surface.onAction.subscribe((action: A2uiClientAction) => {
+      dispatched.action = action;
+    });
+
+    button?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(dispatched.action).not.toBeNull();
+    expect(dispatched.action?.name).toBe('submit_clicked');
+  });
+
+  it('should be disabled when isValid is false', async () => {
+    const el = document.createElement('a2ui-basic-button') as A2uiBasicButtonElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'btn_disabled');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const button = el.querySelector('button');
+    expect(button).not.toBeNull();
+    expect(button?.disabled).toBe(true);
+
+    let dispatchedAction = false;
+    subscription = surface.onAction.subscribe(() => {
+      dispatchedAction = true;
+    });
+
+    button?.click();
+    expect(dispatchedAction).toBe(false);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Card.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Card.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiCardElement} from './Card.js';
+
+describe('Card Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Card.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiCardElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Card',
+              child: 'txt1',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'hello',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and display child content', async () => {
+    const el = document.createElement('a2ui-card') as A2uiCardElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const cardDiv = el.querySelector('.a2ui-card');
+    assert.notStrictEqual(cardDiv, null);
+    const textEl = el.querySelector('a2ui-basic-text');
+    assert.notStrictEqual(textEl, null);
+    assert.strictEqual(el.textContent?.includes('hello'), true);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Card.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Card.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Card Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Card.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Card',
+              child: 'txt1',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'hello',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and display child content', async () => {
+    const el = document.createElement('a2ui-card');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const cardDiv = el.querySelector('.a2ui-card');
+    expect(cardDiv).not.toBeNull();
+    const textEl = el.querySelector('a2ui-basic-text');
+    expect(textEl).not.toBeNull();
+    expect(el.textContent?.includes('hello')).toBeTrue();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/CheckBox.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/CheckBox.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiCheckBoxElement} from './CheckBox.js';
+
+describe('CheckBox Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    // Ensure component is registered
+    await import('./CheckBox.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'checkbox_invalid',
+              component: 'CheckBox',
+              label: 'Check me',
+              value: false,
+              isValid: false,
+              validationErrors: ['This is required'],
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should render label and reflect true and false checked state', async () => {
+    const el = document.createElement('a2ui-checkbox') as A2uiCheckBoxElement;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'checkbox_invalid');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const labelSpan = el.querySelector('.a2ui-check-box-text');
+    assert.notStrictEqual(labelSpan, null);
+    assert.strictEqual(labelSpan?.textContent?.trim(), 'Check me');
+
+    const input = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.checked, false);
+
+    // Update component to value: true
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'checkbox_invalid',
+              component: 'CheckBox',
+              label: 'Check me',
+              value: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const contextTrue = new ComponentContext(surface, 'checkbox_invalid');
+    await asyncUpdate(el, e => {
+      e.context = contextTrue;
+    });
+
+    assert.strictEqual(input?.checked, true);
+    document.body.removeChild(el);
+  });
+
+  it('should update bound data model when changed', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/agree',
+          value: false,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'cb_bound',
+              component: 'CheckBox',
+              label: 'Agree to terms',
+              value: {path: '/agree'},
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-checkbox') as A2uiCheckBoxElement;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'cb_bound');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.checked, false);
+
+    // Simulate user toggling checkbox
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.strictEqual(surface.dataModel.get('/agree'), true);
+    document.body.removeChild(el);
+  });
+
+  it('should render validation error in CheckBox', async () => {
+    const el = document.createElement('a2ui-checkbox') as A2uiCheckBoxElement;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'checkbox_invalid');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const errorDiv = el.querySelector('.a2ui-error-message');
+    assert.notStrictEqual(errorDiv, null);
+    assert.strictEqual(errorDiv?.textContent?.trim(), 'This is required');
+
+    document.body.removeChild(el);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/CheckBox.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/CheckBox.test.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+
+describe('CheckBox Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    // Ensure component is registered
+    await import('./CheckBox.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'checkbox_invalid',
+              component: 'CheckBox',
+              label: 'Check me',
+              value: false,
+              isValid: false,
+              validationErrors: ['This is required'],
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should render label and reflect true and false checked state', async () => {
+    const el = document.createElement('a2ui-checkbox') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'checkbox_invalid');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const labelSpan = el.querySelector('.a2ui-check-box-text');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan?.textContent?.trim()).toBe('Check me');
+
+    const input = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input?.checked).toBe(false);
+
+    // Update component to value: true
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'checkbox_invalid',
+              component: 'CheckBox',
+              label: 'Check me',
+              value: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const contextTrue = new ComponentContext(surface, 'checkbox_invalid');
+    await asyncUpdate(el, (e: any) => {
+      e.context = contextTrue;
+    });
+
+    expect(input?.checked).toBe(true);
+    document.body.removeChild(el);
+  });
+
+  it('should update bound data model when changed', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/agree',
+          value: false,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'cb_bound',
+              component: 'CheckBox',
+              label: 'Agree to terms',
+              value: {path: '/agree'},
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-checkbox') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'cb_bound');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input?.checked).toBe(false);
+
+    // Simulate user toggling checkbox
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(surface.dataModel.get('/agree')).toBe(true);
+    document.body.removeChild(el);
+  });
+
+  it('should render validation error in CheckBox', async () => {
+    const el = document.createElement('a2ui-checkbox') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'checkbox_invalid');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const errorDiv = el.querySelector('.a2ui-error-message');
+    expect(errorDiv).not.toBeNull();
+    expect(errorDiv?.textContent?.trim()).toBe('This is required');
+
+    document.body.removeChild(el);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/ChoicePicker.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/ChoicePicker.test.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiChoicePickerElement} from './ChoicePicker.js';
+
+describe('ChoicePicker Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    // Ensure component is registered
+    await import('./ChoicePicker.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'choice_picker_chips',
+              component: 'ChoicePicker',
+              label: 'Pick chips',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: [],
+              displayStyle: 'chips',
+            },
+            {
+              id: 'choice_picker_filterable',
+              component: 'ChoicePicker',
+              label: 'Filter me',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: [],
+              filterable: true,
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should render chips when displayStyle is chips', async () => {
+    const el = document.createElement('a2ui-choicepicker') as A2uiChoicePickerElement;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'choice_picker_chips');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const buttons = el.querySelectorAll('button.a2ui-chip');
+    assert.strictEqual(buttons.length, 2);
+    assert.strictEqual(buttons[0].textContent?.trim(), 'Apple');
+
+    document.body.removeChild(el);
+  });
+
+  it('should update bound data model when clicking a chip', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/chosen',
+          value: [],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'choice_picker_chips_bound',
+              component: 'ChoicePicker',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: {path: '/chosen'},
+              displayStyle: 'chips',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-choicepicker') as A2uiChoicePickerElement;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'choice_picker_chips_bound');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const buttons = el.querySelectorAll('button.a2ui-chip') as NodeListOf<HTMLButtonElement>;
+    assert.strictEqual(buttons.length, 2);
+
+    // Click Apple chip
+    buttons[0].click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const selected = surface.dataModel.get('/chosen');
+    assert.deepStrictEqual(selected, ['apple']);
+
+    document.body.removeChild(el);
+  });
+
+  it('ChoicePicker radio groups do not collide across surfaces', async () => {
+    // Component ids are only surface-scoped, so two surfaces may each
+    // contain a ChoicePicker with the same id. Radio names are
+    // document-scoped: if the group name is derived from the component id,
+    // both pickers merge into one radio group and fight over one selection.
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'second-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'second-surface',
+          components: [
+            {
+              id: 'choice_picker_filterable',
+              component: 'ChoicePicker',
+              label: 'Filter me',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: [],
+            },
+          ],
+        },
+      },
+    ]);
+    const secondSurface = processor.model.getSurface('second-surface')!;
+
+    const firstContext = new ComponentContext(surface, 'choice_picker_filterable');
+    const secondContext = new ComponentContext(secondSurface, 'choice_picker_filterable');
+
+    const firstEl = document.createElement('a2ui-choicepicker') as A2uiChoicePickerElement;
+    firstEl.context = firstContext;
+    document.body.appendChild(firstEl);
+    await firstEl.updateComplete;
+
+    const secondEl = document.createElement('a2ui-choicepicker') as A2uiChoicePickerElement;
+    secondEl.context = secondContext;
+    document.body.appendChild(secondEl);
+    await secondEl.updateComplete;
+
+    const getGroupNames = (el: HTMLElement) =>
+      new Set(
+        Array.from(el.querySelectorAll<HTMLInputElement>('input[type="radio"]')).map(
+          input => input.name,
+        ),
+      );
+
+    const firstNames = getGroupNames(firstEl);
+    const secondNames = getGroupNames(secondEl);
+
+    assert.strictEqual(firstNames.size, 1);
+    assert.strictEqual(secondNames.size, 1);
+    assert.notStrictEqual([...firstNames][0], [...secondNames][0]);
+
+    document.body.removeChild(firstEl);
+    document.body.removeChild(secondEl);
+  });
+
+  it('should not set a name on checkbox inputs', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'choice_picker_multi',
+              component: 'ChoicePicker',
+              label: 'Multi pick',
+              options: [{label: 'Option 1', value: 'opt1'}],
+              value: [],
+              variant: 'multipleSelection',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-choicepicker') as A2uiChoicePickerElement;
+    el.context = new ComponentContext(surface, 'choice_picker_multi');
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    const checkbox = el.querySelector('input[type="checkbox"]');
+    assert.ok(checkbox);
+    assert.strictEqual(checkbox.hasAttribute('name'), false);
+
+    document.body.removeChild(el);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/ChoicePicker.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/ChoicePicker.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+
+describe('ChoicePicker Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    // Ensure component is registered
+    await import('./ChoicePicker.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'choice_picker_chips',
+              component: 'ChoicePicker',
+              label: 'Pick chips',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: [],
+              displayStyle: 'chips',
+            },
+            {
+              id: 'choice_picker_filterable',
+              component: 'ChoicePicker',
+              label: 'Filter me',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: [],
+              filterable: true,
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should render chips when displayStyle is chips', async () => {
+    const el = document.createElement('a2ui-choicepicker') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'choice_picker_chips');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const buttons = el.querySelectorAll('button.a2ui-chip');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].textContent?.trim()).toBe('Apple');
+
+    document.body.removeChild(el);
+  });
+
+  it('should update bound data model when clicking a chip', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/chosen',
+          value: [],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'choice_picker_chips_bound',
+              component: 'ChoicePicker',
+              options: [
+                {label: 'Apple', value: 'apple'},
+                {label: 'Banana', value: 'banana'},
+              ],
+              value: {path: '/chosen'},
+              displayStyle: 'chips',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-choicepicker') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'choice_picker_chips_bound');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const buttons = el.querySelectorAll('button.a2ui-chip') as NodeListOf<HTMLButtonElement>;
+    expect(buttons.length).toBe(2);
+
+    // Click Apple chip
+    buttons[0].click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const selected = surface.dataModel.get('/chosen');
+    expect(selected).toEqual(['apple']);
+
+    document.body.removeChild(el);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Column.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Column.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiBasicColumnElement} from './Column.js';
+
+describe('Column Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Column.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicColumnElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Column',
+              children: ['txt1', 'txt2'],
+              justify: 'center',
+              align: 'end',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Child 1',
+            },
+            {
+              id: 'txt2',
+              component: 'Text',
+              text: 'Child 2',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render children and apply flex alignment styles', async () => {
+    const el = document.createElement('a2ui-basic-column') as A2uiBasicColumnElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    assert.strictEqual(el.style.justifyContent, 'center');
+    assert.strictEqual(el.style.alignItems, 'flex-end');
+
+    const textElements = el.querySelectorAll('a2ui-basic-text');
+    assert.strictEqual(textElements.length, 2);
+    assert.strictEqual(el.textContent?.includes('Child 1'), true);
+    assert.strictEqual(el.textContent?.includes('Child 2'), true);
+  });
+
+  it('should track and reuse child elements during a reordering operation', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'col-reorder',
+              component: 'Column',
+              children: ['c1', 'c2', 'c3'],
+            },
+            {id: 'c1', component: 'Text', text: 'Item 1'},
+            {id: 'c2', component: 'Text', text: 'Item 2'},
+            {id: 'c3', component: 'Text', text: 'Item 3'},
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-basic-column') as A2uiBasicColumnElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context1 = new ComponentContext(surface, 'col-reorder');
+    await asyncUpdate(el, e => {
+      e.context = context1;
+    });
+
+    const initialNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as (HTMLElement & {
+      __marker?: string;
+    })[];
+    assert.strictEqual(initialNodes.length, 3);
+    const node1 = initialNodes[0];
+    const node2 = initialNodes[1];
+    const node3 = initialNodes[2];
+
+    node1.__marker = 'marker-1';
+    node2.__marker = 'marker-2';
+    node3.__marker = 'marker-3';
+
+    // Reorder children to ['c2', 'c3', 'c1']
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'col-reorder',
+              component: 'Column',
+              children: ['c2', 'c3', 'c1'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const context2 = new ComponentContext(surface, 'col-reorder');
+    await asyncUpdate(el, e => {
+      e.context = context2;
+    });
+
+    const reorderedNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as (HTMLElement & {
+      __marker?: string;
+    })[];
+    assert.strictEqual(reorderedNodes.length, 3);
+
+    // Assert that the exact DOM element instances were moved/reused based on tracking
+    assert.strictEqual(reorderedNodes[0], node2);
+    assert.strictEqual(reorderedNodes[1], node3);
+    assert.strictEqual(reorderedNodes[2], node1);
+    assert.strictEqual(reorderedNodes[0].__marker, 'marker-2');
+    assert.strictEqual(reorderedNodes[1].__marker, 'marker-3');
+    assert.strictEqual(reorderedNodes[2].__marker, 'marker-1');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Column.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Column.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Column Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Column.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Column',
+              children: ['txt1', 'txt2'],
+              justify: 'center',
+              align: 'end',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Child 1',
+            },
+            {
+              id: 'txt2',
+              component: 'Text',
+              text: 'Child 2',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render children and apply flex alignment styles', async () => {
+    const el = document.createElement('a2ui-basic-column');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    expect(el.style.justifyContent).toBe('center');
+    expect(el.style.alignItems).toBe('flex-end');
+
+    const textElements = el.querySelectorAll('a2ui-basic-text');
+    expect(textElements.length).toBe(2);
+    expect(el.textContent?.includes('Child 1')).toBeTrue();
+    expect(el.textContent?.includes('Child 2')).toBeTrue();
+  });
+
+  it('should track and reuse child elements during a reordering operation', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'col-reorder',
+              component: 'Column',
+              children: ['c1', 'c2', 'c3'],
+            },
+            {id: 'c1', component: 'Text', text: 'Item 1'},
+            {id: 'c2', component: 'Text', text: 'Item 2'},
+            {id: 'c3', component: 'Text', text: 'Item 3'},
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-basic-column');
+    element = el;
+    document.body.appendChild(el);
+
+    const context1 = new ComponentContext(surface, 'col-reorder');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context1;
+    });
+
+    const initialNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as HTMLElement[];
+    expect(initialNodes.length).toBe(3);
+    const node1 = initialNodes[0];
+    const node2 = initialNodes[1];
+    const node3 = initialNodes[2];
+
+    (node1 as any).__marker = 'marker-1';
+    (node2 as any).__marker = 'marker-2';
+    (node3 as any).__marker = 'marker-3';
+
+    // Reorder children to ['c2', 'c3', 'c1']
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'col-reorder',
+              component: 'Column',
+              children: ['c2', 'c3', 'c1'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const context2 = new ComponentContext(surface, 'col-reorder');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context2;
+    });
+
+    const reorderedNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as HTMLElement[];
+    expect(reorderedNodes.length).toBe(3);
+
+    // Assert that the exact DOM element instances were moved/reused based on tracking
+    expect(reorderedNodes[0]).toBe(node2);
+    expect(reorderedNodes[1]).toBe(node3);
+    expect(reorderedNodes[2]).toBe(node1);
+    expect((reorderedNodes[0] as any).__marker).toBe('marker-2');
+    expect((reorderedNodes[1] as any).__marker).toBe('marker-3');
+    expect((reorderedNodes[2] as any).__marker).toBe('marker-1');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/DateTimeInput.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/DateTimeInput.test.ts
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiDateTimeInputElement} from './DateTimeInput.js';
+
+describe('DateTimeInput Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./DateTimeInput.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiDateTimeInputElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'DateTimeInput',
+              label: 'Birthday',
+              value: '2023-01-01',
+              enableDate: true,
+              enableTime: false,
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render date and label value', async () => {
+    const el = document.createElement('a2ui-datetimeinput') as A2uiDateTimeInputElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const label = el.querySelector('.a2ui-date-time-label');
+    assert.notStrictEqual(label, null);
+    assert.strictEqual(label?.textContent?.trim(), 'Birthday');
+
+    const input = el.querySelector('input[type="date"]') as HTMLInputElement;
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.value, '2023-01-01');
+  });
+
+  it('should update bound data model when date is selected', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/selectedDate',
+          value: '2023-01-01',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'dt_bound',
+              component: 'DateTimeInput',
+              label: 'Event Date',
+              value: {path: '/selectedDate'},
+              enableDate: true,
+              enableTime: false,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-datetimeinput') as A2uiDateTimeInputElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'dt_bound');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input[type="date"]') as HTMLInputElement;
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.value, '2023-01-01');
+
+    input.value = '2024-05-20';
+    input.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.strictEqual(surface.dataModel.get('/selectedDate'), '2024-05-20');
+  });
+
+  it('should render and update correctly in time-only mode', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/timeVal',
+          value: '09:30',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'dt_time_only',
+              component: 'DateTimeInput',
+              label: 'Meeting Time',
+              value: {path: '/timeVal'},
+              enableDate: false,
+              enableTime: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-datetimeinput') as A2uiDateTimeInputElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'dt_time_only');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    // Date input should not be present
+    assert.strictEqual(el.querySelector('input[type="date"]'), null);
+
+    const timeInput = el.querySelector('input[type="time"]') as HTMLInputElement;
+    assert.notStrictEqual(timeInput, null);
+    assert.strictEqual(timeInput.value, '09:30');
+
+    // Changing time in time-only mode must update to '14:00', NOT '09:30T14:00:00'
+    timeInput.value = '14:00';
+    timeInput.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.strictEqual(surface.dataModel.get('/timeVal'), '14:00');
+  });
+
+  it('should preserve date and time components when editing in datetime mode', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/appointment',
+          value: '2024-06-15T10:00:00',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'dt_combined',
+              component: 'DateTimeInput',
+              label: 'Appointment',
+              value: {path: '/appointment'},
+              enableDate: true,
+              enableTime: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-datetimeinput') as A2uiDateTimeInputElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'dt_combined');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const dateInput = el.querySelector('input[type="date"]') as HTMLInputElement;
+    const timeInput = el.querySelector('input[type="time"]') as HTMLInputElement;
+    assert.notStrictEqual(dateInput, null);
+    assert.notStrictEqual(timeInput, null);
+    assert.strictEqual(dateInput.value, '2024-06-15');
+    assert.strictEqual(timeInput.value, '10:00');
+
+    // Changing time should update time part while preserving date part
+    timeInput.value = '15:30';
+    timeInput.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.strictEqual(surface.dataModel.get('/appointment'), '2024-06-15T15:30:00');
+
+    // Changing date should update date part while preserving time part
+    dateInput.value = '2025-01-20';
+    dateInput.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.strictEqual(surface.dataModel.get('/appointment'), '2025-01-20T15:30:00');
+  });
+
+  it('should fallback to local calendar date when choosing time first in datetime mode', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/new_event',
+          value: '',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'dt_empty',
+              component: 'DateTimeInput',
+              label: 'New Event',
+              value: {path: '/new_event'},
+              enableDate: true,
+              enableTime: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-datetimeinput') as A2uiDateTimeInputElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'dt_empty');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const timeInput = el.querySelector('input[type="time"]') as HTMLInputElement;
+    timeInput.value = '11:00';
+    timeInput.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const now = new Date();
+    const expectedLocalDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    assert.strictEqual(surface.dataModel.get('/new_event'), `${expectedLocalDate}T11:00:00`);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/DateTimeInput.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/DateTimeInput.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('DateTimeInput Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./DateTimeInput.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'DateTimeInput',
+              label: 'Birthday',
+              value: '2023-01-01',
+              enableDate: true,
+              enableTime: false,
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render date and label value', async () => {
+    const el = document.createElement('a2ui-datetimeinput');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const label = el.querySelector('.a2ui-date-time-label');
+    expect(label).not.toBeNull();
+    expect(label?.textContent?.trim()).toBe('Birthday');
+
+    const input = el.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('2023-01-01');
+  });
+
+  it('should update bound data model when date is selected', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/selectedDate',
+          value: '2023-01-01',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'dt_bound',
+              component: 'DateTimeInput',
+              label: 'Event Date',
+              value: {path: '/selectedDate'},
+              enableDate: true,
+              enableTime: false,
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-datetimeinput');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'dt_bound');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input[type="date"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('2023-01-01');
+
+    input.value = '2024-05-20';
+    input.dispatchEvent(new Event('change'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(surface.dataModel.get('/selectedDate')).toBe('2024-05-20');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Divider.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Divider.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiDividerElement} from './Divider.js';
+
+describe('Divider Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Divider.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiDividerElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Divider',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render an hr element', async () => {
+    const el = document.createElement('a2ui-divider') as A2uiDividerElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const hr = el.querySelector('hr');
+    assert.notStrictEqual(hr, null);
+    assert.strictEqual(hr?.classList.contains('a2ui-divider'), true);
+    assert.strictEqual(hr?.classList.contains('horizontal'), true);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Divider.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Divider.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Divider Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Divider.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Divider',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render an hr element', async () => {
+    const el = document.createElement('a2ui-divider');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const hr = el.querySelector('hr');
+    expect(hr).not.toBeNull();
+    expect(hr?.classList.contains('a2ui-divider')).toBeTrue();
+    expect(hr?.classList.contains('horizontal')).toBeTrue();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Icon.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Icon.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiIconElement} from './Icon.js';
+
+describe('Icon Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Icon.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiIconElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'icon_plain',
+              component: 'Icon',
+              name: 'play',
+            },
+            {
+              id: 'icon_svg',
+              component: 'Icon',
+              name: {
+                svgPath: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render plain material icon <i> with correct classes and name override', async () => {
+    const el = document.createElement('a2ui-icon') as A2uiIconElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'icon_plain');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const i = el.querySelector('i');
+    assert.notStrictEqual(i, null);
+    assert.strictEqual(i?.classList.contains('material-icons'), true);
+    assert.strictEqual(i?.classList.contains('a2ui-icon'), true);
+    assert.strictEqual(i?.textContent?.trim(), 'play_arrow');
+  });
+
+  it('should render svg icon with svgPath', async () => {
+    const el = document.createElement('a2ui-icon') as A2uiIconElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'icon_svg');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const svg = el.querySelector('svg');
+    assert.notStrictEqual(svg, null);
+    assert.strictEqual(svg?.classList.contains('a2ui-icon'), true);
+    assert.strictEqual(svg?.classList.contains('svg'), true);
+    const path = svg?.querySelector('path');
+    assert.notStrictEqual(path, null);
+    assert.strictEqual(path?.getAttribute('d'), 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Icon.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Icon.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Icon Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Icon.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'icon_plain',
+              component: 'Icon',
+              name: 'play',
+            },
+            {
+              id: 'icon_svg',
+              component: 'Icon',
+              name: {
+                svgPath: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render plain material icon <i> with correct classes and name override', async () => {
+    const el = document.createElement('a2ui-icon');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'icon_plain');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const i = el.querySelector('i');
+    expect(i).not.toBeNull();
+    expect(i?.classList.contains('material-icons')).toBeTrue();
+    expect(i?.classList.contains('a2ui-icon')).toBeTrue();
+    expect(i?.textContent?.trim()).toBe('play_arrow');
+  });
+
+  it('should render svg icon with svgPath', async () => {
+    const el = document.createElement('a2ui-icon');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'icon_svg');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const svg = el.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.classList.contains('a2ui-icon')).toBeTrue();
+    expect(svg?.classList.contains('svg')).toBeTrue();
+    const path = svg?.querySelector('path');
+    expect(path).not.toBeNull();
+    expect(path?.getAttribute('d')).toBe('M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Image.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Image.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import {ImageApi} from './basic_components.js';
+import type {A2uiImageElement} from './Image.js';
+
+describe('Image Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Image.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiImageElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Image',
+              url: 'http://example.com/image.png',
+              description: 'An example image',
+              variant: 'avatar',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render img element with correct attributes and classes', async () => {
+    const el = document.createElement('a2ui-image') as A2uiImageElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const img = el.querySelector('img');
+    assert.notStrictEqual(img, null);
+    assert.strictEqual(img?.getAttribute('src'), 'http://example.com/image.png');
+    assert.strictEqual(img?.getAttribute('alt'), 'An example image');
+    assert.strictEqual(img?.classList.contains('a2ui-image'), true);
+    assert.strictEqual(img?.classList.contains('avatar'), true);
+  });
+
+  describe('ImageApi schema validation', () => {
+    it('should parse valid image with description', () => {
+      const validImage = {
+        url: 'https://example.com/image.png',
+        description: 'An example image',
+      };
+      const parsed = ImageApi.schema.parse(validImage);
+      assert.strictEqual(parsed.url, 'https://example.com/image.png');
+      assert.strictEqual(parsed.description, 'An example image');
+    });
+
+    it('should parse valid image without description', () => {
+      const validImage = {
+        url: 'https://example.com/image.png',
+      };
+      const parsed = ImageApi.schema.parse(validImage);
+      assert.strictEqual(parsed.url, 'https://example.com/image.png');
+      assert.strictEqual(parsed.description, undefined);
+    });
+
+    it('should throw on invalid image', () => {
+      const invalidImage = {
+        url: 123, // Invalid type
+      };
+      assert.throws(() => ImageApi.schema.parse(invalidImage));
+    });
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Image.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Image.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import {ImageApi} from './basic_components.js';
+
+describe('Image Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Image.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Image',
+              url: 'http://example.com/image.png',
+              description: 'An example image',
+              variant: 'avatar',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render img element with correct attributes and classes', async () => {
+    const el = document.createElement('a2ui-image');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const img = el.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('http://example.com/image.png');
+    expect(img?.getAttribute('alt')).toBe('An example image');
+    expect(img?.classList.contains('a2ui-image')).toBeTrue();
+    expect(img?.classList.contains('avatar')).toBeTrue();
+  });
+
+  describe('ImageApi schema validation', () => {
+    it('should parse valid image with description', () => {
+      const validImage = {
+        url: 'https://example.com/image.png',
+        description: 'An example image',
+      };
+      const parsed = ImageApi.schema.parse(validImage);
+      expect(parsed.url).toBe('https://example.com/image.png');
+      expect(parsed.description).toBe('An example image');
+    });
+
+    it('should parse valid image without description', () => {
+      const validImage = {
+        url: 'https://example.com/image.png',
+      };
+      const parsed = ImageApi.schema.parse(validImage);
+      expect(parsed.url).toBe('https://example.com/image.png');
+      expect(parsed.description).toBeUndefined();
+    });
+
+    it('should throw on invalid image', () => {
+      const invalidImage = {
+        url: 123, // Invalid type
+      };
+      expect(() => ImageApi.schema.parse(invalidImage)).toThrow();
+    });
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/List.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/List.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiListElement} from './List.js';
+
+describe('List Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./List.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiListElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'List',
+              children: ['txt1', 'txt2'],
+              listStyle: 'unordered',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'List Item 1',
+            },
+            {
+              id: 'txt2',
+              component: 'Text',
+              text: 'List Item 2',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render children in list container', async () => {
+    const el = document.createElement('a2ui-list') as A2uiListElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const ul = el.querySelector('ul.a2ui-list');
+    assert.notStrictEqual(ul, null);
+
+    const textElements = el.querySelectorAll('a2ui-basic-text');
+    assert.strictEqual(textElements.length, 2);
+    assert.strictEqual(el.textContent?.includes('List Item 1'), true);
+    assert.strictEqual(el.textContent?.includes('List Item 2'), true);
+  });
+
+  it('should track and reuse child elements during a reordering operation', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'list-reorder',
+              component: 'List',
+              children: ['item1', 'item2', 'item3'],
+              listStyle: 'ordered',
+            },
+            {id: 'item1', component: 'Text', text: 'First Item'},
+            {id: 'item2', component: 'Text', text: 'Second Item'},
+            {id: 'item3', component: 'Text', text: 'Third Item'},
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-list') as A2uiListElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context1 = new ComponentContext(surface, 'list-reorder');
+    await asyncUpdate(el, e => {
+      e.context = context1;
+    });
+
+    const initialNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as (HTMLElement & {
+      __marker?: string;
+    })[];
+    assert.strictEqual(initialNodes.length, 3);
+    const node1 = initialNodes[0];
+    const node2 = initialNodes[1];
+    const node3 = initialNodes[2];
+
+    node1.__marker = 'marker-1';
+    node2.__marker = 'marker-2';
+    node3.__marker = 'marker-3';
+
+    // Reorder children to ['item3', 'item1', 'item2']
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'list-reorder',
+              component: 'List',
+              children: ['item3', 'item1', 'item2'],
+              listStyle: 'ordered',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const context2 = new ComponentContext(surface, 'list-reorder');
+    await asyncUpdate(el, e => {
+      e.context = context2;
+    });
+
+    const reorderedNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as (HTMLElement & {
+      __marker?: string;
+    })[];
+    assert.strictEqual(reorderedNodes.length, 3);
+
+    // Assert that the exact DOM element instances were moved/reused based on tracking
+    assert.strictEqual(reorderedNodes[0], node3);
+    assert.strictEqual(reorderedNodes[1], node1);
+    assert.strictEqual(reorderedNodes[2], node2);
+    assert.strictEqual(reorderedNodes[0].__marker, 'marker-3');
+    assert.strictEqual(reorderedNodes[1].__marker, 'marker-1');
+    assert.strictEqual(reorderedNodes[2].__marker, 'marker-2');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/List.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/List.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('List Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./List.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'List',
+              children: ['txt1', 'txt2'],
+              listStyle: 'unordered',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'List Item 1',
+            },
+            {
+              id: 'txt2',
+              component: 'Text',
+              text: 'List Item 2',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render children in list container', async () => {
+    const el = document.createElement('a2ui-list');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const ul = el.querySelector('ul.a2ui-list');
+    expect(ul).not.toBeNull();
+
+    const textElements = el.querySelectorAll('a2ui-basic-text');
+    expect(textElements.length).toBe(2);
+    expect(el.textContent?.includes('List Item 1')).toBeTrue();
+    expect(el.textContent?.includes('List Item 2')).toBeTrue();
+  });
+
+  it('should track and reuse child elements during a reordering operation', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'list-reorder',
+              component: 'List',
+              children: ['item1', 'item2', 'item3'],
+              listStyle: 'ordered',
+            },
+            {id: 'item1', component: 'Text', text: 'First Item'},
+            {id: 'item2', component: 'Text', text: 'Second Item'},
+            {id: 'item3', component: 'Text', text: 'Third Item'},
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-list');
+    element = el;
+    document.body.appendChild(el);
+
+    const context1 = new ComponentContext(surface, 'list-reorder');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context1;
+    });
+
+    const initialNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as HTMLElement[];
+    expect(initialNodes.length).toBe(3);
+    const node1 = initialNodes[0];
+    const node2 = initialNodes[1];
+    const node3 = initialNodes[2];
+
+    (node1 as any).__marker = 'marker-1';
+    (node2 as any).__marker = 'marker-2';
+    (node3 as any).__marker = 'marker-3';
+
+    // Reorder children to ['item3', 'item1', 'item2']
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'list-reorder',
+              component: 'List',
+              children: ['item3', 'item1', 'item2'],
+              listStyle: 'ordered',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const context2 = new ComponentContext(surface, 'list-reorder');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context2;
+    });
+
+    const reorderedNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as HTMLElement[];
+    expect(reorderedNodes.length).toBe(3);
+
+    // Assert that the exact DOM element instances were moved/reused based on tracking
+    expect(reorderedNodes[0]).toBe(node3);
+    expect(reorderedNodes[1]).toBe(node1);
+    expect(reorderedNodes[2]).toBe(node2);
+    expect((reorderedNodes[0] as any).__marker).toBe('marker-3');
+    expect((reorderedNodes[1] as any).__marker).toBe('marker-1');
+    expect((reorderedNodes[2] as any).__marker).toBe('marker-2');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Modal.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Modal.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiLitModal} from './Modal.js';
+
+describe('Modal Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Modal.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiLitModal | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Modal',
+              trigger: 'txt1',
+              content: 'txt2',
+            },
+            {id: 'txt1', component: 'Text', text: 'Open Modal'},
+            {id: 'txt2', component: 'Text', text: 'Modal Dialog Content'},
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render trigger initially and open modal on click to render content', async () => {
+    const el = document.createElement('a2ui-modal') as A2uiLitModal;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    assert.notStrictEqual(trigger, null);
+    assert.strictEqual(trigger?.textContent?.includes('Open Modal'), true);
+
+    // Initially closed
+    assert.strictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+
+    // Click trigger to open
+    trigger.click();
+    await asyncUpdate(el, () => {});
+
+    const overlay = el.querySelector('.a2ui-modal-overlay');
+    assert.notStrictEqual(overlay, null);
+    const modalContent = el.querySelector('.a2ui-modal-content');
+    assert.notStrictEqual(modalContent, null);
+    assert.strictEqual(modalContent?.textContent?.includes('Modal Dialog Content'), true);
+  });
+
+  it('should close when clicking the close button', async () => {
+    const el = document.createElement('a2ui-modal') as A2uiLitModal;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    trigger.click();
+    await asyncUpdate(el, () => {});
+    assert.notStrictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+
+    const closeBtn = el.querySelector('button.a2ui-modal-close') as HTMLButtonElement;
+    assert.notStrictEqual(closeBtn, null);
+    closeBtn.click();
+    await asyncUpdate(el, () => {});
+
+    assert.strictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+  });
+
+  it('should close when clicking the outside backdrop', async () => {
+    const el = document.createElement('a2ui-modal') as A2uiLitModal;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    trigger.click();
+    await asyncUpdate(el, () => {});
+    assert.notStrictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+
+    const overlay = el.querySelector('.a2ui-modal-overlay') as HTMLElement;
+    overlay.click();
+    await asyncUpdate(el, () => {});
+
+    assert.strictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+  });
+
+  it('should not close when clicking inside', async () => {
+    const el = document.createElement('a2ui-modal') as A2uiLitModal;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    trigger.click();
+    await asyncUpdate(el, () => {});
+    assert.notStrictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+
+    const content = el.querySelector('.a2ui-modal-content') as HTMLElement;
+    content.click();
+    await asyncUpdate(el, () => {});
+
+    // Modal overlay should remain open because inner content click event stops propagation
+    assert.notStrictEqual(el.querySelector('.a2ui-modal-overlay'), null);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Modal.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Modal.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Modal Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Modal.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Modal',
+              trigger: 'txt1',
+              content: 'txt2',
+            },
+            {id: 'txt1', component: 'Text', text: 'Open Modal'},
+            {id: 'txt2', component: 'Text', text: 'Modal Dialog Content'},
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render trigger initially and open modal on click to render content', async () => {
+    const el = document.createElement('a2ui-modal');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent?.includes('Open Modal')).toBeTrue();
+
+    // Initially closed
+    expect(el.querySelector('.a2ui-modal-overlay')).toBeNull();
+
+    // Click trigger to open
+    trigger.click();
+    await asyncUpdate(el, () => {});
+
+    const overlay = el.querySelector('.a2ui-modal-overlay');
+    expect(overlay).not.toBeNull();
+    const modalContent = el.querySelector('.a2ui-modal-content');
+    expect(modalContent).not.toBeNull();
+    expect(modalContent?.textContent?.includes('Modal Dialog Content')).toBeTrue();
+  });
+
+  it('should close when clicking the close button', async () => {
+    const el = document.createElement('a2ui-modal');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    trigger.click();
+    await asyncUpdate(el, () => {});
+    expect(el.querySelector('.a2ui-modal-overlay')).not.toBeNull();
+
+    const closeBtn = el.querySelector('button.a2ui-modal-close') as HTMLButtonElement;
+    expect(closeBtn).not.toBeNull();
+    closeBtn.click();
+    await asyncUpdate(el, () => {});
+
+    expect(el.querySelector('.a2ui-modal-overlay')).toBeNull();
+  });
+
+  it('should close when clicking the outside backdrop', async () => {
+    const el = document.createElement('a2ui-modal');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    trigger.click();
+    await asyncUpdate(el, () => {});
+    expect(el.querySelector('.a2ui-modal-overlay')).not.toBeNull();
+
+    const overlay = el.querySelector('.a2ui-modal-overlay') as HTMLElement;
+    overlay.click();
+    await asyncUpdate(el, () => {});
+
+    expect(el.querySelector('.a2ui-modal-overlay')).toBeNull();
+  });
+
+  it('should not close when clicking inside', async () => {
+    const el = document.createElement('a2ui-modal');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const trigger = el.querySelector('.a2ui-modal-trigger') as HTMLElement;
+    trigger.click();
+    await asyncUpdate(el, () => {});
+    expect(el.querySelector('.a2ui-modal-overlay')).not.toBeNull();
+
+    const content = el.querySelector('.a2ui-modal-content') as HTMLElement;
+    content.click();
+    await asyncUpdate(el, () => {});
+
+    // Modal overlay should remain open because inner content click event stops propagation
+    expect(el.querySelector('.a2ui-modal-overlay')).not.toBeNull();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Row.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Row.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiBasicRowElement} from './Row.js';
+
+describe('Row Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Row.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicRowElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'row1',
+              component: 'Row',
+              children: ['txt1', 'txt2'],
+              justify: 'center',
+              align: 'end',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Left',
+            },
+            {
+              id: 'txt2',
+              component: 'Text',
+              text: 'Right',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render children and apply flex alignment styles', async () => {
+    const el = document.createElement('a2ui-basic-row') as A2uiBasicRowElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'row1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    // Check flex styles on the host element style attribute
+    assert.strictEqual(el.style.justifyContent, 'center');
+    assert.strictEqual(el.style.alignItems, 'flex-end');
+
+    const textElements = el.querySelectorAll('a2ui-basic-text') as
+      | NodeListOf<HTMLElement & {context?: ComponentContext}>
+      | undefined;
+    assert.notStrictEqual(textElements, null);
+    assert.strictEqual(textElements?.length, 2);
+    assert.strictEqual(textElements?.[0].context?.componentModel.id, 'txt1');
+    assert.strictEqual(textElements?.[1].context?.componentModel.id, 'txt2');
+  });
+
+  it('should track and reuse child elements during a reordering operation', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'row-reorder',
+              component: 'Row',
+              children: ['t1', 't2', 't3'],
+            },
+            {id: 't1', component: 'Text', text: 'First'},
+            {id: 't2', component: 'Text', text: 'Second'},
+            {id: 't3', component: 'Text', text: 'Third'},
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-basic-row') as A2uiBasicRowElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context1 = new ComponentContext(surface, 'row-reorder');
+    await asyncUpdate(el, e => {
+      e.context = context1;
+    });
+
+    const initialNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as (HTMLElement & {
+      __marker?: string;
+    })[];
+    assert.strictEqual(initialNodes.length, 3);
+    const node1 = initialNodes[0];
+    const node2 = initialNodes[1];
+    const node3 = initialNodes[2];
+
+    node1.__marker = 'first-marker';
+    node2.__marker = 'second-marker';
+    node3.__marker = 'third-marker';
+
+    // Reorder children to ['t3', 't1', 't2']
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'row-reorder',
+              component: 'Row',
+              children: ['t3', 't1', 't2'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const context2 = new ComponentContext(surface, 'row-reorder');
+    await asyncUpdate(el, e => {
+      e.context = context2;
+    });
+
+    const reorderedNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as (HTMLElement & {
+      __marker?: string;
+    })[];
+    assert.strictEqual(reorderedNodes.length, 3);
+
+    // Assert that the exact DOM element instances were moved/reused based on tracking
+    assert.strictEqual(reorderedNodes[0], node3);
+    assert.strictEqual(reorderedNodes[1], node1);
+    assert.strictEqual(reorderedNodes[2], node2);
+    assert.strictEqual(reorderedNodes[0].__marker, 'third-marker');
+    assert.strictEqual(reorderedNodes[1].__marker, 'first-marker');
+    assert.strictEqual(reorderedNodes[2].__marker, 'second-marker');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Row.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Row.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiBasicRowElement} from './Row.js';
+
+describe('Row Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Row.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicRowElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'row1',
+              component: 'Row',
+              children: ['txt1', 'txt2'],
+              justify: 'center',
+              align: 'end',
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Left',
+            },
+            {
+              id: 'txt2',
+              component: 'Text',
+              text: 'Right',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render children and apply flex alignment styles', async () => {
+    const el = document.createElement('a2ui-basic-row') as A2uiBasicRowElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'row1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    // Check flex styles on the host element style attribute
+    expect(el.style.justifyContent).toBe('center');
+    expect(el.style.alignItems).toBe('flex-end');
+
+    const textElements = el.querySelectorAll('a2ui-basic-text') as
+      | NodeListOf<HTMLElement & {context?: ComponentContext}>
+      | undefined;
+    expect(textElements).not.toBeNull();
+    expect(textElements?.length).toBe(2);
+    expect(textElements?.[0].context?.componentModel.id).toBe('txt1');
+    expect(textElements?.[1].context?.componentModel.id).toBe('txt2');
+  });
+
+  it('should track and reuse child elements during a reordering operation', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'row-reorder',
+              component: 'Row',
+              children: ['t1', 't2', 't3'],
+            },
+            {id: 't1', component: 'Text', text: 'First'},
+            {id: 't2', component: 'Text', text: 'Second'},
+            {id: 't3', component: 'Text', text: 'Third'},
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-basic-row') as A2uiBasicRowElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context1 = new ComponentContext(surface, 'row-reorder');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context1;
+    });
+
+    const initialNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as HTMLElement[];
+    expect(initialNodes.length).toBe(3);
+    const node1 = initialNodes[0];
+    const node2 = initialNodes[1];
+    const node3 = initialNodes[2];
+
+    (node1 as any).__marker = 'first-marker';
+    (node2 as any).__marker = 'second-marker';
+    (node3 as any).__marker = 'third-marker';
+
+    // Reorder children to ['t3', 't1', 't2']
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'row-reorder',
+              component: 'Row',
+              children: ['t3', 't1', 't2'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const context2 = new ComponentContext(surface, 'row-reorder');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context2;
+    });
+
+    const reorderedNodes = Array.from(el.querySelectorAll('a2ui-basic-text')) as HTMLElement[];
+    expect(reorderedNodes.length).toBe(3);
+
+    // Assert that the exact DOM element instances were moved/reused based on tracking
+    expect(reorderedNodes[0]).toBe(node3);
+    expect(reorderedNodes[1]).toBe(node1);
+    expect(reorderedNodes[2]).toBe(node2);
+    expect((reorderedNodes[0] as any).__marker).toBe('third-marker');
+    expect((reorderedNodes[1] as any).__marker).toBe('first-marker');
+    expect((reorderedNodes[2] as any).__marker).toBe('second-marker');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Slider.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Slider.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import {SliderApi} from './basic_components.js';
+import type {A2uiSliderElement} from './Slider.js';
+
+describe('Slider Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Slider.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiSliderElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Slider',
+              label: 'Volume',
+              min: 10,
+              max: 100,
+              value: 50,
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render slider input and header with correct attributes and values', async () => {
+    const el = document.createElement('a2ui-slider') as A2uiSliderElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const label = el.querySelector('.a2ui-slider-label');
+    assert.notStrictEqual(label, null);
+    assert.strictEqual(label?.textContent?.trim(), 'Volume');
+
+    const valueSpan = el.querySelector('.a2ui-slider-value');
+    assert.notStrictEqual(valueSpan, null);
+    assert.strictEqual(valueSpan?.textContent?.trim(), '50');
+
+    const input = el.querySelector('input[type="range"]') as HTMLInputElement;
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.getAttribute('min'), '10');
+    assert.strictEqual(input?.getAttribute('max'), '100');
+    assert.strictEqual(input?.value, '50');
+    assert.strictEqual(input?.classList.contains('a2ui-slider'), true);
+  });
+
+  it('should update bound data model when slider value changes', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/volume',
+          value: 50,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'slider_bound',
+              component: 'Slider',
+              label: 'Volume Control',
+              min: 0,
+              max: 100,
+              value: {path: '/volume'},
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-slider') as A2uiSliderElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'slider_bound');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input[type="range"]') as HTMLInputElement;
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.value, '50');
+
+    input.value = '80';
+    input.dispatchEvent(new Event('input'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.strictEqual(surface.dataModel.get('/volume'), 80);
+  });
+
+  describe('SliderApi schema validation', () => {
+    it('should reject non-spec step property', () => {
+      const validSlider = {
+        max: 100,
+        value: 50,
+      };
+      SliderApi.schema.parse(validSlider);
+
+      const result = SliderApi.schema.safeParse({
+        ...validSlider,
+        step: 5,
+      });
+
+      assert.strictEqual(result.success, false);
+      if (!result.success) {
+        assert.strictEqual(
+          result.error.issues.some(
+            issue => issue.code === 'unrecognized_keys' && issue.keys.includes('step'),
+          ),
+          true,
+        );
+      }
+    });
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Slider.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Slider.test.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import {SliderApi} from './basic_components.js';
+
+describe('Slider Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Slider.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Slider',
+              label: 'Volume',
+              min: 10,
+              max: 100,
+              value: 50,
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render slider input and header with correct attributes and values', async () => {
+    const el = document.createElement('a2ui-slider');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const label = el.querySelector('.a2ui-slider-label');
+    expect(label).not.toBeNull();
+    expect(label?.textContent?.trim()).toBe('Volume');
+
+    const valueSpan = el.querySelector('.a2ui-slider-value');
+    expect(valueSpan).not.toBeNull();
+    expect(valueSpan?.textContent?.trim()).toBe('50');
+
+    const input = el.querySelector('input[type="range"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input?.getAttribute('min')).toBe('10');
+    expect(input?.getAttribute('max')).toBe('100');
+    expect(input?.value).toBe('50');
+    expect(input?.classList.contains('a2ui-slider')).toBeTrue();
+  });
+
+  it('should update bound data model when slider value changes', async () => {
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/volume',
+          value: 50,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'slider_bound',
+              component: 'Slider',
+              label: 'Volume Control',
+              min: 0,
+              max: 100,
+              value: {path: '/volume'},
+            },
+          ],
+        },
+      },
+    ]);
+
+    const el = document.createElement('a2ui-slider');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'slider_bound');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input[type="range"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('50');
+
+    input.value = '80';
+    input.dispatchEvent(new Event('input'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(surface.dataModel.get('/volume')).toBe(80);
+  });
+
+  describe('SliderApi schema validation', () => {
+    it('should reject non-spec step property', () => {
+      const validSlider = {
+        max: 100,
+        value: 50,
+      };
+      SliderApi.schema.parse(validSlider);
+
+      const result = SliderApi.schema.safeParse({
+        ...validSlider,
+        step: 5,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            issue => issue.code === 'unrecognized_keys' && issue.keys.includes('step'),
+          ),
+        ).toBeTrue();
+      }
+    });
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Tabs.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Tabs.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiLitTabs} from './Tabs.js';
+
+describe('Tabs Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Tabs.js');
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiLitTabs | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Tabs',
+              tabs: [
+                {title: 'Tab 1', child: 'txt1'},
+                {title: 'Tab 2', child: 'txt2'},
+              ],
+            },
+            {id: 'txt1', component: 'Text', text: 'Content 1'},
+            {id: 'txt2', component: 'Text', text: 'Content 2'},
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render tab headers with first tab active and display first tab content', async () => {
+    const el = document.createElement('a2ui-tabs') as A2uiLitTabs;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const buttons = el.querySelectorAll('button.a2ui-tab-button');
+    assert.strictEqual(buttons.length, 2);
+    assert.strictEqual(buttons[0].textContent?.trim(), 'Tab 1');
+    assert.strictEqual(buttons[1].textContent?.trim(), 'Tab 2');
+    assert.strictEqual(buttons[0].classList.contains('active'), true);
+    assert.strictEqual(buttons[1].classList.contains('active'), false);
+
+    const content = el.querySelector('.a2ui-tab-content');
+    assert.notStrictEqual(content, null);
+    assert.strictEqual(content?.textContent?.includes('Content 1'), true);
+    assert.strictEqual(content?.textContent?.includes('Content 2'), false);
+  });
+
+  it('should switch active tab and render corresponding content when tab header is clicked', async () => {
+    const el = document.createElement('a2ui-tabs') as A2uiLitTabs;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const buttons = el.querySelectorAll('button.a2ui-tab-button') as NodeListOf<HTMLButtonElement>;
+    assert.strictEqual(buttons.length, 2);
+
+    // Click Tab 2
+    buttons[1].click();
+    await asyncUpdate(el, () => {});
+
+    assert.strictEqual(buttons[0].classList.contains('active'), false);
+    assert.strictEqual(buttons[1].classList.contains('active'), true);
+
+    const content = el.querySelector('.a2ui-tab-content');
+    assert.notStrictEqual(content, null);
+    assert.strictEqual(content?.textContent?.includes('Content 2'), true);
+    assert.strictEqual(content?.textContent?.includes('Content 1'), false);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Tabs.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Tabs.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Tabs Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Tabs.js');
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Tabs',
+              tabs: [
+                {title: 'Tab 1', child: 'txt1'},
+                {title: 'Tab 2', child: 'txt2'},
+              ],
+            },
+            {id: 'txt1', component: 'Text', text: 'Content 1'},
+            {id: 'txt2', component: 'Text', text: 'Content 2'},
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render tab headers with first tab active and display first tab content', async () => {
+    const el = document.createElement('a2ui-tabs');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const buttons = el.querySelectorAll('button.a2ui-tab-button');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].textContent?.trim()).toBe('Tab 1');
+    expect(buttons[1].textContent?.trim()).toBe('Tab 2');
+    expect(buttons[0].classList.contains('active')).toBeTrue();
+    expect(buttons[1].classList.contains('active')).toBeFalse();
+
+    const content = el.querySelector('.a2ui-tab-content');
+    expect(content).not.toBeNull();
+    expect(content?.textContent?.includes('Content 1')).toBeTrue();
+    expect(content?.textContent?.includes('Content 2')).toBeFalse();
+  });
+
+  it('should switch active tab and render corresponding content when tab header is clicked', async () => {
+    const el = document.createElement('a2ui-tabs');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const buttons = el.querySelectorAll('button.a2ui-tab-button') as NodeListOf<HTMLButtonElement>;
+    expect(buttons.length).toBe(2);
+
+    // Click Tab 2
+    buttons[1].click();
+    await asyncUpdate(el, () => {});
+
+    expect(buttons[0].classList.contains('active')).toBeFalse();
+    expect(buttons[1].classList.contains('active')).toBeTrue();
+
+    const content = el.querySelector('.a2ui-tab-content');
+    expect(content).not.toBeNull();
+    expect(content?.textContent?.includes('Content 2')).toBeTrue();
+    expect(content?.textContent?.includes('Content 1')).toBeFalse();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Text.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Text.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiBasicTextElement} from './Text.js';
+
+describe('Text Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Text.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicTextElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 't_static',
+              component: 'Text',
+              text: 'Hello static text',
+            },
+            {
+              id: 't_dynamic',
+              component: 'Text',
+              text: {path: '/dynamic_msg'},
+            },
+            {
+              id: 't_caption',
+              component: 'Text',
+              text: 'Caption text',
+              variant: 'caption',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+    surface.dataModel.set('/dynamic_msg', 'Hello dynamic text');
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render static text content', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_static');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const span = el.querySelector('.no-markdown-renderer');
+    assert.notStrictEqual(span, null);
+    assert.strictEqual(span?.textContent?.trim(), 'Hello static text');
+  });
+
+  it('should render reactive dynamic text content', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_dynamic');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const span = el.querySelector('.no-markdown-renderer');
+    assert.notStrictEqual(span, null);
+    assert.strictEqual(span?.textContent?.trim(), 'Hello dynamic text');
+
+    // Update the data model value
+    surface.dataModel.set('/dynamic_msg', 'Updated dynamic text');
+    await asyncUpdate(el, () => {});
+
+    assert.strictEqual(span?.textContent?.trim(), 'Updated dynamic text');
+  });
+
+  it('should apply caption variant styling structure', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_caption');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const captionSpan = el.querySelector('span.a2ui-text.caption');
+    assert.notStrictEqual(captionSpan, null);
+    const em = captionSpan?.querySelector('em');
+    assert.notStrictEqual(em, null);
+
+    assert.strictEqual(em?.textContent?.trim(), 'Caption text');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Text.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Text.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiBasicTextElement} from './Text.js';
+
+describe('Text Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Text.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicTextElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 't_static',
+              component: 'Text',
+              text: 'Hello static text',
+            },
+            {
+              id: 't_dynamic',
+              component: 'Text',
+              text: {path: '/dynamic_msg'},
+            },
+            {
+              id: 't_caption',
+              component: 'Text',
+              text: 'Caption text',
+              variant: 'caption',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+    surface.dataModel.set('/dynamic_msg', 'Hello dynamic text');
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render static text content', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_static');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const span = el.querySelector('.no-markdown-renderer');
+    expect(span).not.toBeNull();
+    expect(span?.textContent?.trim()).toBe('Hello static text');
+  });
+
+  it('should render reactive dynamic text content', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_dynamic');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const span = el.querySelector('.no-markdown-renderer');
+    expect(span).not.toBeNull();
+    expect(span?.textContent?.trim()).toBe('Hello dynamic text');
+
+    // Update the data model value
+    surface.dataModel.set('/dynamic_msg', 'Updated dynamic text');
+    await asyncUpdate(el, () => {});
+
+    expect(span?.textContent?.trim()).toBe('Updated dynamic text');
+  });
+
+  it('should apply caption variant styling structure', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_caption');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const captionSpan = el.querySelector('span.a2ui-text.caption');
+    expect(captionSpan).not.toBeNull();
+    const em = captionSpan?.querySelector('em');
+    expect(em).not.toBeNull();
+
+    expect(em?.textContent?.trim()).toBe('Caption text');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/TextField.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/TextField.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiBasicTextFieldElement} from './TextField.js';
+
+describe('TextField Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./TextField.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicTextFieldElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'field_name',
+              component: 'TextField',
+              label: 'Username',
+              value: {path: '/user/name'},
+            },
+            {
+              id: 'field_long',
+              component: 'TextField',
+              label: 'Bio',
+              value: 'Initial Bio',
+              variant: 'longText',
+            },
+            {
+              id: 'field_invalid',
+              component: 'TextField',
+              label: 'Email',
+              value: '',
+              isValid: false,
+              validationErrors: ['Email is required', 'Email must contain @'],
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+    surface.dataModel.set('/user/name', 'Bob');
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render input field with label and initial value', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_name');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const label = el.querySelector('label');
+    assert.notStrictEqual(label, null);
+    assert.strictEqual(label?.textContent?.trim(), 'Username');
+
+    const input = el.querySelector('input');
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.value, 'Bob');
+  });
+
+  it('should update the data model value on input event', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_name');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input');
+    assert.notStrictEqual(input, null);
+
+    input!.value = 'Alice';
+    input!.dispatchEvent(new Event('input'));
+    await asyncUpdate(el, () => {});
+
+    // Check that the value is updated in the data model
+    assert.strictEqual(surface.dataModel.get('/user/name'), 'Alice');
+  });
+
+  it('should render textarea for longText variant', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_long');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const textarea = el.querySelector('textarea');
+    assert.notStrictEqual(textarea, null);
+    assert.strictEqual(textarea?.value, 'Initial Bio');
+
+    const input = el.querySelector('input');
+    assert.strictEqual(input, null);
+  });
+
+  it('should render all validation error messages when invalid', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_invalid');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const errors = el.querySelectorAll('.error');
+    assert.strictEqual(errors.length, 2);
+    assert.strictEqual(errors[0].textContent?.trim(), 'Email is required');
+    assert.strictEqual(errors[1].textContent?.trim(), 'Email must contain @');
+
+    const input = el.querySelector('input');
+    assert.notStrictEqual(input, null);
+    assert.strictEqual(input?.classList.contains('invalid'), true);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/TextField.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/TextField.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '../../index.js';
+import type {A2uiBasicTextFieldElement} from './TextField.js';
+
+describe('TextField Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./TextField.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiBasicTextFieldElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'field_name',
+              component: 'TextField',
+              label: 'Username',
+              value: {path: '/user/name'},
+            },
+            {
+              id: 'field_long',
+              component: 'TextField',
+              label: 'Bio',
+              value: 'Initial Bio',
+              variant: 'longText',
+            },
+            {
+              id: 'field_invalid',
+              component: 'TextField',
+              label: 'Email',
+              value: '',
+              isValid: false,
+              validationErrors: ['Email is required', 'Email must contain @'],
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+    surface.dataModel.set('/user/name', 'Bob');
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render input field with label and initial value', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_name');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const label = el.querySelector('label');
+    expect(label).not.toBeNull();
+    expect(label?.textContent?.trim()).toBe('Username');
+
+    const input = el.querySelector('input');
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('Bob');
+  });
+
+  it('should update the data model value on input event', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_name');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const input = el.querySelector('input');
+    expect(input).not.toBeNull();
+
+    input!.value = 'Alice';
+    input!.dispatchEvent(new Event('input'));
+    await asyncUpdate(el, () => {});
+
+    // Check that the value is updated in the data model
+    expect(surface.dataModel.get('/user/name')).toBe('Alice');
+  });
+
+  it('should render textarea for longText variant', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_long');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const textarea = el.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    expect(textarea?.value).toBe('Initial Bio');
+
+    const input = el.querySelector('input');
+    expect(input).toBeNull();
+  });
+
+  it('should render all validation error messages when invalid', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_invalid');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    const errors = el.querySelectorAll('.error');
+    expect(errors.length).toBe(2);
+    expect(errors[0].textContent?.trim()).toBe('Email is required');
+    expect(errors[1].textContent?.trim()).toBe('Email must contain @');
+
+    const input = el.querySelector('input');
+    expect(input).not.toBeNull();
+    expect(input?.classList.contains('invalid')).toBeTrue();
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Video.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Video.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+import type {A2uiVideoElement} from './Video.js';
+
+describe('Video Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Video.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiVideoElement | null = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Video',
+              url: 'http://example.com/video.mp4',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and attach url correctly', async () => {
+    const el = document.createElement('a2ui-video') as A2uiVideoElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.notStrictEqual(el, null);
+    const video = el.querySelector('video');
+    assert.notStrictEqual(video, null);
+    assert.strictEqual(video?.getAttribute('src'), 'http://example.com/video.mp4');
+    assert.strictEqual(video?.classList.contains('a2ui-video'), true);
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/components/Video.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/Video.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../../test/dom-setup.js';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+  Subscription,
+} from '../../index.js';
+
+describe('Video Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  beforeAll(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../index.js')).basicCatalog;
+    await import('./Video.js');
+  });
+
+  afterAll(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: any = null;
+  let subscription: Subscription | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'comp1',
+              component: 'Video',
+              url: 'http://example.com/video.mp4',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+    subscription = null;
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render and attach url correctly', async () => {
+    const el = document.createElement('a2ui-video');
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'comp1');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    expect(el).not.toBeNull();
+    const video = el.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute('src')).toBe('http://example.com/video.mp4');
+    expect(video?.classList.contains('a2ui-video')).toBeTrue();
+  });
+});


### PR DESCRIPTION
## Description

Adds comprehensive unit test suites in `@a2ui/web_core` for all 18 universal Basic Catalog component implementations:
- `AudioPlayer`, `Button`, `Card`, `CheckBox`, `ChoicePicker`, `Column`, `DateTimeInput`, `Divider`, `Icon`, `Image`, `List`, `Modal`, `Row`, `Slider`, `Tabs`, `Text`, `TextField`, `Video`

## Details

- **Component Test Suites**: Each component under `renderers/web_core/src/v0_9/basic_catalog/components/` now has a dedicated `.test.ts` file covering mounting, context bindings, reactive updates, and schema validation.
- **DOM Cleanup**: Leverages `setupTestDom` and `teardownTestDom` with `afterEach` hooks across all test suites to prevent DOM leakage and test pollution.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].
- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples

Related to #1270
