### PR TITLE
fix(swift): use CLDR plural rules by default

### DIFF
--- a/swift/core/Sources/BasicCatalog/Functions/CLDRPluralResolver.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/CLDRPluralResolver.swift
@@ -16,98 +16,154 @@ import Foundation
 
 /// Resolves cardinal plural categories using the Unicode CLDR rules.
 ///
-/// The implementation is a dependency-free port of the CLDR 48 cardinal rules. Numeric values use
-/// the same default formatting behavior as `Intl.PluralRules`: at most three fractional digits,
-/// rounded half away from zero.
+/// The implementation is a dependency-free port of the CLDR 48 cardinal rules. Numeric operands
+/// mirror ICU's `PluralRules::select(double)` / `FixedDecimal(double)` behavior.
 ///
 /// Source data: `unicode-org/cldr` release 48, `common/supplemental/plurals.xml`.
 public final class CLDRPluralResolver: PluralResolver, Sendable {
-  private let localeIdentifier: String
+  private let ruleSet: RuleSet
 
   /// Creates a resolver for a Foundation locale.
   public init(locale: Locale = .current) {
-    self.localeIdentifier = locale.identifier
+    self.ruleSet = Self.ruleSet(for: locale.identifier)
   }
 
   /// Creates a resolver for a BCP-47 or POSIX locale identifier.
   public init(localeIdentifier: String) {
-    self.localeIdentifier = localeIdentifier
+    self.ruleSet = Self.ruleSet(for: localeIdentifier)
   }
 
   public func pluralCategory(for value: Double) -> PluralCategory {
     guard value.isFinite else { return .other }
     let operands = Operands(abs(value))
-    return Self.ruleSet(for: localeIdentifier).category(for: operands)
+    return ruleSet.category(for: operands)
   }
 }
 
 extension CLDRPluralResolver {
   private struct Operands {
-    let integer: Double
+    let number: Double
+    let integer: Int64
     let visibleFractionDigitCount: Int
     let fractionDigits: Int
+    let fractionDigitsWithoutTrailingZeros: Int
 
     init(_ value: Double) {
-      // Values at or above 2^53 have no representable fractional component. Avoid scaling those
-      // values, which could overflow Int64.
-      if value >= 9_007_199_254_740_992 {
-        self.integer = value
+      self.number = value
+
+      let int64UpperBound = Double(Int64.max)
+      if value > int64UpperBound {
+        self.integer = 0
         self.visibleFractionDigitCount = 0
         self.fractionDigits = 0
+        self.fractionDigitsWithoutTrailingZeros = 0
         return
       }
 
-      let scaled = Int64((value * 1_000).rounded(.toNearestOrAwayFromZero))
-      let fraction = Int(scaled % 1_000)
-      self.integer = Double(scaled / 1_000)
-
-      if fraction == 0 {
-        self.visibleFractionDigitCount = 0
-        self.fractionDigits = 0
-      } else if fraction % 100 == 0 {
-        self.visibleFractionDigitCount = 1
-        self.fractionDigits = fraction / 100
-      } else if fraction % 10 == 0 {
-        self.visibleFractionDigitCount = 2
-        self.fractionDigits = fraction / 10
+      // Converting Double(Int64.max) reproduces the boundary behavior of the Clang conversion used
+      // by ICU's FixedDecimal on supported Apple platforms. Double(Int64.max) is exactly 2^63.
+      if value == int64UpperBound {
+        self.integer = .min
       } else {
-        self.visibleFractionDigitCount = 3
-        self.fractionDigits = fraction
+        self.integer = Int64(value)
       }
+
+      let visibleDigits = Self.visibleFractionDigitCount(of: value)
+      self.visibleFractionDigitCount = visibleDigits
+      let fractionDigits = Self.fractionDigits(of: value, visibleDigitCount: visibleDigits)
+      self.fractionDigits = fractionDigits
+      self.fractionDigitsWithoutTrailingZeros = Self.removingTrailingZeros(from: fractionDigits)
     }
 
-    var isInteger: Bool { visibleFractionDigitCount == 0 }
+    var isInteger: Bool { number == number.rounded(.down) }
 
     func integerIs(_ values: Int...) -> Bool {
-      values.contains { Double($0) == integer }
+      values.contains { Int64($0) == integer }
     }
 
     func integerIs(in range: ClosedRange<Int>) -> Bool {
-      integer >= Double(range.lowerBound) && integer <= Double(range.upperBound)
+      integer >= Int64(range.lowerBound) && integer <= Int64(range.upperBound)
     }
 
     func integerModulo(_ divisor: Int) -> Int {
-      Int(integer.truncatingRemainder(dividingBy: Double(divisor)))
+      Int(integer % Int64(divisor))
     }
 
     func numberIs(_ values: Int...) -> Bool {
-      isInteger && values.contains { Double($0) == integer }
+      isInteger && values.contains { Double($0) == number }
     }
 
     func numberIs(in range: ClosedRange<Int>) -> Bool {
-      isInteger && integerIs(in: range)
+      isInteger && number >= Double(range.lowerBound) && number <= Double(range.upperBound)
     }
 
     func numberModulo(_ divisor: Int, is values: Int...) -> Bool {
-      isInteger && values.contains(integerModulo(divisor))
+      isInteger && values.contains(numberModulo(divisor))
     }
 
     func numberModulo(_ divisor: Int, isIn range: ClosedRange<Int>) -> Bool {
-      isInteger && range.contains(integerModulo(divisor))
+      isInteger && range.contains(numberModulo(divisor))
+    }
+
+    func numberModulo(_ divisor: Int) -> Int {
+      Int(number.truncatingRemainder(dividingBy: Double(divisor)))
+    }
+
+    private static func visibleFractionDigitCount(of value: Double) -> Int {
+      let powersOfTen = [1.0, 10.0, 100.0, 1_000.0]
+      for (digitCount, power) in powersOfTen.enumerated()
+      where value * power == (value * power).rounded(.down) {
+        return digitCount
+      }
+
+      // ICU's FixedDecimal slow path uses snprintf("%1.15e") and trims trailing zeroes from the
+      // 15-digit mantissa before accounting for the scientific exponent.
+      let scientific = String(format: "%1.15e", value)
+      guard let exponentIndex = scientific.firstIndex(where: { $0 == "e" || $0 == "E" }) else {
+        return 0
+      }
+      let mantissa = scientific[..<exponentIndex]
+      let exponentStart = scientific.index(after: exponentIndex)
+      guard let exponent = Int(scientific[exponentStart...]) else { return 0 }
+      let mantissaFraction = mantissa.split(separator: ".", maxSplits: 1).last ?? ""
+      let significantFractionCount =
+        mantissaFraction.drop(while: { $0 == "0" }).isEmpty
+        ? 0
+        : mantissaFraction.lastIndex(where: { $0 != "0" }).map {
+          mantissaFraction.distance(from: mantissaFraction.startIndex, to: $0) + 1
+        } ?? 0
+      return significantFractionCount - exponent
+    }
+
+    private static func fractionDigits(of value: Double, visibleDigitCount: Int) -> Int {
+      guard visibleDigitCount != 0, value != value.rounded(.down) else { return 0 }
+      let fraction = value - value.rounded(.down)
+      let scaled: Double
+      switch visibleDigitCount {
+      case 1:
+        scaled = fraction * 10.0 + 0.5
+      case 2:
+        scaled = fraction * 100.0 + 0.5
+      case 3:
+        scaled = fraction * 1_000.0 + 0.5
+      default:
+        scaled = fraction * pow(10.0, Double(visibleDigitCount)) + 0.5
+      }
+      guard scaled < Double(Int64.max) else { return Int(Int64.max) }
+      return Int(scaled.rounded(.down))
+    }
+
+    private static func removingTrailingZeros(from value: Int) -> Int {
+      guard value != 0 else { return 0 }
+      var result = value
+      while result % 10 == 0 {
+        result /= 10
+      }
+      return result
     }
   }
 
-  private enum RuleSet {
+  private enum RuleSet: Sendable {
     case arabic
     case belarusian
     case breton
@@ -245,11 +301,11 @@ extension CLDRPluralResolver {
 
     private static func belarusianCategory(_ operands: Operands) -> PluralCategory {
       guard operands.isInteger else { return .other }
-      if operands.integerModulo(10) == 1 && operands.integerModulo(100) != 11 {
+      if operands.numberModulo(10) == 1 && operands.numberModulo(100) != 11 {
         return .one
       }
-      if (2...4).contains(operands.integerModulo(10))
-        && !(12...14).contains(operands.integerModulo(100))
+      if (2...4).contains(operands.numberModulo(10))
+        && !(12...14).contains(operands.numberModulo(100))
       {
         return .few
       }
@@ -258,8 +314,8 @@ extension CLDRPluralResolver {
 
     private static func bretonCategory(_ operands: Operands) -> PluralCategory {
       guard operands.isInteger else { return .other }
-      let modulo10 = operands.integerModulo(10)
-      let modulo100 = operands.integerModulo(100)
+      let modulo10 = operands.numberModulo(10)
+      let modulo100 = operands.numberModulo(100)
       if modulo10 == 1 && ![11, 71, 91].contains(modulo100) { return .one }
       if modulo10 == 2 && ![12, 72, 92].contains(modulo100) { return .two }
       if [3, 4, 9].contains(modulo10)
@@ -269,7 +325,7 @@ extension CLDRPluralResolver {
       {
         return .few
       }
-      if !operands.numberIs(0) && operands.integerModulo(1_000_000) == 0 {
+      if !operands.numberIs(0) && operands.numberModulo(1_000_000) == 0 {
         return .many
       }
       return .other
@@ -286,10 +342,10 @@ extension CLDRPluralResolver {
       if operands.numberIs(0) { return .zero }
       if operands.numberIs(1) { return .one }
 
-      let modulo100 = operands.integerModulo(100)
-      let moduloOneThousand = operands.integerModulo(1_000)
-      let moduloOneHundredThousand = operands.integerModulo(100_000)
-      let moduloOneMillion = operands.integerModulo(1_000_000)
+      let modulo100 = operands.numberModulo(100)
+      let moduloOneThousand = operands.numberModulo(1_000)
+      let moduloOneHundredThousand = operands.numberModulo(100_000)
+      let moduloOneMillion = operands.numberModulo(1_000_000)
       if [2, 22, 42, 62, 82].contains(modulo100)
         || (moduloOneThousand == 0
           && ((1_000...20_000).contains(moduloOneHundredThousand)
@@ -352,12 +408,13 @@ extension CLDRPluralResolver {
     }
 
     private static func icelandicCategory(_ operands: Operands) -> PluralCategory {
-      if (operands.fractionDigits == 0
+      let fractionDigits = operands.fractionDigitsWithoutTrailingZeros
+      if (fractionDigits == 0
         && operands.integerModulo(10) == 1
         && operands.integerModulo(100) != 11)
-        || (operands.fractionDigits != 0
-          && operands.fractionDigits % 10 == 1
-          && operands.fractionDigits % 100 != 11)
+        || (fractionDigits != 0
+          && fractionDigits % 10 == 1
+          && fractionDigits % 100 != 11)
       {
         return .one
       }
@@ -612,11 +669,14 @@ extension CLDRPluralResolver {
   private static func ruleSet(for identifier: String) -> RuleSet {
     let locale = languageAndRegion(identifier)
     switch locale.language {
-    case "am", "as", "bn", "doi", "fa", "gu", "hi", "kn", "kok", "pcm", "zu":
+    // These identifiers fall back to root in the pinned swift-foundation-icu data bundle.
+    case "cv", "ie", "kok", "sgs":
+      return .otherOnly
+    case "am", "as", "bn", "doi", "fa", "gu", "hi", "kn", "pcm", "zu":
       return .oneWhenI0OrN1
     case "ff", "hy", "kab":
       return .oneWhenI0Or1
-    case "ast", "de", "en", "et", "fi", "fy", "gl", "ia", "ie", "io", "ji", "lij",
+    case "ast", "de", "en", "et", "fi", "fy", "gl", "ia", "io", "ji", "lij",
       "nl", "sc", "sv", "sw", "ur", "yi":
       return .oneWhenI1V0
     case "si":
@@ -646,7 +706,7 @@ extension CLDRPluralResolver {
       return .latvian
     case "lag":
       return .langi
-    case "blo", "cv", "ksh":
+    case "blo", "ksh":
       return .colognian
     case "he", "iw":
       return .hebrew
@@ -682,8 +742,6 @@ extension CLDRPluralResolver {
       return .lithuanian
     case "ru", "uk":
       return .russian
-    case "sgs":
-      return .samogitian
     case "br":
       return .breton
     case "mt":
@@ -707,11 +765,13 @@ extension CLDRPluralResolver {
     _ identifier: String
   ) -> (language: String, region: String?) {
     let withoutKeyword = identifier.split(separator: "@", maxSplits: 1).first ?? ""
-    let baseIdentifier = withoutKeyword.split(separator: ".", maxSplits: 1).first ?? ""
-    let subtags = baseIdentifier.split { $0 == "-" || $0 == "_" }
+    let subtags = withoutKeyword.split { $0 == "-" || $0 == "_" }
     guard let language = subtags.first else { return ("", nil) }
 
     for subtag in subtags.dropFirst() {
+      if subtag.count == 1 && subtag.allSatisfy({ $0.isLetter || $0.isNumber }) {
+        break
+      }
       if subtag.count == 2 && subtag.allSatisfy(\.isLetter) {
         return (language.lowercased(), subtag.uppercased())
       }

--- a/swift/core/Sources/BasicCatalog/Functions/CLDRPluralResolver.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/CLDRPluralResolver.swift
@@ -1,0 +1,724 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Resolves cardinal plural categories using the Unicode CLDR rules.
+///
+/// The implementation is a dependency-free port of the CLDR 48 cardinal rules. Numeric values use
+/// the same default formatting behavior as `Intl.PluralRules`: at most three fractional digits,
+/// rounded half away from zero.
+///
+/// Source data: `unicode-org/cldr` release 48, `common/supplemental/plurals.xml`.
+public final class CLDRPluralResolver: PluralResolver, Sendable {
+  private let localeIdentifier: String
+
+  /// Creates a resolver for a Foundation locale.
+  public init(locale: Locale = .current) {
+    self.localeIdentifier = locale.identifier
+  }
+
+  /// Creates a resolver for a BCP-47 or POSIX locale identifier.
+  public init(localeIdentifier: String) {
+    self.localeIdentifier = localeIdentifier
+  }
+
+  public func pluralCategory(for value: Double) -> PluralCategory {
+    guard value.isFinite else { return .other }
+    let operands = Operands(abs(value))
+    return Self.ruleSet(for: localeIdentifier).category(for: operands)
+  }
+}
+
+extension CLDRPluralResolver {
+  private struct Operands {
+    let integer: Double
+    let visibleFractionDigitCount: Int
+    let fractionDigits: Int
+
+    init(_ value: Double) {
+      // Values at or above 2^53 have no representable fractional component. Avoid scaling those
+      // values, which could overflow Int64.
+      if value >= 9_007_199_254_740_992 {
+        self.integer = value
+        self.visibleFractionDigitCount = 0
+        self.fractionDigits = 0
+        return
+      }
+
+      let scaled = Int64((value * 1_000).rounded(.toNearestOrAwayFromZero))
+      let fraction = Int(scaled % 1_000)
+      self.integer = Double(scaled / 1_000)
+
+      if fraction == 0 {
+        self.visibleFractionDigitCount = 0
+        self.fractionDigits = 0
+      } else if fraction % 100 == 0 {
+        self.visibleFractionDigitCount = 1
+        self.fractionDigits = fraction / 100
+      } else if fraction % 10 == 0 {
+        self.visibleFractionDigitCount = 2
+        self.fractionDigits = fraction / 10
+      } else {
+        self.visibleFractionDigitCount = 3
+        self.fractionDigits = fraction
+      }
+    }
+
+    var isInteger: Bool { visibleFractionDigitCount == 0 }
+
+    func integerIs(_ values: Int...) -> Bool {
+      values.contains { Double($0) == integer }
+    }
+
+    func integerIs(in range: ClosedRange<Int>) -> Bool {
+      integer >= Double(range.lowerBound) && integer <= Double(range.upperBound)
+    }
+
+    func integerModulo(_ divisor: Int) -> Int {
+      Int(integer.truncatingRemainder(dividingBy: Double(divisor)))
+    }
+
+    func numberIs(_ values: Int...) -> Bool {
+      isInteger && values.contains { Double($0) == integer }
+    }
+
+    func numberIs(in range: ClosedRange<Int>) -> Bool {
+      isInteger && integerIs(in: range)
+    }
+
+    func numberModulo(_ divisor: Int, is values: Int...) -> Bool {
+      isInteger && values.contains(integerModulo(divisor))
+    }
+
+    func numberModulo(_ divisor: Int, isIn range: ClosedRange<Int>) -> Bool {
+      isInteger && range.contains(integerModulo(divisor))
+    }
+  }
+
+  private enum RuleSet {
+    case arabic
+    case belarusian
+    case breton
+    case colognian
+    case cornish
+    case czech
+    case danish
+    case filipino
+    case french
+    case hebrew
+    case icelandic
+    case irish
+    case italian
+    case langi
+    case latvian
+    case lithuanian
+    case macedonian
+    case maltese
+    case manx
+    case oneTwo
+    case oneWhenI0Or1
+    case oneWhenI0OrN1
+    case oneWhenI1V0
+    case oneWhenN0Through1
+    case oneWhenN1
+    case otherOnly
+    case polish
+    case portuguese
+    case romanian
+    case russian
+    case samogitian
+    case scottishGaelic
+    case serboCroatian
+    case shilha
+    case sinhala
+    case slovenian
+    case sorbian
+    case spanish
+    case tachelhitTamazight
+    case welsh
+
+    func category(for operands: Operands) -> PluralCategory {
+      switch self {
+      case .arabic:
+        return Self.arabicCategory(operands)
+      case .belarusian:
+        return Self.belarusianCategory(operands)
+      case .breton:
+        return Self.bretonCategory(operands)
+      case .colognian:
+        return Self.colognianCategory(operands)
+      case .cornish:
+        return Self.cornishCategory(operands)
+      case .czech:
+        return Self.czechCategory(operands)
+      case .danish:
+        return Self.danishCategory(operands)
+      case .filipino:
+        return Self.filipinoCategory(operands)
+      case .french:
+        return Self.frenchCategory(operands)
+      case .hebrew:
+        return Self.hebrewCategory(operands)
+      case .icelandic:
+        return Self.icelandicCategory(operands)
+      case .irish:
+        return Self.irishCategory(operands)
+      case .italian:
+        return Self.italianCategory(operands)
+      case .langi:
+        return Self.langiCategory(operands)
+      case .latvian:
+        return Self.latvianCategory(operands)
+      case .lithuanian:
+        return Self.lithuanianCategory(operands)
+      case .macedonian:
+        return Self.macedonianCategory(operands)
+      case .maltese:
+        return Self.malteseCategory(operands)
+      case .manx:
+        return Self.manxCategory(operands)
+      case .oneTwo:
+        return Self.oneTwoCategory(operands)
+      case .oneWhenI0Or1:
+        return operands.integerIs(0, 1) ? .one : .other
+      case .oneWhenI0OrN1:
+        return operands.integerIs(0) || operands.numberIs(1) ? .one : .other
+      case .oneWhenI1V0:
+        return operands.integerIs(1) && operands.visibleFractionDigitCount == 0 ? .one : .other
+      case .oneWhenN0Through1:
+        return operands.numberIs(in: 0...1) ? .one : .other
+      case .oneWhenN1:
+        return operands.numberIs(1) ? .one : .other
+      case .otherOnly:
+        return .other
+      case .polish:
+        return Self.polishCategory(operands)
+      case .portuguese:
+        return Self.portugueseCategory(operands)
+      case .romanian:
+        return Self.romanianCategory(operands)
+      case .russian:
+        return Self.russianCategory(operands)
+      case .samogitian:
+        return Self.samogitianCategory(operands)
+      case .scottishGaelic:
+        return Self.scottishGaelicCategory(operands)
+      case .serboCroatian:
+        return Self.serboCroatianCategory(operands)
+      case .shilha:
+        return Self.shilhaCategory(operands)
+      case .sinhala:
+        return Self.sinhalaCategory(operands)
+      case .slovenian:
+        return Self.slovenianCategory(operands)
+      case .sorbian:
+        return Self.sorbianCategory(operands)
+      case .spanish:
+        return Self.spanishCategory(operands)
+      case .tachelhitTamazight:
+        return operands.numberIs(in: 0...1) || operands.numberIs(in: 11...99) ? .one : .other
+      case .welsh:
+        return Self.welshCategory(operands)
+      }
+    }
+
+    private static func arabicCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(0) { return .zero }
+      if operands.numberIs(1) { return .one }
+      if operands.numberIs(2) { return .two }
+      if operands.numberModulo(100, isIn: 3...10) { return .few }
+      if operands.numberModulo(100, isIn: 11...99) { return .many }
+      return .other
+    }
+
+    private static func belarusianCategory(_ operands: Operands) -> PluralCategory {
+      guard operands.isInteger else { return .other }
+      if operands.integerModulo(10) == 1 && operands.integerModulo(100) != 11 {
+        return .one
+      }
+      if (2...4).contains(operands.integerModulo(10))
+        && !(12...14).contains(operands.integerModulo(100))
+      {
+        return .few
+      }
+      return .many
+    }
+
+    private static func bretonCategory(_ operands: Operands) -> PluralCategory {
+      guard operands.isInteger else { return .other }
+      let modulo10 = operands.integerModulo(10)
+      let modulo100 = operands.integerModulo(100)
+      if modulo10 == 1 && ![11, 71, 91].contains(modulo100) { return .one }
+      if modulo10 == 2 && ![12, 72, 92].contains(modulo100) { return .two }
+      if [3, 4, 9].contains(modulo10)
+        && !(10...19).contains(modulo100)
+        && !(70...79).contains(modulo100)
+        && !(90...99).contains(modulo100)
+      {
+        return .few
+      }
+      if !operands.numberIs(0) && operands.integerModulo(1_000_000) == 0 {
+        return .many
+      }
+      return .other
+    }
+
+    private static func colognianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(0) { return .zero }
+      if operands.numberIs(1) { return .one }
+      return .other
+    }
+
+    private static func cornishCategory(_ operands: Operands) -> PluralCategory {
+      guard operands.isInteger else { return .other }
+      if operands.numberIs(0) { return .zero }
+      if operands.numberIs(1) { return .one }
+
+      let modulo100 = operands.integerModulo(100)
+      let moduloOneThousand = operands.integerModulo(1_000)
+      let moduloOneHundredThousand = operands.integerModulo(100_000)
+      let moduloOneMillion = operands.integerModulo(1_000_000)
+      if [2, 22, 42, 62, 82].contains(modulo100)
+        || (moduloOneThousand == 0
+          && ((1_000...20_000).contains(moduloOneHundredThousand)
+            || [40_000, 60_000, 80_000].contains(moduloOneHundredThousand)))
+        || (!operands.numberIs(0) && moduloOneMillion == 100_000)
+      {
+        return .two
+      }
+      if [3, 23, 43, 63, 83].contains(modulo100) { return .few }
+      if !operands.numberIs(1) && [1, 21, 41, 61, 81].contains(modulo100) {
+        return .many
+      }
+      return .other
+    }
+
+    private static func czechCategory(_ operands: Operands) -> PluralCategory {
+      if operands.visibleFractionDigitCount != 0 { return .many }
+      if operands.integerIs(1) { return .one }
+      if operands.integerIs(in: 2...4) { return .few }
+      return .other
+    }
+
+    private static func danishCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(1)
+        || (operands.fractionDigits != 0 && operands.integerIs(0, 1))
+      {
+        return .one
+      }
+      return .other
+    }
+
+    private static func filipinoCategory(_ operands: Operands) -> PluralCategory {
+      let excludedDigits = [4, 6, 9]
+      if operands.visibleFractionDigitCount == 0 {
+        return operands.integerIs(1, 2, 3)
+          || !excludedDigits.contains(operands.integerModulo(10)) ? .one : .other
+      }
+      return excludedDigits.contains(operands.fractionDigits % 10) ? .other : .one
+    }
+
+    private static func frenchCategory(_ operands: Operands) -> PluralCategory {
+      if operands.integerIs(0, 1) { return .one }
+      if operands.visibleFractionDigitCount == 0
+        && !operands.integerIs(0)
+        && operands.integerModulo(1_000_000) == 0
+      {
+        return .many
+      }
+      return .other
+    }
+
+    private static func hebrewCategory(_ operands: Operands) -> PluralCategory {
+      if (operands.integerIs(1) && operands.visibleFractionDigitCount == 0)
+        || (operands.integerIs(0) && operands.visibleFractionDigitCount != 0)
+      {
+        return .one
+      }
+      if operands.integerIs(2) && operands.visibleFractionDigitCount == 0 { return .two }
+      return .other
+    }
+
+    private static func icelandicCategory(_ operands: Operands) -> PluralCategory {
+      if (operands.fractionDigits == 0
+        && operands.integerModulo(10) == 1
+        && operands.integerModulo(100) != 11)
+        || (operands.fractionDigits != 0
+          && operands.fractionDigits % 10 == 1
+          && operands.fractionDigits % 100 != 11)
+      {
+        return .one
+      }
+      return .other
+    }
+
+    private static func irishCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(1) { return .one }
+      if operands.numberIs(2) { return .two }
+      if operands.numberIs(in: 3...6) { return .few }
+      if operands.numberIs(in: 7...10) { return .many }
+      return .other
+    }
+
+    private static func italianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.integerIs(1) && operands.visibleFractionDigitCount == 0 { return .one }
+      if operands.visibleFractionDigitCount == 0
+        && !operands.integerIs(0)
+        && operands.integerModulo(1_000_000) == 0
+      {
+        return .many
+      }
+      return .other
+    }
+
+    private static func langiCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(0) { return .zero }
+      if operands.integerIs(0, 1) { return .one }
+      return .other
+    }
+
+    private static func latvianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberModulo(10, is: 0)
+        || operands.numberModulo(100, isIn: 11...19)
+        || (operands.visibleFractionDigitCount == 2
+          && (11...19).contains(operands.fractionDigits % 100))
+      {
+        return .zero
+      }
+      if (operands.numberModulo(10, is: 1) && !operands.numberModulo(100, is: 11))
+        || (operands.visibleFractionDigitCount == 2
+          && operands.fractionDigits % 10 == 1
+          && operands.fractionDigits % 100 != 11)
+        || (operands.visibleFractionDigitCount != 2 && operands.fractionDigits % 10 == 1)
+      {
+        return .one
+      }
+      return .other
+    }
+
+    private static func lithuanianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberModulo(10, is: 1)
+        && !operands.numberModulo(100, isIn: 11...19)
+      {
+        return .one
+      }
+      if operands.numberModulo(10, isIn: 2...9)
+        && !operands.numberModulo(100, isIn: 11...19)
+      {
+        return .few
+      }
+      if operands.fractionDigits != 0 { return .many }
+      return .other
+    }
+
+    private static func macedonianCategory(_ operands: Operands) -> PluralCategory {
+      if (operands.visibleFractionDigitCount == 0
+        && operands.integerModulo(10) == 1
+        && operands.integerModulo(100) != 11)
+        || (operands.fractionDigits % 10 == 1 && operands.fractionDigits % 100 != 11)
+      {
+        return .one
+      }
+      return .other
+    }
+
+    private static func malteseCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(1) { return .one }
+      if operands.numberIs(2) { return .two }
+      if operands.numberIs(0) || operands.numberModulo(100, isIn: 3...10) { return .few }
+      if operands.numberModulo(100, isIn: 11...19) { return .many }
+      return .other
+    }
+
+    private static func manxCategory(_ operands: Operands) -> PluralCategory {
+      if operands.visibleFractionDigitCount != 0 { return .many }
+      if operands.integerModulo(10) == 1 { return .one }
+      if operands.integerModulo(10) == 2 { return .two }
+      if [0, 20, 40, 60, 80].contains(operands.integerModulo(100)) { return .few }
+      return .other
+    }
+
+    private static func oneTwoCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(1) { return .one }
+      if operands.numberIs(2) { return .two }
+      return .other
+    }
+
+    private static func polishCategory(_ operands: Operands) -> PluralCategory {
+      guard operands.visibleFractionDigitCount == 0 else { return .other }
+      if operands.integerIs(1) { return .one }
+      if (2...4).contains(operands.integerModulo(10))
+        && !(12...14).contains(operands.integerModulo(100))
+      {
+        return .few
+      }
+      return .many
+    }
+
+    private static func portugueseCategory(_ operands: Operands) -> PluralCategory {
+      if operands.integerIs(in: 0...1) { return .one }
+      if operands.visibleFractionDigitCount == 0
+        && !operands.integerIs(0)
+        && operands.integerModulo(1_000_000) == 0
+      {
+        return .many
+      }
+      return .other
+    }
+
+    private static func romanianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.integerIs(1) && operands.visibleFractionDigitCount == 0 { return .one }
+      if operands.visibleFractionDigitCount != 0
+        || operands.numberIs(0)
+        || (!operands.numberIs(1) && operands.numberModulo(100, isIn: 1...19))
+      {
+        return .few
+      }
+      return .other
+    }
+
+    private static func russianCategory(_ operands: Operands) -> PluralCategory {
+      guard operands.visibleFractionDigitCount == 0 else { return .other }
+      if operands.integerModulo(10) == 1 && operands.integerModulo(100) != 11 {
+        return .one
+      }
+      if (2...4).contains(operands.integerModulo(10))
+        && !(12...14).contains(operands.integerModulo(100))
+      {
+        return .few
+      }
+      return .many
+    }
+
+    private static func samogitianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.fractionDigits != 0 { return .many }
+      if operands.numberModulo(10, is: 1) && !operands.numberModulo(100, is: 11) {
+        return .one
+      }
+      if operands.numberIs(2) { return .two }
+      if !operands.numberIs(2)
+        && operands.numberModulo(10, isIn: 2...9)
+        && !operands.numberModulo(100, isIn: 11...19)
+      {
+        return .few
+      }
+      return .other
+    }
+
+    private static func serboCroatianCategory(_ operands: Operands) -> PluralCategory {
+      if (operands.visibleFractionDigitCount == 0
+        && operands.integerModulo(10) == 1
+        && operands.integerModulo(100) != 11)
+        || (operands.visibleFractionDigitCount != 0
+          && operands.fractionDigits % 10 == 1
+          && operands.fractionDigits % 100 != 11)
+      {
+        return .one
+      }
+      if (operands.visibleFractionDigitCount == 0
+        && (2...4).contains(operands.integerModulo(10))
+        && !(12...14).contains(operands.integerModulo(100)))
+        || (operands.visibleFractionDigitCount != 0
+          && (2...4).contains(operands.fractionDigits % 10)
+          && !(12...14).contains(operands.fractionDigits % 100))
+      {
+        return .few
+      }
+      return .other
+    }
+
+    private static func scottishGaelicCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(1, 11) { return .one }
+      if operands.numberIs(2, 12) { return .two }
+      if operands.numberIs(in: 3...10) || operands.numberIs(in: 13...19) { return .few }
+      return .other
+    }
+
+    private static func shilhaCategory(_ operands: Operands) -> PluralCategory {
+      if operands.integerIs(0) || operands.numberIs(1) { return .one }
+      if operands.numberIs(in: 2...10) { return .few }
+      return .other
+    }
+
+    private static func sinhalaCategory(_ operands: Operands) -> PluralCategory {
+      return operands.numberIs(0, 1)
+        || (operands.integerIs(0) && operands.fractionDigits == 1) ? .one : .other
+    }
+
+    private static func slovenianCategory(_ operands: Operands) -> PluralCategory {
+      if operands.visibleFractionDigitCount != 0 { return .few }
+      switch operands.integerModulo(100) {
+      case 1: return .one
+      case 2: return .two
+      case 3, 4: return .few
+      default: return .other
+      }
+    }
+
+    private static func sorbianCategory(_ operands: Operands) -> PluralCategory {
+      let fractionModulo100 = operands.fractionDigits % 100
+      if (operands.visibleFractionDigitCount == 0 && operands.integerModulo(100) == 1)
+        || fractionModulo100 == 1
+      {
+        return .one
+      }
+      if (operands.visibleFractionDigitCount == 0 && operands.integerModulo(100) == 2)
+        || fractionModulo100 == 2
+      {
+        return .two
+      }
+      if (operands.visibleFractionDigitCount == 0
+        && (3...4).contains(operands.integerModulo(100)))
+        || (3...4).contains(fractionModulo100)
+      {
+        return .few
+      }
+      return .other
+    }
+
+    private static func spanishCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(1) { return .one }
+      if operands.visibleFractionDigitCount == 0
+        && !operands.integerIs(0)
+        && operands.integerModulo(1_000_000) == 0
+      {
+        return .many
+      }
+      return .other
+    }
+
+    private static func welshCategory(_ operands: Operands) -> PluralCategory {
+      if operands.numberIs(0) { return .zero }
+      if operands.numberIs(1) { return .one }
+      if operands.numberIs(2) { return .two }
+      if operands.numberIs(3) { return .few }
+      if operands.numberIs(6) { return .many }
+      return .other
+    }
+  }
+
+  private static func ruleSet(for identifier: String) -> RuleSet {
+    let locale = languageAndRegion(identifier)
+    switch locale.language {
+    case "am", "as", "bn", "doi", "fa", "gu", "hi", "kn", "kok", "pcm", "zu":
+      return .oneWhenI0OrN1
+    case "ff", "hy", "kab":
+      return .oneWhenI0Or1
+    case "ast", "de", "en", "et", "fi", "fy", "gl", "ia", "ie", "io", "ji", "lij",
+      "nl", "sc", "sv", "sw", "ur", "yi":
+      return .oneWhenI1V0
+    case "si":
+      return .sinhala
+    case "ak", "bho", "csw", "guw", "ln", "mg", "nso", "pa", "ti", "wa":
+      return .oneWhenN0Through1
+    case "tzm":
+      return .tachelhitTamazight
+    case "af", "an", "asa", "az", "bal", "bem", "bez", "bg", "brx", "ce", "cgg", "chr",
+      "ckb", "dv", "ee", "el", "eo", "eu", "fo", "fur", "gsw", "ha", "haw", "hu",
+      "jgo", "jmc", "ka", "kaj", "kcg", "kk", "kkj", "kl", "ks", "ksb", "ku", "ky",
+      "lb", "lg", "mas", "mgo", "ml", "mn", "mr", "nah", "nb", "nd", "ne", "nn",
+      "nnh", "no", "nr", "ny", "nyn", "om", "or", "os", "pap", "ps", "rm", "rof",
+      "rwk", "saq", "sd", "sdh", "seh", "sn", "so", "sq", "ss", "ssy", "st", "syr",
+      "ta", "te", "teo", "tig", "tk", "tn", "tr", "ts", "ug", "uz", "ve", "vo",
+      "vun", "wae", "xh", "xog":
+      return .oneWhenN1
+    case "da":
+      return .danish
+    case "is":
+      return .icelandic
+    case "mk":
+      return .macedonian
+    case "ceb", "fil", "tl":
+      return .filipino
+    case "lv", "prg":
+      return .latvian
+    case "lag":
+      return .langi
+    case "blo", "cv", "ksh":
+      return .colognian
+    case "he", "iw":
+      return .hebrew
+    case "iu", "naq", "sat", "se", "sma", "smi", "smj", "smn", "sms":
+      return .oneTwo
+    case "shi":
+      return .shilha
+    case "mo", "ro":
+      return .romanian
+    case "bs", "hr", "sh", "sr":
+      return .serboCroatian
+    case "fr":
+      return .french
+    case "pt":
+      return locale.region == "PT" ? .italian : .portuguese
+    case "ca", "it", "lld", "scn", "vec":
+      return .italian
+    case "es":
+      return .spanish
+    case "gd":
+      return .scottishGaelic
+    case "sl":
+      return .slovenian
+    case "dsb", "hsb":
+      return .sorbian
+    case "cs", "sk":
+      return .czech
+    case "pl":
+      return .polish
+    case "be":
+      return .belarusian
+    case "lt":
+      return .lithuanian
+    case "ru", "uk":
+      return .russian
+    case "sgs":
+      return .samogitian
+    case "br":
+      return .breton
+    case "mt":
+      return .maltese
+    case "ga":
+      return .irish
+    case "gv":
+      return .manx
+    case "kw":
+      return .cornish
+    case "ar", "ars":
+      return .arabic
+    case "cy":
+      return .welsh
+    default:
+      return .otherOnly
+    }
+  }
+
+  private static func languageAndRegion(
+    _ identifier: String
+  ) -> (language: String, region: String?) {
+    let withoutKeyword = identifier.split(separator: "@", maxSplits: 1).first ?? ""
+    let baseIdentifier = withoutKeyword.split(separator: ".", maxSplits: 1).first ?? ""
+    let subtags = baseIdentifier.split { $0 == "-" || $0 == "_" }
+    guard let language = subtags.first else { return ("", nil) }
+
+    for subtag in subtags.dropFirst() {
+      if subtag.count == 2 && subtag.allSatisfy(\.isLetter) {
+        return (language.lowercased(), subtag.uppercased())
+      }
+      if subtag.count == 3 && subtag.allSatisfy(\.isNumber) {
+        return (language.lowercased(), String(subtag))
+      }
+    }
+    return (language.lowercased(), nil)
+  }
+}

--- a/swift/core/Sources/BasicCatalog/Functions/PluralizeFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/PluralizeFunction.swift
@@ -21,12 +21,10 @@ public enum PluralCategory: String, Sendable {
   case zero, one, two, few, many, other
 }
 
-/// A protocol for providing custom CLDR plural categorization logic.
+/// A protocol for overriding CLDR plural categorization logic.
 ///
-/// Since Apple's Foundation framework does not expose a public runtime API for
-/// determining CLDR plural categories dynamically, host applications can implement
-/// this protocol to bridge their own internationalization engine (e.g. ICU rules)
-/// into the A2UI evaluation pipeline.
+/// A2UI uses ``CLDRPluralResolver`` by default. Host applications can implement this protocol to
+/// bridge another internationalization engine into the evaluation pipeline.
 public protocol PluralResolver: AnyObject, Sendable {
   /// Determines the CLDR plural category for the given numeric value.
   func pluralCategory(for value: Double) -> PluralCategory
@@ -56,34 +54,28 @@ public final class PluralizeFunction: FunctionImplementation, @unchecked Sendabl
   )
 
   public weak var resolver: (any PluralResolver)?
+  private let defaultResolver: CLDRPluralResolver
 
   /// Initializes a new pluralize function, optionally accepting a custom resolver.
   ///
-  /// - Parameter resolver: An optional weak reference to a `PluralResolver`. If `nil`,
-  ///   the function falls back to a simplified English-centric heuristic matching
-  ///   exact cases for `0`, `1`, and `2`, and falling back to `other`.
-  public init(resolver: (any PluralResolver)? = nil) {
+  /// - Parameters:
+  ///   - resolver: An optional weak reference to a custom `PluralResolver`.
+  ///   - locale: The locale used by the built-in CLDR resolver when `resolver` is `nil`.
+  public init(resolver: (any PluralResolver)? = nil, locale: Locale = .current) {
     self.resolver = resolver
-  }
-
-  private func defaultCategory(for numberValue: Double) -> PluralCategory {
-    let absVal = abs(numberValue)
-    if absVal == 0 { return .zero }
-    if absVal == 1 { return .one }
-    if absVal == 2 { return .two }
-    return .other
+    self.defaultResolver = CLDRPluralResolver(locale: locale)
   }
 
   /// Evaluates the pluralize function.
   ///
-  /// This implementation checks the numeric `value` argument against the configured `PluralResolver`
-  /// (or uses a simplified heuristic fallback if no resolver is present) to determine its `PluralCategory`.
-  /// It then returns the string argument corresponding to that category (e.g. `one`, `few`, `other`).
+  /// This implementation checks the numeric `value` argument against the configured
+  /// `PluralResolver`, or the built-in CLDR resolver if no override is present. It then returns the
+  /// string argument corresponding to that category (e.g. `one`, `few`, `other`).
   ///
   /// - Parameters:
   ///   - arguments: The dictionary of arguments provided to the function.
   ///   - context: The current data context.
-  /// - Returns: The resolved localized string, or the `other` string if a specific category was not provided.
+  /// - Returns: The resolved string, or `other` when the selected category is not provided.
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let other = arguments["other"]?.stringValue else {
       return .string("")
@@ -98,7 +90,9 @@ public final class PluralizeFunction: FunctionImplementation, @unchecked Sendabl
       return .string(other)
     }
 
-    let category = resolver?.pluralCategory(for: numberValue) ?? defaultCategory(for: numberValue)
+    let category =
+      resolver?.pluralCategory(for: numberValue)
+      ?? defaultResolver.pluralCategory(for: numberValue)
 
     let match: String
     switch category {

--- a/swift/core/Tests/BasicCatalogTests/CLDRPluralResolverTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/CLDRPluralResolverTests.swift
@@ -63,8 +63,8 @@ struct CLDRPluralResolverTests {
       ("lag", 0.0, "zero"),
       ("lag", 0.5, "one"),
       ("lag", 2.0, "other"),
-      ("cv", 0.0, "zero"),
-      ("cv", 1.0, "one"),
+      ("cv", 0.0, "other"),
+      ("cv", 1.0, "other"),
       ("cv", 2.0, "other"),
       ("he", 0.5, "one"),
       ("he", 1.0, "one"),
@@ -142,11 +142,11 @@ struct CLDRPluralResolverTests {
       ("ru", 2.0, "few"),
       ("ru", 5.0, "many"),
       ("ru", 0.5, "other"),
-      ("sgs", 1.0, "one"),
-      ("sgs", 2.0, "two"),
-      ("sgs", 3.0, "few"),
+      ("sgs", 1.0, "other"),
+      ("sgs", 2.0, "other"),
+      ("sgs", 3.0, "other"),
       ("sgs", 11.0, "other"),
-      ("sgs", 0.5, "many"),
+      ("sgs", 0.5, "other"),
       ("br", 1.0, "one"),
       ("br", 2.0, "two"),
       ("br", 3.0, "few"),
@@ -189,7 +189,68 @@ struct CLDRPluralResolverTests {
       ("cy", 4.0, "other"),
     ]
   )
-  func matchesCLDR48(localeIdentifier: String, value: Double, expected: String) {
+  func matchesPinnedICU(localeIdentifier: String, value: Double, expected: String) {
+    let resolver = CLDRPluralResolver(localeIdentifier: localeIdentifier)
+    #expect(resolver.pluralCategory(for: value).rawValue == expected)
+  }
+
+  // Reference fixtures generated with swift-foundation-icu revision
+  // 2e2854eee567589ed44c5f3c85c7343e6d91978d (swift-6.3.1-RELEASE).
+  @Test(
+    arguments: [
+      (Double(16.0005).nextDown, "other"),
+      (16.0005, "other"),
+      (Double(16.0005).nextUp, "other"),
+      (4.0005, "other"),
+      (8.0095, "other"),
+      (16.0995, "other"),
+    ]
+  )
+  func matchesPinnedICUDecimalBoundaryFixtures(value: Double, expected: String) {
+    let resolver = CLDRPluralResolver(localeIdentifier: "tzm")
+    #expect(resolver.pluralCategory(for: value).rawValue == expected)
+  }
+
+  @Test(
+    arguments: [
+      ("is", 8.001, "other"),
+      ("is", 8.005, "one"),
+      ("is", 8.21, "one"),
+      ("is", 64.21, "other"),
+      ("mk", 8.21, "other"),
+    ]
+  )
+  func matchesPinnedICUFractionOperandFixtures(
+    localeIdentifier: String,
+    value: Double,
+    expected: String
+  ) {
+    let resolver = CLDRPluralResolver(localeIdentifier: localeIdentifier)
+    #expect(resolver.pluralCategory(for: value).rawValue == expected)
+  }
+
+  @Test(
+    arguments: [
+      ("is", 9_007_199_254_740_991.0, "one"),
+      ("is", 9_007_199_254_740_992.0, "other"),
+      ("gv", Double(Int64.max).nextDown, "other"),
+      ("gv", Double(Int64.max), "other"),
+      ("fr", 1_000_000_000_000_000_000.0, "many"),
+      ("fr", 1_000_000_000_001_000_000.0, "other"),
+      ("it", 1_000_000_000_000_000_000.0, "many"),
+      ("fr", 1e20, "one"),
+      ("br", 1e20, "many"),
+      ("ar", Double.greatestFiniteMagnitude, "many"),
+      ("fr", Double.greatestFiniteMagnitude, "one"),
+      ("it", Double.greatestFiniteMagnitude, "other"),
+      ("en", Double.leastNonzeroMagnitude, "other"),
+    ]
+  )
+  func matchesPinnedICULargeNumberFixtures(
+    localeIdentifier: String,
+    value: Double,
+    expected: String
+  ) {
     let resolver = CLDRPluralResolver(localeIdentifier: localeIdentifier)
     #expect(resolver.pluralCategory(for: value).rawValue == expected)
   }
@@ -199,7 +260,6 @@ struct CLDRPluralResolverTests {
       ("en-US", "en_US", 1.0, "one"),
       ("en-US", "en_US", 2.0, "other"),
       ("pt-PT", "pt_PT", 0.0, "other"),
-      ("pt-PT", "pt_PT.UTF-8", 0.0, "other"),
       ("pt-PT", "pt_PT@currency=EUR", 0.0, "other"),
       ("zh-Hans-CN", "zh_Hans_CN", 1.0, "other"),
     ]
@@ -216,9 +276,33 @@ struct CLDRPluralResolverTests {
     #expect(posixCategory == bcp47Category)
   }
 
+  @Test(
+    arguments: [
+      ("pt-x-PT", "one"),
+      ("pt-Latn-x-PT", "one"),
+      ("pt-a-PT", "one"),
+      ("pt-u-rg-ptzzzz", "one"),
+      ("pt-PT", "other"),
+      ("pt_PT.UTF-8", "one"),
+      ("pt_PT@currency=EUR", "other"),
+    ]
+  )
+  func respectsLocaleCoreBoundaries(localeIdentifier: String, expected: String) {
+    let resolver = CLDRPluralResolver(localeIdentifier: localeIdentifier)
+    #expect(resolver.pluralCategory(for: 0).rawValue == expected)
+  }
+
   @Test func returnsOtherForUnknownLocales() {
     let resolver = CLDRPluralResolver(localeIdentifier: "xx")
     #expect(resolver.pluralCategory(for: 1) == .other)
+  }
+
+  @Test(arguments: ["cv", "ie", "kok", "kok-Latn", "sgs"])
+  func matchesPinnedICURootFallbacks(localeIdentifier: String) {
+    let resolver = CLDRPluralResolver(localeIdentifier: localeIdentifier)
+    #expect(resolver.pluralCategory(for: 0) == .other)
+    #expect(resolver.pluralCategory(for: 1) == .other)
+    #expect(resolver.pluralCategory(for: 2) == .other)
   }
 
   @Test(arguments: [Double.nan, Double.infinity, -Double.infinity])

--- a/swift/core/Tests/BasicCatalogTests/CLDRPluralResolverTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/CLDRPluralResolverTests.swift
@@ -1,0 +1,229 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import BasicCatalog
+import Testing
+
+struct CLDRPluralResolverTests {
+  @Test(
+    arguments: [
+      ("en-US", 0.0, "other"),
+      ("en-US", 1.0, "one"),
+      ("en-US", 2.0, "other"),
+      ("en-US", -1.0, "one"),
+      ("en-US", 1.5, "other"),
+      ("de", 1.0, "one"),
+      ("de", 2.0, "other"),
+      ("zh-CN", 1.0, "other"),
+      ("tr", 1.0, "one"),
+      ("tr", 2.0, "other"),
+      ("hi", 0.0, "one"),
+      ("hi", 0.5, "one"),
+      ("hi", 2.0, "other"),
+      ("ff", 0.0, "one"),
+      ("ff", 1.5, "one"),
+      ("ak", 0.0, "one"),
+      ("ak", 1.0, "one"),
+      ("ak", 0.5, "other"),
+      ("tzm", 11.0, "one"),
+      ("tzm", 99.0, "one"),
+      ("tzm", 100.0, "other"),
+      ("si", 0.0, "one"),
+      ("si", 0.1, "one"),
+      ("si", 0.2, "other"),
+      ("da", 0.5, "one"),
+      ("da", 2.5, "other"),
+      ("is", 21.0, "one"),
+      ("is", 11.0, "other"),
+      ("is", 0.1, "one"),
+      ("mk", 21.0, "one"),
+      ("mk", 11.0, "other"),
+      ("mk", 0.1, "one"),
+      ("ceb", 4.0, "other"),
+      ("ceb", 5.0, "one"),
+      ("fil", 1.4, "other"),
+      ("fil", 1.5, "one"),
+      ("lv", 0.0, "zero"),
+      ("lv", 1.0, "one"),
+      ("lv", 11.0, "zero"),
+      ("lv", 0.1, "one"),
+      ("lv", 0.11, "zero"),
+      ("lv", 0.2, "other"),
+      ("lag", 0.0, "zero"),
+      ("lag", 0.5, "one"),
+      ("lag", 2.0, "other"),
+      ("cv", 0.0, "zero"),
+      ("cv", 1.0, "one"),
+      ("cv", 2.0, "other"),
+      ("he", 0.5, "one"),
+      ("he", 1.0, "one"),
+      ("he", 2.0, "two"),
+      ("he", 3.0, "other"),
+      ("se", 1.0, "one"),
+      ("se", 2.0, "two"),
+      ("se", 3.0, "other"),
+      ("shi", 0.0, "one"),
+      ("shi", 2.0, "few"),
+      ("shi", 11.0, "other"),
+      ("ro", 1.0, "one"),
+      ("ro", 0.0, "few"),
+      ("ro", 2.0, "few"),
+      ("ro", 20.0, "other"),
+      ("ro", 1.5, "few"),
+      ("sr", 1.0, "one"),
+      ("sr", 2.0, "few"),
+      ("sr", 5.0, "other"),
+      ("sr", 0.1, "one"),
+      ("sr", 0.2, "few"),
+      ("fr", 0.0, "one"),
+      ("fr", 1.5, "one"),
+      ("fr", 2.0, "other"),
+      ("fr", 1_000_000.0, "many"),
+      ("pt-BR", 0.0, "one"),
+      ("pt-BR", 1.5, "one"),
+      ("pt-BR", 2.0, "other"),
+      ("pt-BR", 1_000_000.0, "many"),
+      ("pt-PT", 0.0, "other"),
+      ("pt-PT", 1.0, "one"),
+      ("pt-PT", 1.5, "other"),
+      ("pt-PT", 1_000_000.0, "many"),
+      ("it", 1.0, "one"),
+      ("it", 1.5, "other"),
+      ("it", 1_000_000.0, "many"),
+      ("es", 1.0, "one"),
+      ("es", 0.0, "other"),
+      ("es", 1_000_000.0, "many"),
+      ("gd", 1.0, "one"),
+      ("gd", 2.0, "two"),
+      ("gd", 3.0, "few"),
+      ("gd", 11.0, "one"),
+      ("gd", 12.0, "two"),
+      ("gd", 20.0, "other"),
+      ("sl", 1.0, "one"),
+      ("sl", 2.0, "two"),
+      ("sl", 3.0, "few"),
+      ("sl", 0.5, "few"),
+      ("sl", 5.0, "other"),
+      ("hsb", 1.0, "one"),
+      ("hsb", 2.0, "two"),
+      ("hsb", 3.0, "few"),
+      ("hsb", 0.1, "one"),
+      ("hsb", 0.2, "two"),
+      ("hsb", 0.3, "few"),
+      ("hsb", 0.5, "other"),
+      ("cs", 1.0, "one"),
+      ("cs", 2.0, "few"),
+      ("cs", 5.0, "other"),
+      ("cs", 1.5, "many"),
+      ("pl", 1.0, "one"),
+      ("pl", 2.0, "few"),
+      ("pl", 5.0, "many"),
+      ("pl", 0.5, "other"),
+      ("be", 1.0, "one"),
+      ("be", 2.0, "few"),
+      ("be", 5.0, "many"),
+      ("be", 0.5, "other"),
+      ("lt", 1.0, "one"),
+      ("lt", 2.0, "few"),
+      ("lt", 10.0, "other"),
+      ("lt", 0.5, "many"),
+      ("ru", 1.0, "one"),
+      ("ru", 2.0, "few"),
+      ("ru", 5.0, "many"),
+      ("ru", 0.5, "other"),
+      ("sgs", 1.0, "one"),
+      ("sgs", 2.0, "two"),
+      ("sgs", 3.0, "few"),
+      ("sgs", 11.0, "other"),
+      ("sgs", 0.5, "many"),
+      ("br", 1.0, "one"),
+      ("br", 2.0, "two"),
+      ("br", 3.0, "few"),
+      ("br", 1_000_000.0, "many"),
+      ("br", 5.0, "other"),
+      ("mt", 1.0, "one"),
+      ("mt", 2.0, "two"),
+      ("mt", 3.0, "few"),
+      ("mt", 11.0, "many"),
+      ("mt", 20.0, "other"),
+      ("ga", 1.0, "one"),
+      ("ga", 2.0, "two"),
+      ("ga", 3.0, "few"),
+      ("ga", 7.0, "many"),
+      ("ga", 11.0, "other"),
+      ("gv", 1.0, "one"),
+      ("gv", 2.0, "two"),
+      ("gv", 20.0, "few"),
+      ("gv", 0.5, "many"),
+      ("gv", 3.0, "other"),
+      ("kw", 0.0, "zero"),
+      ("kw", 1.0, "one"),
+      ("kw", 2.0, "two"),
+      ("kw", 3.0, "few"),
+      ("kw", 21.0, "many"),
+      ("kw", 4.0, "other"),
+      ("kw", 1_000.0, "two"),
+      ("ar", 0.0, "zero"),
+      ("ar", 1.0, "one"),
+      ("ar", 2.0, "two"),
+      ("ar", 3.0, "few"),
+      ("ar", 11.0, "many"),
+      ("ar", 100.0, "other"),
+      ("ar", 0.5, "other"),
+      ("cy", 0.0, "zero"),
+      ("cy", 1.0, "one"),
+      ("cy", 2.0, "two"),
+      ("cy", 3.0, "few"),
+      ("cy", 6.0, "many"),
+      ("cy", 4.0, "other"),
+    ]
+  )
+  func matchesCLDR48(localeIdentifier: String, value: Double, expected: String) {
+    let resolver = CLDRPluralResolver(localeIdentifier: localeIdentifier)
+    #expect(resolver.pluralCategory(for: value).rawValue == expected)
+  }
+
+  @Test(
+    arguments: [
+      ("en-US", "en_US", 1.0, "one"),
+      ("en-US", "en_US", 2.0, "other"),
+      ("pt-PT", "pt_PT", 0.0, "other"),
+      ("pt-PT", "pt_PT.UTF-8", 0.0, "other"),
+      ("pt-PT", "pt_PT@currency=EUR", 0.0, "other"),
+      ("zh-Hans-CN", "zh_Hans_CN", 1.0, "other"),
+    ]
+  )
+  func acceptsBCP47AndPOSIXIdentifiers(
+    bcp47: String,
+    posix: String,
+    value: Double,
+    expected: String
+  ) {
+    let bcp47Category = CLDRPluralResolver(localeIdentifier: bcp47).pluralCategory(for: value)
+    let posixCategory = CLDRPluralResolver(localeIdentifier: posix).pluralCategory(for: value)
+    #expect(bcp47Category.rawValue == expected)
+    #expect(posixCategory == bcp47Category)
+  }
+
+  @Test func returnsOtherForUnknownLocales() {
+    let resolver = CLDRPluralResolver(localeIdentifier: "xx")
+    #expect(resolver.pluralCategory(for: 1) == .other)
+  }
+
+  @Test(arguments: [Double.nan, Double.infinity, -Double.infinity])
+  func returnsOtherForNonFiniteValues(value: Double) {
+    let resolver = CLDRPluralResolver(localeIdentifier: "ar")
+    #expect(resolver.pluralCategory(for: value) == .other)
+  }
+}

--- a/swift/core/Tests/BasicCatalogTests/PluralizeFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/PluralizeFunctionTests.swift
@@ -39,7 +39,8 @@ private final class MockPluralResolver: PluralResolver, @unchecked Sendable {
 
 struct PluralizeFunctionTests {
 
-  let function = PluralizeFunction()
+  let function = PluralizeFunction(locale: Locale(identifier: "en_US"))
+  let welshFunction = PluralizeFunction(locale: Locale(identifier: "cy"))
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
 
@@ -50,7 +51,7 @@ struct PluralizeFunctionTests {
     #expect(function.api.returnType == .string)
   }
 
-  // MARK: - Evaluation (Default Heuristic)
+  // MARK: - Evaluation (Built-in CLDR resolver)
 
   @Test func returnsOneWhenValueIsOne() throws {
     let result = try function.evaluate(
@@ -72,7 +73,7 @@ struct PluralizeFunctionTests {
   }
 
   @Test func returnsZeroWhenValueIsZeroAndZeroIsProvided() throws {
-    let result = try function.evaluate(
+    let result = try welshFunction.evaluate(
       arguments: [
         "value": .number(0),
         "zero": .string("No items"),
@@ -82,7 +83,7 @@ struct PluralizeFunctionTests {
   }
 
   @Test func returnsOtherWhenValueIsZeroAndZeroIsMissing() throws {
-    let result = try function.evaluate(
+    let result = try welshFunction.evaluate(
       arguments: [
         "value": .number(0),
         "other": .string("0 items"),
@@ -91,7 +92,7 @@ struct PluralizeFunctionTests {
   }
 
   @Test func returnsTwoWhenValueIsTwoAndTwoIsProvided() throws {
-    let result = try function.evaluate(
+    let result = try welshFunction.evaluate(
       arguments: [
         "value": .number(2),
         "two": .string("a pair of items"),
@@ -108,6 +109,18 @@ struct PluralizeFunctionTests {
         "other": .string("100 items"),
       ], context: context)
     #expect(result == .string("100 items"))
+  }
+
+  @Test(arguments: [0.0, 2.0])
+  func englishUsesOtherForZeroAndTwo(value: Double) throws {
+    let result = try function.evaluate(
+      arguments: [
+        "value": .number(value),
+        "zero": .string("zero"),
+        "two": .string("two"),
+        "other": .string("other"),
+      ], context: context)
+    #expect(result == .string("other"))
   }
 
   @Test func worksWithNumericStrings() throws {


### PR DESCRIPTION
## Summary

- replace the English-centric zero/one/two fallback with a dependency-free CLDR cardinal resolver
- preserve custom `PluralResolver` injection while caching the built-in locale rule set at initialization
- match the historical Swift implementation's `_FoundationICU` behavior, including decimal operands,
  signed 64-bit boundaries, large finite values, locale extensions, and ICU locale fallback behavior
- add regression coverage for decimal boundaries, `2^53`, `2^63`, large exponents, subnormal values,
  BCP-47 extensions, POSIX identifiers, and locales absent from the pinned ICU data bundle

Credit: The original pure-Swift CLDR implementation was contributed by @fangmobile in
[BBC6BAE9/a2ui-swift#75](https://github.com/BBC6BAE9/a2ui-swift/pull/75). This PR adapts that work to
the official Swift API and expands its embedded rule table from the CLDR 44 subset to CLDR 48.

## Acceptance oracle

The acceptance oracle is the same SwiftPM package and API introduced by the earlier Swift
implementation:

- package: `swiftlang/swift-foundation-icu`
- revision: `swift-6.3.1-RELEASE`
  (`2e2854eee567589ed44c5f3c85c7343e6d91978d`)
- bundled ICU: 76.1
- API: `uplrules_openForType(..., UPLURAL_TYPE_CARDINAL, ...)` and `uplrules_select`

ICU is used only by an external temporary differential harness. This PR does not add ICU or any
other dependency to the A2UI package manifest.

## Verification

- external `_FoundationICU` differential matrix: 226 locale identifiers × 3,154 values = 712,804
  comparisons, zero mismatches
- focused `CLDRPluralResolverTests`: 9 tests with 214 parameterized cases, all passing
- `swift/core/run_tests.sh`: 207 tests across 18 suites, all passing
- `xcrun swift-format format -i -r Package.swift swift/`
- `swift build`

## Notable compatibility behavior

- `PluralRules::select(double)` does not apply the default three-fraction-digit formatting used by
  JavaScript `Intl.PluralRules`; this implementation mirrors ICU `FixedDecimal(double)` instead
- `pt_PT.UTF-8` falls back to generic Portuguese while `pt_PT@currency=EUR` retains the `PT` region,
  matching the pinned ICU API
- `cv`, `ie`, `kok`, and `sgs` fall back to the ICU root rule (`other`) because they are absent from
  the pinned ICU data bundle
- unknown locale identifiers and non-finite values return `other`

## Checklist

- [x] Google CLA signed
- [x] contributor and Swift style guides reviewed
- [x] public API documentation and regression tests added
- [x] Swift formatting, tests, package build, and pinned-ICU differential checks pass
- [ ] repository-wide e2e script and sample app build not run; the change is isolated to Swift
  BasicCatalog, and the prescribed Swift Core suite plus package build pass
