### PR TITLE
style(swift): normalize acronym casing for ID, URI, JSON, and URL

### DIFF
--- a/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
+++ b/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
@@ -160,7 +160,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
     case checks
     case action
     case childList
-    case componentId
+    case componentID
     case number
     case integer
     case standard
@@ -189,7 +189,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
       case "CheckRule", "Checkable": return .checks
       case "Action": return .action
       case "ChildList": return .childList
-      case "ComponentId": return .componentId
+      case "ComponentId": return .componentID
       default: break
       }
     }
@@ -422,7 +422,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
         components: components,
         data: data
       )
-    case .componentId:
+    case .componentID:
       guard let childID = value.stringValue else { return nil }
       return resolveNode(
         definitionID: childID,

--- a/swift/core/Tests/A2UICoreTests/CatalogTests.swift
+++ b/swift/core/Tests/A2UICoreTests/CatalogTests.swift
@@ -147,7 +147,7 @@ struct CatalogTests {
 
   // MARK: - Initialization
 
-  @Test func catalogInitializesWithIdComponentsAndFunctions() throws {
+  @Test func catalogInitializesWithIDComponentsAndFunctions() throws {
     let buttonSchema = try Schema(
       instance: """
         {

--- a/swift/core/Tests/A2UICoreTests/MessageErrorMapperTests.swift
+++ b/swift/core/Tests/A2UICoreTests/MessageErrorMapperTests.swift
@@ -147,7 +147,7 @@ struct MessageErrorMapperTests {
     }
   }
 
-  @Test func parseReturnsNilSurfaceIDForInvalidJson() {
+  @Test func parseReturnsNilSurfaceIDForInvalidJSON() {
     let parser = MessageParser()
     do {
       _ = try parser.parse(jsonString: "not valid json")

--- a/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
+++ b/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
@@ -60,7 +60,7 @@ struct MessageParserTests {
     }
   }
 
-  @Test func parseInvalidJsonThrows() throws {
+  @Test func parseInvalidJSONThrows() throws {
     let parser = MessageParser()
     #expect(throws: MessageParseError.self) {
       try parser.parse(jsonString: "not valid json")

--- a/swift/core/Tests/A2UICoreTests/ModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/ModelTests.swift
@@ -21,7 +21,7 @@ struct NodeTests {
 
   // MARK: - Initialization
 
-  @Test func nodeInitializesWithIdTypeAndProperties() {
+  @Test func nodeInitializesWithIDTypeAndProperties() {
     let node = Node(
       id: "btn1",
       type: "button",
@@ -426,7 +426,7 @@ struct ComponentPropertiesTests {
     #expect(a != b)
   }
 
-  @Test func componentPropertiesInequalityByDifferentJson() throws {
+  @Test func componentPropertiesInequalityByDifferentJSON() throws {
     let schema = try Schema(instance: "{\"type\": \"object\"}")
     let a = ComponentProperties(type: "button", schema: schema, json: ["id": "btn1"])
     let b = ComponentProperties(type: "button", schema: schema, json: ["id": "btn2"])

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -212,7 +212,7 @@ struct SurfaceViewModelTests {
     }
   }
 
-  @Test func updateComponentsRejectsMissingIdKey() throws {
+  @Test func updateComponentsRejectsMissingIDKey() throws {
     let (processor, _, handler) = try makeProcessor()
     processor.updateComponents(
       surfaceID: "test-surface",
@@ -999,7 +999,7 @@ struct SurfaceViewModelTests {
 
 struct ComponentModelTests {
 
-  @Test func componentModelStoresIdTypeAndProperties() {
+  @Test func componentModelStoresIDTypeAndProperties() {
     let model = ComponentModel(
       id: "btn1",
       type: "button",
@@ -1079,7 +1079,7 @@ struct SurfaceComponentsModelTests {
     #expect(model.components.isEmpty)
   }
 
-  @Test func replaceComponentWithSameId() {
+  @Test func replaceComponentWithSameID() {
     let model = SurfaceComponentsModel()
     model.addComponent(ComponentModel(id: "btn1", type: "button", properties: ["label": "Old"]))
     model.addComponent(ComponentModel(id: "btn1", type: "button", properties: ["label": "New"]))

--- a/swift/core/Tests/A2UIJSONTests/A2UICommonSchemaTests.swift
+++ b/swift/core/Tests/A2UIJSONTests/A2UICommonSchemaTests.swift
@@ -28,7 +28,7 @@ struct A2UICommonSchemaTests {
     )
   }
 
-  @Test func testUriForDefinition() {
+  @Test func testURIForDefinition() {
     #expect(
       A2UICommonSchema.uri(for: "DataBinding")
         == "https://a2ui.org/schemas/v0_9_1/common.json#/$defs/DataBinding"
@@ -340,7 +340,7 @@ struct A2UICommonSchemaTests {
 
   // MARK: - Validation: ComponentCommon
 
-  @Test func testComponentCommonValidatesWithId() throws {
+  @Test func testComponentCommonValidatesWithID() throws {
     let schema = try Schema(
       instance: """
         { "$ref": "\(A2UICommonSchema.uri(for: "ComponentCommon"))" }
@@ -352,7 +352,7 @@ struct A2UICommonSchemaTests {
     #expect(result.isValid)
   }
 
-  @Test func testComponentCommonRejectsMissingId() throws {
+  @Test func testComponentCommonRejectsMissingID() throws {
     let schema = try Schema(
       instance: """
         { "$ref": "\(A2UICommonSchema.uri(for: "ComponentCommon"))" }

--- a/swift/core/Tests/BasicCatalogTests/OpenURLFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/OpenURLFunctionTests.swift
@@ -47,7 +47,7 @@ struct OpenURLFunctionTests {
 
   // MARK: - Evaluation
 
-  @Test func opensValidHTTPSUrl() throws {
+  @Test func opensValidHTTPSURL() throws {
     let handler = MockOpenURLHandler()
     let function = OpenURLFunction(handler: handler)
 
@@ -60,7 +60,7 @@ struct OpenURLFunctionTests {
     #expect(handler.openedURL?.absoluteString == "https://example.com/foo?bar=baz")
   }
 
-  @Test func opensValidHTTPUrl() throws {
+  @Test func opensValidHTTPURL() throws {
     let handler = MockOpenURLHandler()
     let function = OpenURLFunction(handler: handler)
 
@@ -72,7 +72,7 @@ struct OpenURLFunctionTests {
     #expect(handler.openedURL?.absoluteString == "http://insecure.com")
   }
 
-  @Test func resolvesRelativeUrlWhenBaseUrlIsProvided() throws {
+  @Test func resolvesRelativeURLWhenBaseURLIsProvided() throws {
     let handler = MockOpenURLHandler()
     let baseURL = try #require(URL(string: "https://google.com/search"))
     let function = OpenURLFunction(handler: handler, baseURL: baseURL)
@@ -85,7 +85,7 @@ struct OpenURLFunctionTests {
     #expect(handler.openedURL?.absoluteString == "https://google.com/search?q=swift")
   }
 
-  @Test func throwsErrorWhenMissingUrlArgument() {
+  @Test func throwsErrorWhenMissingURLArgument() {
     let function = OpenURLFunction()
 
     #expect(throws: FunctionError.self) {
@@ -117,7 +117,7 @@ struct OpenURLFunctionTests {
     }
   }
 
-  @Test func throwsErrorWhenRelativeUrlHasNoSchemeAndNoBaseUrl() {
+  @Test func throwsErrorWhenRelativeURLHasNoSchemeAndNoBaseURL() {
     let function = OpenURLFunction()
 
     #expect(throws: FunctionError.self) {


### PR DESCRIPTION
## Summary

Normalizes identifier and test method naming across the Swift codebase to adhere to standard Swift API Design Guidelines regarding acronym capitalization (`ID`, `URI`, `JSON`, `URL`).

## Changes

- **Core Models**:
  - `SurfaceViewModel.PropertyType`: Renamed `.componentId` to `.componentID` in `swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift`.
- **Test Suites**:
  - Renamed test methods across `A2UICoreTests`, `A2UIJSONTests`, and `BasicCatalogTests` to use consistent acronym capitalization (e.g., `parseInvalidJSONThrows`, `testURIForDefinition`, `opensValidHTTPSURL`, `resolvesRelativeURLWhenBaseURLIsProvided`, `replaceComponentWithSameID`).

## Impact & Risks

- **Impact**: Improves naming consistency and conformance with Swift conventions.
- **Risks**: None. Internal naming cleanup with no behavioral or protocol changes.

## Testing

- Code formatting and linting:
  ```bash
  swift-format format -i -r Package.swift swift/core swift/swiftui swift/sample/Sources
  swift-format lint -r Package.swift swift/core swift/swiftui swift/sample/Sources
  ```
