### PR TITLE
feat(web_core): enhance generic binder schema inference

### DIFF
--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -6,6 +6,7 @@
 - (v0_9) Emit `$ref` in inline-catalog capabilities for the basic catalog's child-reference properties even when a per-usage description is set; new `componentId()`/`childList()` helpers compose custom descriptions without losing the `$ref` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `GenericBinder` reuses action closures across identical component resends, so action-valued props keep reference identity and downstream equality checks see them as unchanged ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `Catalog` and `SurfaceModel` accept a function-kind type parameter (defaulting to `FunctionImplementation`); invoking a catalog function that has no implementation now throws `A2uiExpressionError` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
+- (v0_9) Enhance `GenericBinder` schema inference to recognize `$defs` descriptions and child reference metadata.([#2359](https://github.com/a2ui-project/a2ui/pull/2359))
 
 ## 0.10.6
 

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -4,6 +4,7 @@
 - (v0_9) Emit `$ref` in inline-catalog capabilities for the basic catalog's child-reference properties even when a per-usage description is set; new `componentId()`/`childList()` helpers compose custom descriptions without losing the `$ref` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `GenericBinder` reuses action closures across identical component resends, so action-valued props keep reference identity and downstream equality checks see them as unchanged ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `Catalog` and `SurfaceModel` accept a function-kind type parameter (defaulting to `FunctionImplementation`); invoking a catalog function that has no implementation now throws `A2uiExpressionError` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
+- (v0_9) Enhance `GenericBinder` schema inference to recognize `$defs` descriptions, structural template component IDs (`id` / `componentId`), and provide runtime reactive fallback binding for static or unannotated schemas. [#2359](https://github.com/a2ui-project/a2ui/pull/2359)
 
 ## 0.10.6
 

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -17,7 +17,7 @@
 import * as assert from 'node:assert';
 import {describe, it} from 'node:test';
 import {z} from 'zod';
-import {GenericBinder} from './generic-binder.js';
+import {GenericBinder, scrapeSchemaBehavior} from './generic-binder.js';
 import {ComponentContext} from './component-context.js';
 import {SurfaceModel} from '../state/surface-model.js';
 import {Catalog} from '../catalog/types.js';
@@ -316,5 +316,89 @@ describe('GenericBinder Checkable Trait', () => {
       extra: 'another_prop',
     };
     assert.strictEqual(notificationCount, 1);
+  });
+
+  describe('scrapeSchemaBehavior schema inference', () => {
+    it('should infer behavior from schema descriptions', () => {
+      // Description-based matching
+      assert.deepStrictEqual(
+        scrapeSchemaBehavior(z.any().describe('REF:common_types.json#/$defs/Action')),
+        {
+          type: 'ACTION',
+        },
+      );
+      assert.deepStrictEqual(scrapeSchemaBehavior(z.any().describe('#/$defs/ChildList')), {
+        type: 'STRUCTURAL',
+      });
+      assert.deepStrictEqual(scrapeSchemaBehavior(z.any().describe('#/$defs/DynamicString')), {
+        type: 'DYNAMIC',
+      });
+      assert.deepStrictEqual(
+        scrapeSchemaBehavior(z.any().describe('REF:common_types.json#/$defs/DataBinding')),
+        {
+          type: 'DYNAMIC',
+        },
+      );
+
+      // Checks property is CHECKABLE, while unannotated fields are STATIC
+      const objSchema = z.object({
+        checks: z.any(),
+        customProp: z.any(),
+      });
+
+      const behavior = scrapeSchemaBehavior(objSchema);
+      assert.strictEqual(behavior.type, 'OBJECT');
+      assert.strictEqual((behavior as any).shape.checks.type, 'CHECKABLE');
+      assert.strictEqual((behavior as any).shape.customProp.type, 'STATIC');
+
+      // Do not short-circuit to DYNAMIC if property is a nested ZodObject or ZodArray
+      const nestedSchema = z.object({
+        value: z.object({
+          nestedField: z.string().describe('#/$defs/DynamicString'),
+        }),
+        text: z.array(z.string().describe('#/$defs/DynamicString')),
+      });
+      const nestedBehavior = scrapeSchemaBehavior(nestedSchema);
+      assert.strictEqual(nestedBehavior.type, 'OBJECT');
+      assert.strictEqual((nestedBehavior as any).shape.value.type, 'OBJECT');
+      assert.strictEqual((nestedBehavior as any).shape.text.type, 'ARRAY');
+    });
+  });
+
+  describe('Static behavior for unannotated schemas', () => {
+    it('should pass unannotated properties through as static values without guessing bindings', () => {
+      const {surface} = setupSurfaceAndMocks();
+
+      const unannotatedSchema = z.object({
+        customProp: z.any(),
+        items: z.any(),
+        handleClick: z.any(),
+      });
+
+      const compModel = new ComponentModel('c10', 'Custom', {
+        customProp: {path: '/rawTitle'},
+        items: {componentId: 'card-view', path: '/cards'},
+        handleClick: {
+          event: {
+            name: 'custom_click',
+            context: {userId: {path: '/user/id'}},
+          },
+        },
+      });
+      surface.componentsModel.addComponent(compModel);
+
+      const context = new ComponentContext(surface, 'c10');
+      const binder = new GenericBinder<any>(context, unannotatedSchema);
+
+      // Data is passed through as-is rather than being misinterpreted as reactive bindings
+      assert.deepStrictEqual(binder.snapshot.customProp, {path: '/rawTitle'});
+      assert.deepStrictEqual(binder.snapshot.items, {componentId: 'card-view', path: '/cards'});
+      assert.deepStrictEqual(binder.snapshot.handleClick, {
+        event: {
+          name: 'custom_click',
+          context: {userId: {path: '/user/id'}},
+        },
+      });
+    });
   });
 });

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -17,7 +17,7 @@
 import * as assert from 'node:assert';
 import {describe, it} from 'node:test';
 import {z} from 'zod';
-import {GenericBinder} from './generic-binder.js';
+import {GenericBinder, scrapeSchemaBehavior} from './generic-binder.js';
 import {ComponentContext} from './component-context.js';
 import {SurfaceModel} from '../state/surface-model.js';
 import {Catalog} from '../catalog/types.js';
@@ -316,5 +316,164 @@ describe('GenericBinder Checkable Trait', () => {
       extra: 'another_prop',
     };
     assert.strictEqual(notificationCount, 1);
+  });
+
+  it('should resolve STRUCTURAL ChildList bindings using id instead of componentId', async () => {
+    const {surface} = setupSurfaceAndMocks();
+    surface.dataModel.set('/rows', [{name: 'Row 1'}, {name: 'Row 2'}]);
+
+    const structuralSchema = z.object({
+      children: CommonSchemas.ChildList,
+    });
+
+    const compModel = new ComponentModel('c9', 'List', {
+      children: {
+        id: 'row-template',
+        path: '/rows',
+      },
+    });
+    surface.componentsModel.addComponent(compModel);
+
+    const context = new ComponentContext(surface, 'c9');
+    const binder = new GenericBinder<any>(context, structuralSchema);
+
+    assert.deepStrictEqual(binder.snapshot.children, [
+      {id: 'row-template', basePath: '/rows/0'},
+      {id: 'row-template', basePath: '/rows/1'},
+    ]);
+  });
+
+  describe('scrapeSchemaBehavior schema inference', () => {
+    it('should infer behavior from schema descriptions and property names', () => {
+      // Description-based matching
+      assert.deepStrictEqual(scrapeSchemaBehavior(z.any().describe('#/$defs/Action')), {
+        type: 'ACTION',
+      });
+      assert.deepStrictEqual(scrapeSchemaBehavior(z.any().describe('#/$defs/ChildList')), {
+        type: 'STRUCTURAL',
+      });
+      assert.deepStrictEqual(scrapeSchemaBehavior(z.any().describe('#/$defs/DynamicString')), {
+        type: 'DYNAMIC',
+      });
+      assert.deepStrictEqual(scrapeSchemaBehavior(z.any().describe('#/$defs/DataBinding')), {
+        type: 'DYNAMIC',
+      });
+
+      // Object properties matching
+      const objSchema = z.object({
+        action: z.any(),
+        children: z.any(),
+        text: z.any(),
+        label: z.any(),
+        value: z.any(),
+        url: z.any(),
+        checks: z.any(),
+      });
+
+      const behavior = scrapeSchemaBehavior(objSchema);
+      assert.strictEqual(behavior.type, 'OBJECT');
+      assert.strictEqual((behavior as any).shape.action.type, 'ACTION');
+      assert.strictEqual((behavior as any).shape.children.type, 'STRUCTURAL');
+      assert.strictEqual((behavior as any).shape.text.type, 'DYNAMIC');
+      assert.strictEqual((behavior as any).shape.label.type, 'DYNAMIC');
+      assert.strictEqual((behavior as any).shape.value.type, 'DYNAMIC');
+      assert.strictEqual((behavior as any).shape.url.type, 'DYNAMIC');
+      assert.strictEqual((behavior as any).shape.checks.type, 'CHECKABLE');
+
+      // Do not short-circuit to DYNAMIC if property is a nested ZodObject or ZodArray
+      const nestedSchema = z.object({
+        value: z.object({
+          nestedField: z.string().describe('#/$defs/DynamicString'),
+        }),
+        text: z.array(z.string().describe('#/$defs/DynamicString')),
+      });
+      const nestedBehavior = scrapeSchemaBehavior(nestedSchema);
+      assert.strictEqual(nestedBehavior.type, 'OBJECT');
+      assert.strictEqual((nestedBehavior as any).shape.value.type, 'OBJECT');
+      assert.strictEqual((nestedBehavior as any).shape.text.type, 'ARRAY');
+    });
+  });
+
+  describe('Static fallback behavior for unannotated schemas', () => {
+    it('should resolve dynamic path bindings in static schema properties reactively', async () => {
+      const {surface} = setupSurfaceAndMocks();
+      surface.dataModel.set('/rawTitle', 'Static Title');
+
+      const unannotatedSchema = z.object({
+        customProp: z.any(),
+      });
+
+      const compModel = new ComponentModel('c10', 'Custom', {
+        customProp: {path: '/rawTitle'},
+      });
+      surface.componentsModel.addComponent(compModel);
+
+      const context = new ComponentContext(surface, 'c10');
+      const binder = new GenericBinder<any>(context, unannotatedSchema);
+      binder.subscribe(() => {});
+
+      assert.strictEqual(binder.snapshot.customProp, 'Static Title');
+
+      surface.dataModel.set('/rawTitle', 'Updated Static Title');
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      assert.strictEqual(binder.snapshot.customProp, 'Updated Static Title');
+    });
+
+    it('should resolve structural templates in static schema properties', () => {
+      const {surface} = setupSurfaceAndMocks();
+      surface.dataModel.set('/cards', [{a: 1}, {a: 2}]);
+
+      const unannotatedSchema = z.object({
+        items: z.any(),
+      });
+
+      const compModel = new ComponentModel('c11', 'Custom', {
+        items: {id: 'card-view', path: '/cards'},
+      });
+      surface.componentsModel.addComponent(compModel);
+
+      const context = new ComponentContext(surface, 'c11');
+      const binder = new GenericBinder<any>(context, unannotatedSchema);
+
+      assert.deepStrictEqual(binder.snapshot.items, [
+        {id: 'card-view', basePath: '/cards/0'},
+        {id: 'card-view', basePath: '/cards/1'},
+      ]);
+    });
+
+    it('should resolve action events in static schema properties', () => {
+      const {surface} = setupSurfaceAndMocks();
+      surface.dataModel.set('/user/id', 42);
+
+      const unannotatedSchema = z.object({
+        handleClick: z.any(),
+      });
+
+      const compModel = new ComponentModel('c12', 'Custom', {
+        handleClick: {
+          event: {
+            name: 'custom_click',
+            context: {userId: {path: '/user/id'}},
+          },
+        },
+      });
+      surface.componentsModel.addComponent(compModel);
+
+      let dispatched: any = null;
+      surface.onAction.subscribe(a => {
+        dispatched = a;
+      });
+
+      const context = new ComponentContext(surface, 'c12');
+      const binder = new GenericBinder<any>(context, unannotatedSchema);
+
+      assert.strictEqual(typeof binder.snapshot.handleClick, 'function');
+      binder.snapshot.handleClick();
+
+      assert.ok(dispatched);
+      assert.strictEqual(dispatched.name, 'custom_click');
+      assert.deepStrictEqual(dispatched.context, {userId: 42});
+    });
   });
 });

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -16,7 +16,13 @@
 
 import {z} from 'zod';
 import {ComponentContext} from './component-context.js';
-import {Action, ChildList, DataBinding, FunctionCall} from '../schema/common-types.js';
+import {
+  Action,
+  ChildList,
+  DataBinding,
+  FunctionCall,
+  childRefKindOf,
+} from '../schema/common-types.js';
 
 // --- Schema Scraping ---
 
@@ -55,8 +61,15 @@ export function scrapeSchemaBehavior(schema: z.ZodTypeAny): BehaviorNode {
   return getFieldBehavior(schema);
 }
 
+// TODO(#2443): Export and reuse these schema reference constants from a central location across web_core.
+const ACTION_REF = 'REF:common_types.json#/$defs/Action';
+const DATA_BINDING_REF = 'REF:common_types.json#/$defs/DataBinding';
+const DYNAMIC_REF_PREFIX = '#/$defs/Dynamic';
+
 function getFieldBehavior(type: z.ZodTypeAny, propertyName?: string): BehaviorNode {
   let current = type;
+
+  let description = current._def?.description || '';
 
   // Unwrap optionals/nullables/defaults
   while (
@@ -64,11 +77,33 @@ function getFieldBehavior(type: z.ZodTypeAny, propertyName?: string): BehaviorNo
     current._def.typeName === 'ZodNullable' ||
     current._def.typeName === 'ZodDefault'
   ) {
+    if (!description && current._def.description) {
+      description = current._def.description;
+    }
     current = current._def.innerType;
+  }
+  if (!description && current._def.description) {
+    description = current._def.description;
   }
 
   if (propertyName === 'checks') {
     return {type: 'CHECKABLE'};
+  }
+
+  if (description.startsWith(ACTION_REF)) {
+    return {type: 'ACTION'};
+  }
+
+  if (childRefKindOf(current) === 'child-list' || description.includes('#/$defs/ChildList')) {
+    return {type: 'STRUCTURAL'};
+  }
+
+  if (
+    (description.startsWith(DATA_BINDING_REF) || description.includes(DYNAMIC_REF_PREFIX)) &&
+    current._def.typeName !== 'ZodObject' &&
+    current._def.typeName !== 'ZodArray'
+  ) {
+    return {type: 'DYNAMIC'};
   }
 
   // Structural matching for A2UI primitives using typeName to avoid dual-module instanceof issues
@@ -122,13 +157,21 @@ type DynamicTypes = DataBinding | FunctionCall;
 type IsDynamic<T> = DataBinding extends NonNullable<T> ? true : false;
 
 /**
+ * A resolved reference to a child component, containing its unique ID and bound data context path.
+ */
+export interface ResolvedChildRef {
+  id: string;
+  basePath: string;
+}
+
+/**
  * Maps raw Zod inferred types to their resolved runtime equivalents.
  * For example, an `Action` object becomes a callable `() => void` function.
  */
 export type ResolveA2uiProp<T> = [NonNullable<T>] extends [Action]
   ? (() => void) | Extract<T, undefined>
   : [NonNullable<T>] extends [ChildList]
-    ? any | Extract<T, undefined>
+    ? (string | ResolvedChildRef)[] | Extract<T, undefined>
     : Exclude<T, DynamicTypes> extends never
       ? any
       : Exclude<T, DynamicTypes>;
@@ -226,76 +269,97 @@ export class GenericBinder<T> {
     this.notify();
   }
 
-  private resolveAndBind(value: any, behavior: BehaviorNode, path: string[], isSync: boolean): any {
-    if (value === undefined || value === null) return value;
+  private bindDynamicValue(value: any, path: string[], isSync: boolean): any {
+    const bound = this.context.dataContext.subscribeDynamicValue(value, newVal => {
+      this.updateDeepValue(path, newVal);
+      this.notify();
+    });
 
-    switch (behavior.type) {
-      case 'DYNAMIC': {
-        const bound = this.context.dataContext.subscribeDynamicValue(value, newVal => {
-          this.updateDeepValue(path, newVal);
-          this.notify();
-        });
+    if (!isSync) {
+      this.dataListeners.push(() => bound.unsubscribe());
+    } else {
+      bound.unsubscribe();
+    }
+    return bound.value;
+  }
+
+  private bindAction(value: any, path: string[]): () => void {
+    const cacheKey = path.join('/');
+    const cached = this.actionClosures.get(cacheKey);
+    if (cached && jsonEquals(cached.raw, value)) {
+      return cached.closure;
+    }
+    const closure = () => {
+      const resolveDeepSync = (val: any): any => {
+        if (typeof val !== 'object' || val === null) return val;
+        if ('path' in val || 'call' in val) {
+          return this.context.dataContext.resolveDynamicValue(val);
+        }
+        if (Array.isArray(val)) return val.map(resolveDeepSync);
+        const res: any = {};
+        for (const [k, v] of Object.entries(val)) res[k] = resolveDeepSync(v);
+        return res;
+      };
+      this.context.dispatchAction(resolveDeepSync(value));
+    };
+    this.actionClosures.set(cacheKey, {raw: value, closure});
+    return closure;
+  }
+
+  private bindStructuralTemplate(
+    value: any,
+    path: string[],
+    isSync: boolean,
+  ): ResolvedChildRef[] | any {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const templatePath = value.path;
+      const templateComponentId = value.componentId;
+      if (templatePath && templateComponentId) {
+        const bound = this.context.dataContext.subscribeDynamicValue(
+          {path: templatePath},
+          newVal => {
+            const arr = Array.isArray(newVal) ? newVal : [];
+            const listContext = this.context.dataContext.nested(templatePath);
+            const resolvedChildren: ResolvedChildRef[] = arr.map((_, i) => ({
+              id: templateComponentId,
+              basePath: listContext.nested(String(i)).path,
+            }));
+            this.updateDeepValue(path, resolvedChildren);
+            this.notify();
+          },
+        );
 
         if (!isSync) {
           this.dataListeners.push(() => bound.unsubscribe());
         } else {
           bound.unsubscribe();
         }
-        return bound.value;
+
+        const currentArr = Array.isArray(bound.value) ? bound.value : [];
+        const listContext = this.context.dataContext.nested(templatePath);
+        return currentArr.map((_, i) => ({
+          id: templateComponentId,
+          basePath: listContext.nested(String(i)).path,
+        }));
+      }
+    }
+    return value;
+  }
+
+  private resolveAndBind(value: any, behavior: BehaviorNode, path: string[], isSync: boolean): any {
+    if (value === undefined || value === null) return value;
+
+    switch (behavior.type) {
+      case 'DYNAMIC': {
+        return this.bindDynamicValue(value, path, isSync);
       }
 
       case 'ACTION': {
-        const cacheKey = path.join('/');
-        const cached = this.actionClosures.get(cacheKey);
-        if (cached && jsonEquals(cached.raw, value)) {
-          return cached.closure;
-        }
-        const closure = () => {
-          const resolveDeepSync = (val: any): any => {
-            if (typeof val !== 'object' || val === null) return val;
-            if ('path' in val || 'call' in val)
-              return this.context.dataContext.resolveDynamicValue(val);
-            if (Array.isArray(val)) return val.map(resolveDeepSync);
-            const res: any = {};
-            for (const [k, v] of Object.entries(val)) res[k] = resolveDeepSync(v);
-            return res;
-          };
-          this.context.dispatchAction(resolveDeepSync(value));
-        };
-        this.actionClosures.set(cacheKey, {raw: value, closure});
-        return closure;
+        return this.bindAction(value, path);
       }
 
       case 'STRUCTURAL': {
-        if (value && typeof value === 'object' && value.path && value.componentId) {
-          const bound = this.context.dataContext.subscribeDynamicValue(
-            {path: value.path},
-            newVal => {
-              const arr = Array.isArray(newVal) ? newVal : [];
-              const listContext = this.context.dataContext.nested(value.path);
-              const resolvedChildren = arr.map((_, i) => ({
-                id: value.componentId,
-                basePath: listContext.nested(String(i)).path,
-              }));
-              this.updateDeepValue(path, resolvedChildren);
-              this.notify();
-            },
-          );
-
-          if (!isSync) {
-            this.dataListeners.push(() => bound.unsubscribe());
-          } else {
-            bound.unsubscribe();
-          }
-
-          const currentArr = Array.isArray(bound.value) ? bound.value : [];
-          const listContext = this.context.dataContext.nested(value.path);
-          return currentArr.map((_, i) => ({
-            id: value.componentId,
-            basePath: listContext.nested(String(i)).path,
-          }));
-        }
-        return value;
+        return this.bindStructuralTemplate(value, path, isSync);
       }
 
       case 'CHECKABLE': {
@@ -339,8 +403,9 @@ export class GenericBinder<T> {
         return value; // The 'checks' property itself remains as the original rules array
       }
 
-      case 'STATIC':
+      case 'STATIC': {
         return value;
+      }
 
       case 'ARRAY': {
         if (!Array.isArray(value)) return value;

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -58,17 +58,50 @@ export function scrapeSchemaBehavior(schema: z.ZodTypeAny): BehaviorNode {
 function getFieldBehavior(type: z.ZodTypeAny, propertyName?: string): BehaviorNode {
   let current = type;
 
+  let description = current._def?.description || '';
+
   // Unwrap optionals/nullables/defaults
   while (
     current._def.typeName === 'ZodOptional' ||
     current._def.typeName === 'ZodNullable' ||
     current._def.typeName === 'ZodDefault'
   ) {
+    if (!description && current._def.description) {
+      description = current._def.description;
+    }
     current = current._def.innerType;
+  }
+  if (!description && current._def.description) {
+    description = current._def.description;
   }
 
   if (propertyName === 'checks') {
     return {type: 'CHECKABLE'};
+  }
+
+  if (
+    propertyName === 'action' ||
+    description.includes('#/$defs/Action') ||
+    description.includes('Triggers a server-side event')
+  ) {
+    return {type: 'ACTION'};
+  }
+
+  if (propertyName === 'children' || description.includes('#/$defs/ChildList')) {
+    return {type: 'STRUCTURAL'};
+  }
+
+  if (
+    (propertyName === 'text' ||
+      propertyName === 'label' ||
+      propertyName === 'value' ||
+      propertyName === 'url' ||
+      description.includes('#/$defs/Dynamic') ||
+      description.includes('#/$defs/DataBinding')) &&
+    current._def.typeName !== 'ZodObject' &&
+    current._def.typeName !== 'ZodArray'
+  ) {
+    return {type: 'DYNAMIC'};
   }
 
   // Structural matching for A2UI primitives using typeName to avoid dual-module instanceof issues
@@ -122,13 +155,21 @@ type DynamicTypes = DataBinding | FunctionCall;
 type IsDynamic<T> = DataBinding extends NonNullable<T> ? true : false;
 
 /**
+ * A resolved reference to a child component, containing its unique ID and bound data context path.
+ */
+export interface ResolvedChildRef {
+  id: string;
+  basePath: string;
+}
+
+/**
  * Maps raw Zod inferred types to their resolved runtime equivalents.
  * For example, an `Action` object becomes a callable `() => void` function.
  */
 export type ResolveA2uiProp<T> = [NonNullable<T>] extends [Action]
   ? (() => void) | Extract<T, undefined>
   : [NonNullable<T>] extends [ChildList]
-    ? any | Extract<T, undefined>
+    ? (string | ResolvedChildRef)[] | Extract<T, undefined>
     : Exclude<T, DynamicTypes> extends never
       ? any
       : Exclude<T, DynamicTypes>;
@@ -226,76 +267,97 @@ export class GenericBinder<T> {
     this.notify();
   }
 
-  private resolveAndBind(value: any, behavior: BehaviorNode, path: string[], isSync: boolean): any {
-    if (value === undefined || value === null) return value;
+  private bindDynamicValue(value: any, path: string[], isSync: boolean): any {
+    const bound = this.context.dataContext.subscribeDynamicValue(value, newVal => {
+      this.updateDeepValue(path, newVal);
+      this.notify();
+    });
 
-    switch (behavior.type) {
-      case 'DYNAMIC': {
-        const bound = this.context.dataContext.subscribeDynamicValue(value, newVal => {
-          this.updateDeepValue(path, newVal);
-          this.notify();
-        });
+    if (!isSync) {
+      this.dataListeners.push(() => bound.unsubscribe());
+    } else {
+      bound.unsubscribe();
+    }
+    return bound.value;
+  }
+
+  private bindAction(value: any, path: string[]): () => void {
+    const cacheKey = path.join('/');
+    const cached = this.actionClosures.get(cacheKey);
+    if (cached && jsonEquals(cached.raw, value)) {
+      return cached.closure;
+    }
+    const closure = () => {
+      const resolveDeepSync = (val: any): any => {
+        if (typeof val !== 'object' || val === null) return val;
+        if ('path' in val || 'call' in val) {
+          return this.context.dataContext.resolveDynamicValue(val);
+        }
+        if (Array.isArray(val)) return val.map(resolveDeepSync);
+        const res: any = {};
+        for (const [k, v] of Object.entries(val)) res[k] = resolveDeepSync(v);
+        return res;
+      };
+      this.context.dispatchAction(resolveDeepSync(value));
+    };
+    this.actionClosures.set(cacheKey, {raw: value, closure});
+    return closure;
+  }
+
+  private bindStructuralTemplate(
+    value: any,
+    path: string[],
+    isSync: boolean,
+  ): ResolvedChildRef[] | any {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const templatePath = value.path;
+      const templateComponentId = value.componentId || value.id;
+      if (templatePath && templateComponentId) {
+        const bound = this.context.dataContext.subscribeDynamicValue(
+          {path: templatePath},
+          newVal => {
+            const arr = Array.isArray(newVal) ? newVal : [];
+            const listContext = this.context.dataContext.nested(templatePath);
+            const resolvedChildren: ResolvedChildRef[] = arr.map((_, i) => ({
+              id: templateComponentId,
+              basePath: listContext.nested(String(i)).path,
+            }));
+            this.updateDeepValue(path, resolvedChildren);
+            this.notify();
+          },
+        );
 
         if (!isSync) {
           this.dataListeners.push(() => bound.unsubscribe());
         } else {
           bound.unsubscribe();
         }
-        return bound.value;
+
+        const currentArr = Array.isArray(bound.value) ? bound.value : [];
+        const listContext = this.context.dataContext.nested(templatePath);
+        return currentArr.map((_, i) => ({
+          id: templateComponentId,
+          basePath: listContext.nested(String(i)).path,
+        }));
+      }
+    }
+    return value;
+  }
+
+  private resolveAndBind(value: any, behavior: BehaviorNode, path: string[], isSync: boolean): any {
+    if (value === undefined || value === null) return value;
+
+    switch (behavior.type) {
+      case 'DYNAMIC': {
+        return this.bindDynamicValue(value, path, isSync);
       }
 
       case 'ACTION': {
-        const cacheKey = path.join('/');
-        const cached = this.actionClosures.get(cacheKey);
-        if (cached && jsonEquals(cached.raw, value)) {
-          return cached.closure;
-        }
-        const closure = () => {
-          const resolveDeepSync = (val: any): any => {
-            if (typeof val !== 'object' || val === null) return val;
-            if ('path' in val || 'call' in val)
-              return this.context.dataContext.resolveDynamicValue(val);
-            if (Array.isArray(val)) return val.map(resolveDeepSync);
-            const res: any = {};
-            for (const [k, v] of Object.entries(val)) res[k] = resolveDeepSync(v);
-            return res;
-          };
-          this.context.dispatchAction(resolveDeepSync(value));
-        };
-        this.actionClosures.set(cacheKey, {raw: value, closure});
-        return closure;
+        return this.bindAction(value, path);
       }
 
       case 'STRUCTURAL': {
-        if (value && typeof value === 'object' && value.path && value.componentId) {
-          const bound = this.context.dataContext.subscribeDynamicValue(
-            {path: value.path},
-            newVal => {
-              const arr = Array.isArray(newVal) ? newVal : [];
-              const listContext = this.context.dataContext.nested(value.path);
-              const resolvedChildren = arr.map((_, i) => ({
-                id: value.componentId,
-                basePath: listContext.nested(String(i)).path,
-              }));
-              this.updateDeepValue(path, resolvedChildren);
-              this.notify();
-            },
-          );
-
-          if (!isSync) {
-            this.dataListeners.push(() => bound.unsubscribe());
-          } else {
-            bound.unsubscribe();
-          }
-
-          const currentArr = Array.isArray(bound.value) ? bound.value : [];
-          const listContext = this.context.dataContext.nested(value.path);
-          return currentArr.map((_, i) => ({
-            id: value.componentId,
-            basePath: listContext.nested(String(i)).path,
-          }));
-        }
-        return value;
+        return this.bindStructuralTemplate(value, path, isSync);
       }
 
       case 'CHECKABLE': {
@@ -339,8 +401,20 @@ export class GenericBinder<T> {
         return value; // The 'checks' property itself remains as the original rules array
       }
 
-      case 'STATIC':
+      case 'STATIC': {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          if (('componentId' in value || 'id' in value) && 'path' in value) {
+            return this.bindStructuralTemplate(value, path, isSync);
+          }
+          if ('path' in value || 'call' in value) {
+            return this.bindDynamicValue(value, path, isSync);
+          }
+          if ('event' in value || 'functionCall' in value) {
+            return this.bindAction(value, path);
+          }
+        }
         return value;
+      }
 
       case 'ARRAY': {
         if (!Array.isArray(value)) return value;

--- a/renderers/web_core/tsconfig.json
+++ b/renderers/web_core/tsconfig.json
@@ -40,5 +40,6 @@
     "strictTemplates": true,
     "strictPropertyInitialization": false
   },
-  "include": ["src/**/*.ts", "src/**/*.json"]
+  "include": ["src/**/*.ts", "src/**/*.json"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# Description

Enhances `@a2ui/web_core` `GenericBinder` and `scrapeSchemaBehavior` to recognize schema `$defs` references and child-reference metadata during schema inference, types resolved child lists, and guards structural template parsing.

## Motivation

In `@a2ui/web_core`, `scrapeSchemaBehavior` previously identified A2UI primitives (`Action`, `DataBinding`, `ChildList`) solely through structural union checks (`ZodUnion` options). When component schemas were defined using descriptions referencing `$defs` (such as `#/$defs/Action`, `#/$defs/ChildList`, `#/$defs/DynamicString`, or `REF:common_types.json#/$defs/DataBinding`), or using custom metadata like `a2uiChildRef`, `scrapeSchemaBehavior` failed to match them and defaulted to `STATIC`.

Additionally, child lists inferred through `ResolveA2uiProp` resolved to `any`, and structural binding did not explicitly guard against arrays before checking template object fields.

## Key Changes

1. **Schema Description and Metadata Matching (`scrapeSchemaBehavior`)**:
   - Inspects `_def.description` across unwrapped `ZodOptional`, `ZodNullable`, and `ZodDefault` wrappers.
   - Detects action schemas via `ACTION_REF` (`REF:common_types.json#/$defs/Action`) or description text matching `Triggers a server-side event`.
   - Detects child lists via `_def.a2uiChildRef === 'child-list'` or `#/$defs/ChildList` in descriptions.
   - Detects dynamic bindings via `DATA_BINDING_REF` (`REF:common_types.json#/$defs/DataBinding`) or `#/$defs/Dynamic`, while excluding `ZodObject` and `ZodArray` so nested containers continue recursive traversal.

2. **Array Guard in Structural Template Binding (`GenericBinder`)**:
   - Adds an `!Array.isArray(value)` check in `bindStructuralTemplate` so static child ID arrays (`string[]`) pass through untouched and are not evaluated as `{ path, componentId }` templates.

3. **Type Improvements (`ResolveA2uiProp`)**:
   - Exports the `ResolvedChildRef` interface (`{ id: string; basePath: string }`).
   - Updates `ResolveA2uiProp<T>` to type `ChildList` properties as `(string | ResolvedChildRef)[]` instead of `any`.

4. **Internal Binding Modularization**:
   - Extracts `bindDynamicValue`, `bindAction`, and `bindStructuralTemplate` from `resolveAndBind` for clearer separation of binding logic.

5. **Build and Test Coverage**:
   - Adds unit tests in `generic-binder.test.ts` verifying description-based inference, nested object/array traversal, and static pass-through for unannotated schemas.
   - Updates `renderers/web_core/tsconfig.json` to exclude `node_modules` and `dist`.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].
- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples

Related to #1270