### PR TITLE
ci: switch GitHub Actions runners to ubuntu-latest

### DIFF
--- a/.github/workflows/community_code.yml
+++ b/.github/workflows/community_code.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   web:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: samples/community
@@ -68,7 +68,7 @@ jobs:
         run: yarn workspace custom-lit-components run build
 
   python:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   changes:
     if: github.repository == 'a2ui-project/a2ui'
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -67,7 +67,7 @@ jobs:
   build_and_deploy:
     needs: changes
     if: github.repository == 'a2ui-project/a2ui' && (github.event_name == 'push' || needs.changes.outputs.docs == 'true')
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     # Requires write access to publish built documentation to gh-pages branch
     permissions:
       contents: write

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -26,7 +26,7 @@ jobs:
     # Do not run on forked branches,
     # because the test does not have access to secrets in forks.
     if: github.repository == 'a2ui-project/a2ui'
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/flutter_packages_test.yml
+++ b/.github/workflows/flutter_packages_test.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
       flutter_version: ${{ steps.generate_matrix.outputs.flutter_version }}
@@ -70,7 +70,7 @@ jobs:
           fi
 
   cycle-check:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/kotlin_agent_sdk_build_and_test.yml
+++ b/.github/workflows/kotlin_agent_sdk_build_and_test.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   static-checks:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -66,7 +66,7 @@ jobs:
         run: ./scripts/fix_licenses.py --check
 
   format-check:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -87,7 +87,7 @@ jobs:
         run: ./scripts/fix_format.sh --check
 
   workspace-lint:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -48,7 +48,7 @@ permissions:
 
 jobs:
   python-ci:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/remediate_chatops.yml
+++ b/.github/workflows/remediate_chatops.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   run-remediation:
     name: Execute Automated Remediation Draft PR
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     if: >
       !github.event.issue.pull_request &&

--- a/.github/workflows/run_evals.yml
+++ b/.github/workflows/run_evals.yml
@@ -35,7 +35,7 @@ on:
     - cron: "0 0 * * *" # daily
 jobs:
   run-evals:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -54,7 +54,9 @@ on:
 # result on its own, and the daily cron is a backstop either way.
 concurrency:
   group: triage
-  cancel-in-progress: true
+  # Not cancelling in-progress runs because otherwise some issues go unlabled
+  # when multiple issues arrive concurrently.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/validate_blueprints.yml
+++ b/.github/workflows/validate_blueprints.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   validate-blueprints:
     name: Validate Blueprints
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/validate_specifications.yml
+++ b/.github/workflows/validate_specifications.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   validate:
     name: Validate Specifications
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     permissions:
       contents: read
 

--- a/.github/workflows/web_ci.yml
+++ b/.github/workflows/web_ci.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     outputs:
       renderers: ${{ steps.filter.outputs.renderers }}
       tools: ${{ steps.filter.outputs.tools }}
@@ -81,7 +81,7 @@ jobs:
   ci-renderers:
     needs: changes
     if: ${{ needs.changes.outputs.renderers == 'true' }}
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     # Healthy runs finish in ~20 min. Cap the job so a hung test fails fast
     # instead of running to the default 6h timeout (see issue #1637).
     timeout-minutes: 30
@@ -109,7 +109,7 @@ jobs:
   ci-tools:
     needs: changes
     if: ${{ needs.changes.outputs.tools == 'true' }}
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -125,7 +125,7 @@ jobs:
   ci-samples:
     needs: changes
     if: ${{ needs.changes.outputs.samples == 'true' }}
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -143,7 +143,7 @@ jobs:
   ci-scripts:
     needs: changes
     if: ${{ needs.changes.outputs.scripts == 'true' }}
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -157,7 +157,7 @@ jobs:
   ci-other:
     needs: changes
     if: ${{ needs.changes.outputs.other == 'true' }}
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   run-audit:
     name: Execute Antigravity Compliance Audit
-    runs-on: ubuntu-latest-extra-capacity
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     # Requires issue write permissions to create compliance audit reports
     permissions:


### PR DESCRIPTION
## Summary
Switches GitHub Actions workflows across the repository from `ubuntu-latest-extra-capacity` runners to the standard `ubuntu-latest` runner pool to prevent capacity starvation, and updates the triage workflow concurrency setting.

## Changes
- Updated all GitHub Actions workflows using `ubuntu-latest-extra-capacity` to use `ubuntu-latest`:
  - `.github/workflows/community_code.yml`
  - `.github/workflows/docs.yml`
  - `.github/workflows/e2e_test.yml`
  - `.github/workflows/flutter_packages_test.yml`
  - `.github/workflows/kotlin_agent_sdk_build_and_test.yml`
  - `.github/workflows/presubmit-lint.yml`
  - `.github/workflows/python_ci.yml`
  - `.github/workflows/remediate_chatops.yml`
  - `.github/workflows/run_evals.yml`
  - `.github/workflows/triage.yml`
  - `.github/workflows/validate_blueprints.yml`
  - `.github/workflows/validate_specifications.yml`
  - `.github/workflows/web_ci.yml`
  - `.github/workflows/weekly-audit.yml`
- In `.github/workflows/triage.yml`, set `concurrency.cancel-in-progress` to `false` so concurrent issue events do not cancel running triage executions and leave issues unlabeled.

## Impact & Risks
- **Impact**: Workflows will run on standard GitHub-hosted runners, avoiding queue delays caused by capacity limits on the `ubuntu-latest-extra-capacity` pool. Triage workflow runs will complete sequentially without cancelling in-flight runs.
- **Risks**: Jobs will run with default runner resource allocations rather than extra-capacity resources.

## Testing
- Verified syntax across modified YAML workflow files.
- CI workflows triggered by this pull request will run on `ubuntu-latest`.
