### PR TITLE
fix(eval,parser): preserve solver prose, normalize format version, and add JSON escape hints

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
@@ -77,9 +77,7 @@ class ExpressParser(Parser):
         normalized = re.sub(
             r"`+<a2ui\b([^>]*)>`+", r"<a2ui\1>", normalized, flags=re.IGNORECASE
         )
-        normalized = re.sub(
-            r"`+</a2ui>`+", r"</a2ui>", normalized, flags=re.IGNORECASE
-        )
+        normalized = re.sub(r"`+</a2ui>`+", r"</a2ui>", normalized, flags=re.IGNORECASE)
 
         from a2ui.parser.lexer import BlockLexer
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
@@ -14,6 +14,7 @@
 
 """Parser utilities to extract and compile A2UI Express DSL from LLM responses."""
 
+import re
 from typing import Any, List, Union
 from a2ui.core.catalog import Catalog
 from a2ui.schema.catalog import A2uiCatalog
@@ -65,6 +66,21 @@ class ExpressParser(Parser):
 
     def unwrap(self, content: str) -> List[ResponsePart]:
         """Unwraps/tokenizes the response content into raw Express DSL parts."""
+        # Normalize code fences: ```a2ui ... ``` -> <a2ui> ... </a2ui>
+        normalized = re.sub(
+            r"```(?:a2ui|express)\s*\n(.*?)\n```",
+            r"<a2ui>\n\1\n</a2ui>",
+            content,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        # Normalize backticked tags: `<a2ui>` -> <a2ui>, `</a2ui>` -> </a2ui>
+        normalized = re.sub(
+            r"`+<a2ui\b([^>]*)>`+", r"<a2ui\1>", normalized, flags=re.IGNORECASE
+        )
+        normalized = re.sub(
+            r"`+</a2ui>`+", r"</a2ui>", normalized, flags=re.IGNORECASE
+        )
+
         from a2ui.parser.lexer import BlockLexer
 
         lexer = BlockLexer(
@@ -73,7 +89,7 @@ class ExpressParser(Parser):
             string_delimiters={"'", '"'},
             single_line_comments={"#"},
         )
-        return lexer.tokenize(content)
+        return lexer.tokenize(normalized)
 
     def compile(
         self, format_content: str, *, is_final: bool = True

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
@@ -66,18 +66,10 @@ class ExpressParser(Parser):
 
     def unwrap(self, content: str) -> List[ResponsePart]:
         """Unwraps/tokenizes the response content into raw Express DSL parts."""
-        # Normalize code fences: ```a2ui ... ``` -> <a2ui> ... </a2ui>
-        normalized = re.sub(
-            r"```(?:a2ui|express)\s*\n(.*?)\n?```",
-            r"<a2ui>\n\1\n</a2ui>",
-            content,
-            flags=re.DOTALL | re.IGNORECASE,
-        )
         # Normalize backticked tags: `<a2ui>` -> <a2ui>, `</a2ui>` -> </a2ui>
         normalized = re.sub(
-            r"`+<a2ui\b([^>]*)>`+", r"<a2ui\1>", normalized, flags=re.IGNORECASE
+            r"`+(</?a2ui\b[^>]*>)`+", r"\1", content, flags=re.IGNORECASE
         )
-        normalized = re.sub(r"`+</a2ui>`+", r"</a2ui>", normalized, flags=re.IGNORECASE)
 
         from a2ui.parser.lexer import BlockLexer
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
@@ -14,7 +14,6 @@
 
 """Parser utilities to extract and compile A2UI Express DSL from LLM responses."""
 
-import re
 from typing import Any, List, Union
 from a2ui.core.catalog import Catalog
 from a2ui.schema.catalog import A2uiCatalog
@@ -66,11 +65,6 @@ class ExpressParser(Parser):
 
     def unwrap(self, content: str) -> List[ResponsePart]:
         """Unwraps/tokenizes the response content into raw Express DSL parts."""
-        # Normalize backticked tags: `<a2ui>` -> <a2ui>, `</a2ui>` -> </a2ui>
-        normalized = re.sub(
-            r"`+(</?a2ui\b[^>]*>)`+", r"\1", content, flags=re.IGNORECASE
-        )
-
         from a2ui.parser.lexer import BlockLexer
 
         lexer = BlockLexer(
@@ -79,7 +73,7 @@ class ExpressParser(Parser):
             string_delimiters={"'", '"'},
             single_line_comments={"#"},
         )
-        return lexer.tokenize(normalized)
+        return lexer.tokenize(content)
 
     def compile(
         self, format_content: str, *, is_final: bool = True

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/parser.py
@@ -68,7 +68,7 @@ class ExpressParser(Parser):
         """Unwraps/tokenizes the response content into raw Express DSL parts."""
         # Normalize code fences: ```a2ui ... ``` -> <a2ui> ... </a2ui>
         normalized = re.sub(
-            r"```(?:a2ui|express)\s*\n(.*?)\n```",
+            r"```(?:a2ui|express)\s*\n(.*?)\n?```",
             r"<a2ui>\n\1\n</a2ui>",
             content,
             flags=re.DOTALL | re.IGNORECASE,

--- a/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
@@ -38,10 +38,10 @@ def parse_and_fix(payload: str) -> List[Dict[str, Any]]:
     except (
         json.JSONDecodeError,
         ValueError,
+        A2uiParseError,
     ) as e:
         logger.warning(f"Initial A2UI payload validation failed: {e}")
         updated_payload = _remove_trailing_commas(normalized_payload)
-        updated_payload = _fix_unescaped_backslashes(updated_payload)
         a2ui_json = _parse(updated_payload)
         return a2ui_json
 
@@ -58,7 +58,14 @@ def _parse(payload: str) -> List[Dict[str, Any]]:
         return a2ui_json
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse JSON: {e}")
-        raise A2uiParseError(f"Failed to parse JSON: {e}")
+        hint = ""
+        if "Invalid \\escape" in e.msg:
+            hint = (
+                f" - Help: Unescaped backslash found at line {e.lineno}, col"
+                f" {e.colno}. In JSON strings, all backslashes must be escaped"
+                " as '\\\\' (e.g. '\\\\approx', '\\\\alpha')."
+            )
+        raise A2uiParseError(f"Failed to parse JSON: {e}{hint}") from e
 
 
 def _normalize_smart_quotes(json_str: str) -> str:
@@ -86,26 +93,4 @@ def _remove_trailing_commas(json_str: str) -> str:
     if fixed_json != json_str:
         logger.warning("Detected trailing commas in LLM output; applied autofix.")
 
-    return fixed_json
-
-
-def _fix_unescaped_backslashes(json_str: str) -> str:
-    """Escapes invalid backslashes inside JSON strings (e.g. \\approx, \\Delta).
-
-    Args:
-      json_str: The raw JSON string from the LLM.
-
-    Returns:
-      A JSON string with invalid backslashes escaped.
-    """
-    fixed_json = re.sub(
-        r'(\\["\\/bfnrt]|\\u[0-9a-fA-F]{4})|\\',
-        lambda m: m.group(1) or r"\\",
-        json_str,
-    )
-    if fixed_json != json_str:
-        logger.warning(
-            "Detected invalid escape sequences in LLM output; applied backslash"
-            " autofix."
-        )
     return fixed_json

--- a/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
@@ -41,6 +41,7 @@ def parse_and_fix(payload: str) -> List[Dict[str, Any]]:
     ) as e:
         logger.warning(f"Initial A2UI payload validation failed: {e}")
         updated_payload = _remove_trailing_commas(normalized_payload)
+        updated_payload = _fix_unescaped_backslashes(updated_payload)
         a2ui_json = _parse(updated_payload)
         return a2ui_json
 
@@ -85,4 +86,21 @@ def _remove_trailing_commas(json_str: str) -> str:
     if fixed_json != json_str:
         logger.warning("Detected trailing commas in LLM output; applied autofix.")
 
+    return fixed_json
+
+
+def _fix_unescaped_backslashes(json_str: str) -> str:
+    """Escapes invalid backslashes inside JSON strings (e.g. \\approx, \\Delta).
+
+    Args:
+      json_str: The raw JSON string from the LLM.
+
+    Returns:
+      A JSON string with invalid backslashes escaped.
+    """
+    fixed_json = re.sub(r'\\(?![/"\\bfnrtu]|u[0-9a-fA-F]{4})', r"\\\\", json_str)
+    if fixed_json != json_str:
+        logger.warning(
+            "Detected invalid escape sequences in LLM output; applied backslash autofix."
+        )
     return fixed_json

--- a/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
@@ -98,9 +98,14 @@ def _fix_unescaped_backslashes(json_str: str) -> str:
     Returns:
       A JSON string with invalid backslashes escaped.
     """
-    fixed_json = re.sub(r'\\(?![/"\\bfnrtu]|u[0-9a-fA-F]{4})', r"\\\\", json_str)
+    fixed_json = re.sub(
+        r'(\\["\\/bfnrt]|\\u[0-9a-fA-F]{4})|\\',
+        lambda m: m.group(1) or r"\\",
+        json_str,
+    )
     if fixed_json != json_str:
         logger.warning(
-            "Detected invalid escape sequences in LLM output; applied backslash autofix."
+            "Detected invalid escape sequences in LLM output; applied backslash"
+            " autofix."
         )
     return fixed_json

--- a/agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py
+++ b/agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py
@@ -415,8 +415,8 @@ class TestExpressParser(unittest.TestCase):
         decompiled = decompiler.decompile(envelope)
         self.assertIn('surface("update-surf-789")', decompiled)
 
-    def test_has_format_content_and_unwrap_backtick_tags(self):
-        """Test has_format_content checks and unwrap backticked tag normalization."""
+    def test_has_format_content_and_unwrap_tags(self):
+        """Test has_format_content checks and unwrap tag tokenization."""
         parser = ExpressParser(self.catalog)
         self.assertTrue(
             parser.has_format_content("<a2ui>root = Text('Hi')</a2ui>", complete=True)
@@ -428,8 +428,7 @@ class TestExpressParser(unittest.TestCase):
             parser.has_format_content("<a2ui>root = Text('Hi')", complete=False)
         )
 
-        # Backticked tags `<a2ui>` ... `</a2ui>`
-        content = "Intro\n`<a2ui>`\nroot = Text('Hi')\n`</a2ui>`\nOutro"
+        content = "Intro\n<a2ui>\nroot = Text('Hi')\n</a2ui>\nOutro"
         parts = parser.unwrap(content)
         self.assertEqual(len(parts), 2)
         self.assertEqual(parts[0].text, "Intro")

--- a/agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py
+++ b/agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py
@@ -415,8 +415,8 @@ class TestExpressParser(unittest.TestCase):
         decompiled = decompiler.decompile(envelope)
         self.assertIn('surface("update-surf-789")', decompiled)
 
-    def test_is_complete_and_unwrap_fence_variations(self):
-        """Test has_format_content checks and unwrap code fence variants without trailing newlines."""
+    def test_has_format_content_and_unwrap_backtick_tags(self):
+        """Test has_format_content checks and unwrap backticked tag normalization."""
         parser = ExpressParser(self.catalog)
         self.assertTrue(
             parser.has_format_content("<a2ui>root = Text('Hi')</a2ui>", complete=True)
@@ -428,8 +428,8 @@ class TestExpressParser(unittest.TestCase):
             parser.has_format_content("<a2ui>root = Text('Hi')", complete=False)
         )
 
-        # Code fence with no trailing newline before closing fence
-        content = "Intro\n```a2ui\nroot = Text('Hi')```\nOutro"
+        # Backticked tags `<a2ui>` ... `</a2ui>`
+        content = "Intro\n`<a2ui>`\nroot = Text('Hi')\n`</a2ui>`\nOutro"
         parts = parser.unwrap(content)
         self.assertEqual(len(parts), 2)
         self.assertEqual(parts[0].text, "Intro")

--- a/agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py
+++ b/agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py
@@ -415,6 +415,26 @@ class TestExpressParser(unittest.TestCase):
         decompiled = decompiler.decompile(envelope)
         self.assertIn('surface("update-surf-789")', decompiled)
 
+    def test_is_complete_and_unwrap_fence_variations(self):
+        """Test has_format_content checks and unwrap code fence variants without trailing newlines."""
+        parser = ExpressParser(self.catalog)
+        self.assertTrue(
+            parser.has_format_content("<a2ui>root = Text('Hi')</a2ui>", complete=True)
+        )
+        self.assertFalse(
+            parser.has_format_content("<a2ui>root = Text('Hi')", complete=True)
+        )
+        self.assertTrue(
+            parser.has_format_content("<a2ui>root = Text('Hi')", complete=False)
+        )
+
+        # Code fence with no trailing newline before closing fence
+        content = "Intro\n```a2ui\nroot = Text('Hi')```\nOutro"
+        parts = parser.unwrap(content)
+        self.assertEqual(len(parts), 2)
+        self.assertEqual(parts[0].text, "Intro")
+        self.assertIn("root = Text('Hi')", parts[0].a2ui_raw)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py
@@ -15,8 +15,8 @@
 """Unit tests for JSON payload autofixer."""
 
 import unittest
+from a2ui.core import A2uiParseError
 from a2ui.parser.payload_fixer import (
-    _fix_unescaped_backslashes,
     _remove_trailing_commas,
     parse_and_fix,
 )
@@ -25,16 +25,15 @@ from a2ui.parser.payload_fixer import (
 class TestPayloadFixer(unittest.TestCase):
     """Unit test suite for payload_fixer."""
 
-    def test_fix_unescaped_backslashes_latex(self):
-        """Verify invalid backslashes (e.g. LaTeX) are escaped while valid ones are preserved."""
-        invalid_json = (
-            r'{"formula": "\approx \Delta x", "valid": "line1\nline2", "escaped_slash":'
-            r' "path\\to\\file"}'
+    def test_unescaped_backslashes_error_hint(self):
+        """Verify invalid backslashes (e.g. LaTeX) produce an actionable error hint."""
+        invalid_json = r'{"formula": "\approx \Delta x"}'
+        with self.assertRaises(A2uiParseError) as ctx:
+            parse_and_fix(invalid_json)
+        self.assertIn('Help: Unescaped backslash found', str(ctx.exception))
+        self.assertIn(
+            'In JSON strings, all backslashes must be escaped', str(ctx.exception)
         )
-        fixed = _fix_unescaped_backslashes(invalid_json)
-        self.assertIn(r'"formula": "\\approx \\Delta x"', fixed)
-        self.assertIn(r'"valid": "line1\nline2"', fixed)
-        self.assertIn(r'"escaped_slash": "path\\to\\file"', fixed)
 
     def test_fix_trailing_commas(self):
         """Verify trailing commas in objects and arrays are cleanly removed."""
@@ -43,15 +42,15 @@ class TestPayloadFixer(unittest.TestCase):
         self.assertNotIn(', ]', fixed)
         self.assertNotIn(', }', fixed)
 
-    def test_parse_and_fix_recovers_from_corrupt_json(self):
-        """Verify parse_and_fix recovers payloads with both trailing commas and LaTeX."""
+    def test_parse_and_fix_recovers_trailing_commas(self):
+        """Verify parse_and_fix recovers payloads with trailing commas."""
         corrupt_payload = (
             r'[{"version": "v0.9", "createSurface": {"surfaceId": "default",'
             r' "components": ['
-            r'{"id": "t1", "component": "Text", "text": "Formula: \approx \Delta",},'
+            r'{"id": "t1", "component": "Text", "text": "Hello world",},'
             r']}}]'
         )
         res = parse_and_fix(corrupt_payload)
         self.assertEqual(len(res), 1)
         components = res[0]['createSurface']['components']
-        self.assertEqual(components[0]['text'], r'Formula: \approx \Delta')
+        self.assertEqual(components[0]['text'], 'Hello world')

--- a/agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for JSON payload autofixer."""
+
+import unittest
+from a2ui.parser.payload_fixer import (
+    _fix_unescaped_backslashes,
+    _remove_trailing_commas,
+    parse_and_fix,
+)
+
+
+class TestPayloadFixer(unittest.TestCase):
+    """Unit test suite for payload_fixer."""
+
+    def test_fix_unescaped_backslashes_latex(self):
+        """Verify invalid backslashes (e.g. LaTeX) are escaped while valid ones are preserved."""
+        invalid_json = (
+            r'{"formula": "\approx \Delta x", "valid": "line1\nline2", "escaped_slash":'
+            r' "path\\to\\file"}'
+        )
+        fixed = _fix_unescaped_backslashes(invalid_json)
+        self.assertIn(r'"formula": "\\approx \\Delta x"', fixed)
+        self.assertIn(r'"valid": "line1\nline2"', fixed)
+        self.assertIn(r'"escaped_slash": "path\\to\\file"', fixed)
+
+    def test_fix_trailing_commas(self):
+        """Verify trailing commas in objects and arrays are cleanly removed."""
+        trailing_comma_json = r'{"a": [1, 2, ], "b": {"k": "v", }, }'
+        fixed = _remove_trailing_commas(trailing_comma_json)
+        self.assertNotIn(', ]', fixed)
+        self.assertNotIn(', }', fixed)
+
+    def test_parse_and_fix_recovers_from_corrupt_json(self):
+        """Verify parse_and_fix recovers payloads with both trailing commas and LaTeX."""
+        corrupt_payload = (
+            r'[{"version": "v0.9", "createSurface": {"surfaceId": "default",'
+            r' "components": ['
+            r'{"id": "t1", "component": "Text", "text": "Formula: \approx \Delta",},'
+            r']}}]'
+        )
+        res = parse_and_fix(corrupt_payload)
+        self.assertEqual(len(res), 1)
+        components = res[0]['createSurface']['components']
+        self.assertEqual(components[0]['text'], r'Formula: \approx \Delta')

--- a/eval/a2ui_eval/strategies/format.py
+++ b/eval/a2ui_eval/strategies/format.py
@@ -140,7 +140,7 @@ def _parse_and_validate_in_process(
     compiled_jsons = []
     serialized_parts = []
     for p in parts:
-        part_dict = {"text": p.text, "a2ui_json": p.a2ui_json}
+        part_dict = {"text": p.text, "a2ui_json": getattr(p, "a2ui_json", None)}
         serialized_parts.append(part_dict)
         a2ui_json = getattr(p, "a2ui_json", None)
         if a2ui_json:

--- a/eval/a2ui_eval/strategies/format.py
+++ b/eval/a2ui_eval/strategies/format.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import re
+from typing import Any
 from inspect_ai.solver import Solver, solver, TaskState, Generate
 from inspect_ai.model import (
     ChatMessageSystem,
@@ -121,7 +122,7 @@ def _parse_and_validate_in_process(
     resolved_catalog_path: str,
     surface_id: str,
     completion: str,
-) -> dict:
+) -> dict[str, Any]:
     catalog_config = CatalogConfig.from_path("basic_catalog", resolved_catalog_path)
     strategy = _get_strategy(
         format_name,
@@ -185,7 +186,7 @@ def parse_with_hard_kill_timeout(
     surface_id: str,
     completion: str,
     timeout_sec: float = 5.0,
-) -> dict:
+) -> dict[str, Any]:
     with multiprocessing.Manager() as manager:
         return_dict = manager.dict()
         p = multiprocessing.Process(

--- a/eval/a2ui_eval/strategies/format.py
+++ b/eval/a2ui_eval/strategies/format.py
@@ -54,10 +54,13 @@ def _get_strategy(
         return direct_json_format
 
     catalog = direct_json_format.get_selected_catalog()
+    formatted_version = f"v{version}" if not version.startswith("v") else version
     if format_name == "express":
         from a2ui.inference_formats.experimental.express.format import ExpressFormat
 
-        return ExpressFormat(catalog=catalog, surface_id=surface_id)
+        return ExpressFormat(
+            catalog=catalog, surface_id=surface_id, version=formatted_version
+        )
     elif format_name == "elemental":
         from a2ui.inference_formats.experimental.elemental.format import ElementalFormat
 
@@ -118,7 +121,7 @@ def _parse_and_validate_in_process(
     resolved_catalog_path: str,
     surface_id: str,
     completion: str,
-) -> list:
+) -> dict:
     catalog_config = CatalogConfig.from_path("basic_catalog", resolved_catalog_path)
     strategy = _get_strategy(
         format_name,
@@ -135,7 +138,10 @@ def _parse_and_validate_in_process(
 
     parts = strategy.parser.parse_response(completion)
     compiled_jsons = []
+    serialized_parts = []
     for p in parts:
+        part_dict = {"text": p.text, "a2ui_json": p.a2ui_json}
+        serialized_parts.append(part_dict)
         a2ui_json = getattr(p, "a2ui_json", None)
         if a2ui_json:
             if isinstance(a2ui_json, list):
@@ -149,7 +155,7 @@ def _parse_and_validate_in_process(
         )
 
     validator.validate(compiled_jsons)
-    return compiled_jsons
+    return {"compiled_jsons": compiled_jsons, "parts": serialized_parts}
 
 
 import traceback
@@ -179,7 +185,7 @@ def parse_with_hard_kill_timeout(
     surface_id: str,
     completion: str,
     timeout_sec: float = 5.0,
-) -> list:
+) -> dict:
     with multiprocessing.Manager() as manager:
         return_dict = manager.dict()
         p = multiprocessing.Process(
@@ -238,7 +244,7 @@ def compile_format_payload(format_name: str, version: str) -> Solver:
                 surface_id = found_id
 
         try:
-            compiled_jsons = await asyncio.to_thread(
+            res_dict = await asyncio.to_thread(
                 parse_with_hard_kill_timeout,
                 format_name,
                 version,
@@ -248,9 +254,26 @@ def compile_format_payload(format_name: str, version: str) -> Solver:
                 timeout_sec=5.0,
             )
 
-            formatted = (
-                f"<a2ui-json>\n{json.dumps(compiled_jsons, indent=2)}\n</a2ui-json>"
-            )
+            compiled_jsons = res_dict.get("compiled_jsons", [])
+            parts = res_dict.get("parts", [])
+
+            formatted_parts = []
+            for p in parts:
+                text_part = p.get("text")
+                if text_part:
+                    formatted_parts.append(text_part)
+                json_part = p.get("a2ui_json")
+                if json_part:
+                    formatted_parts.append(
+                        f"<a2ui-json>\n{json.dumps(json_part, indent=2)}\n</a2ui-json>"
+                    )
+
+            formatted = "\n\n".join(formatted_parts).strip()
+            if "<a2ui-json>" not in formatted:
+                formatted = (
+                    f"<a2ui-json>\n{json.dumps(compiled_jsons, indent=2)}\n</a2ui-json>"
+                )
+
             state.output = ModelOutput(
                 model=state.output.model,
                 choices=[

--- a/eval/tests/test_strategies.py
+++ b/eval/tests/test_strategies.py
@@ -147,9 +147,9 @@ async def test_a2ui_express_solvers() -> None:
                 ChatCompletionChoice(
                     message=ChatMessageAssistant(
                         content=(
-                            'Here is the domain research synthesis.\n\n'
+                            "Here is the domain research synthesis.\n\n"
                             '```a2ui\nroot = Text("Hello")\n```\n\n'
-                            'Additional reference notes.'
+                            "Additional reference notes."
                         )
                     )
                 )

--- a/eval/tests/test_strategies.py
+++ b/eval/tests/test_strategies.py
@@ -139,7 +139,7 @@ async def test_a2ui_express_solvers() -> None:
         assert state.messages[0].role == "system"
         assert "A2UI Express DSL Output Contract" in state.messages[0].content
 
-        # 2. Test Compile Solver with accompanying text and backticks
+        # 2. Test Compile Solver with accompanying text and backticks (with and without trailing newline before closing fence)
         compile_solver = compile_format_payload("express", version="1.0")
         state.output = ModelOutput(
             model="mock/model",
@@ -148,7 +148,7 @@ async def test_a2ui_express_solvers() -> None:
                     message=ChatMessageAssistant(
                         content=(
                             "Here is the domain research synthesis.\n\n"
-                            '```a2ui\nroot = Text("Hello")\n```\n\n'
+                            '```a2ui\nroot = Text("Hello")```\n\n'
                             "Additional reference notes."
                         )
                     )
@@ -275,3 +275,83 @@ async def test_a2ui_atom_solvers() -> None:
     finally:
         if original_git_root is not None:
             setattr(format_module, "GIT_ROOT", original_git_root)
+
+
+@pytest.mark.asyncio
+async def test_format_system_prompt_with_domain_prompt() -> None:
+    from a2ui_eval.shared.utils import GIT_ROOT
+    from a2ui_eval.strategies.format import format_system_prompt, _get_strategy, _parse_and_validate_in_process, compile_format_payload
+    from a2ui.schema.catalog import CatalogConfig
+
+    catalog_file = GIT_ROOT / "specification/v1_0/catalogs/basic/catalog.json"
+    catalog_config = CatalogConfig.from_path("basic_catalog", str(catalog_file))
+
+    # Test unknown format raises ValueError
+    with pytest.raises(ValueError, match="Unknown format strategy"):
+        _get_strategy("unknown_strategy", "1.0", catalog_config)
+
+    # Test format_system_prompt with domain prompt metadata
+    solver = format_system_prompt("direct_json", version="1.0")
+    state = TaskState(
+        model=ModelName("mock/model"),
+        sample_id=1,
+        epoch=1,
+        input="test",
+        messages=[],
+        metadata={
+            "catalog": str(catalog_file),
+            "system_prompt": "You are a research bot.",
+            "protocol_role": "Custom UI generator",
+            "generation_rules": "Follow catalog strictly",
+        },
+    )
+    state = await solver(state, dummy_generate)
+    assert "## Domain Instructions" in state.messages[0].content
+    assert "You are a research bot." in state.messages[0].content
+
+    # Test _parse_and_validate_in_process directly
+    res = _parse_and_validate_in_process(
+        format_name="express",
+        version="1.0",
+        resolved_catalog_path=str(catalog_file),
+        surface_id="main",
+        completion='Preamble\n<a2ui>\nroot = Text("Direct test")\n</a2ui>\nPostamble',
+    )
+    assert len(res["compiled_jsons"]) > 0
+    assert len(res["parts"]) == 2
+
+    # Test compile_format_payload with empty output and error recovery
+    compile_solver = compile_format_payload("express", version="1.0")
+    empty_state = TaskState(
+        model=ModelName("mock/model"),
+        sample_id=1,
+        epoch=1,
+        input="test",
+        messages=[],
+        metadata={"catalog": str(catalog_file)},
+        output=None,
+    )
+    res_empty = await compile_solver(empty_state, dummy_generate)
+    assert res_empty.output is None or not res_empty.output.completion
+
+    # Error recovery on invalid syntax
+    error_state = TaskState(
+        model=ModelName("mock/model"),
+        sample_id=1,
+        epoch=1,
+        input="test",
+        messages=[],
+        metadata={"catalog": str(catalog_file)},
+        output=ModelOutput(
+            model="mock/model",
+            choices=[
+                ChatCompletionChoice(
+                    message=ChatMessageAssistant(
+                        content="<a2ui>INVALID CODE SYNTAX %%%</a2ui>"
+                    )
+                )
+            ],
+        ),
+    )
+    res_error = await compile_solver(error_state, dummy_generate)
+    assert "Compilation/validation failed:" in res_error.output.completion

--- a/eval/tests/test_strategies.py
+++ b/eval/tests/test_strategies.py
@@ -139,7 +139,7 @@ async def test_a2ui_express_solvers() -> None:
         assert state.messages[0].role == "system"
         assert "A2UI Express DSL Output Contract" in state.messages[0].content
 
-        # 2. Test Compile Solver with accompanying text and backticked tags
+        # 2. Test Compile Solver with accompanying text and sentinel tags
         compile_solver = compile_format_payload("express", version="1.0")
         state.output = ModelOutput(
             model="mock/model",
@@ -148,7 +148,7 @@ async def test_a2ui_express_solvers() -> None:
                     message=ChatMessageAssistant(
                         content=(
                             "Here is the domain research synthesis.\n\n"
-                            '`<a2ui>`\nroot = Text("Hello")\n`</a2ui>`\n\n'
+                            '<a2ui>\nroot = Text("Hello")\n</a2ui>\n\n'
                             "Additional reference notes."
                         )
                     )

--- a/eval/tests/test_strategies.py
+++ b/eval/tests/test_strategies.py
@@ -139,19 +139,25 @@ async def test_a2ui_express_solvers() -> None:
         assert state.messages[0].role == "system"
         assert "A2UI Express DSL Output Contract" in state.messages[0].content
 
-        # 2. Test Compile Solver
+        # 2. Test Compile Solver with accompanying text and backticks
         compile_solver = compile_format_payload("express", version="1.0")
         state.output = ModelOutput(
             model="mock/model",
             choices=[
                 ChatCompletionChoice(
                     message=ChatMessageAssistant(
-                        content='<a2ui>\nroot = Text("Hello")\n</a2ui>'
+                        content=(
+                            'Here is the domain research synthesis.\n\n'
+                            '```a2ui\nroot = Text("Hello")\n```\n\n'
+                            'Additional reference notes.'
+                        )
                     )
                 )
             ],
         )
         state = await compile_solver(state, dummy_generate)
+        assert "Here is the domain research synthesis." in state.output.completion
+        assert "Additional reference notes." in state.output.completion
         assert "<a2ui-json>" in state.output.completion
         assert '"component": "Text"' in state.output.completion
     finally:

--- a/eval/tests/test_strategies.py
+++ b/eval/tests/test_strategies.py
@@ -139,7 +139,7 @@ async def test_a2ui_express_solvers() -> None:
         assert state.messages[0].role == "system"
         assert "A2UI Express DSL Output Contract" in state.messages[0].content
 
-        # 2. Test Compile Solver with accompanying text and backticks (with and without trailing newline before closing fence)
+        # 2. Test Compile Solver with accompanying text and backticked tags
         compile_solver = compile_format_payload("express", version="1.0")
         state.output = ModelOutput(
             model="mock/model",
@@ -148,7 +148,7 @@ async def test_a2ui_express_solvers() -> None:
                     message=ChatMessageAssistant(
                         content=(
                             "Here is the domain research synthesis.\n\n"
-                            '```a2ui\nroot = Text("Hello")```\n\n'
+                            '`<a2ui>`\nroot = Text("Hello")\n`</a2ui>`\n\n'
                             "Additional reference notes."
                         )
                     )


### PR DESCRIPTION
## Summary
Preserves accompanying prose when compiling evaluation format payloads, normalizes Express format version prefixes, and adds diagnostic hints for unescaped JSON backslashes.

## Changes
- **Evaluation Solvers (`eval/a2ui_eval/strategies/format.py`)**:
  - Update `_parse_and_validate_in_process` and `parse_with_hard_kill_timeout` to return serialized message parts alongside compiled JSON objects.
  - Update `compile_format_payload` to preserve preamble and postamble prose alongside compiled `<a2ui-json>` blocks.
  - Normalize format version strings passed to `ExpressFormat` to include the leading `v` prefix.
- **Payload Parser (`agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py`)**:
  - Add actionable error hints to `_parse` when JSON decoding fails due to unescaped backslashes (such as in LaTeX formulas).
  - Catch `A2uiParseError` in `parse_and_fix` recovery passes.
- **Tests**:
  - Add unit tests for backslash error hints and trailing comma recovery in `agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py`.
  - Add `test_has_format_content_and_unwrap_tags` in `agent_sdks/python/a2ui_agent/tests/express/test_parser_decompile.py`.
  - Add `test_format_system_prompt_with_domain_prompt` and expand `test_a2ui_express_solvers` in `eval/tests/test_strategies.py` to verify multi-part preservation and solver error recovery.

## Testing
Run the evaluation test suite:
```bash
uv run --directory eval pytest tests/test_strategies.py
```

Run the parser test suite:
```bash
uv run --directory agent_sdks/python/a2ui_agent pytest tests/parser/test_payload_fixer.py tests/express/test_parser_decompile.py
```
