### PR TITLE
docs(spec): fix unsatisfiable catalogId prose in v0.9/v0.9.1 server_to_client.json

### DIFF
--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -53,7 +53,7 @@
         },
         "updateComponents": {
           "type": "object",
-          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one specified by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -114,7 +114,7 @@
         },
         "deleteSurface": {
           "type": "object",
-          "description": "Signals the client to delete the surface identified by 'surfaceId'. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
+          "description": "Signals the client to delete the surface identified by 'surfaceId'. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one specified by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -84,7 +84,7 @@
         },
         "updateDataModel": {
           "type": "object",
-          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one specified by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -53,7 +53,7 @@
         },
         "updateComponents": {
           "type": "object",
-          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",
@@ -84,7 +84,7 @@
         },
         "updateDataModel": {
           "type": "object",
-          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",
@@ -114,7 +114,7 @@
         },
         "deleteSurface": {
           "type": "object",
-          "description": "Signals the client to delete the surface identified by 'surfaceId'. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "description": "Signals the client to delete the surface identified by 'surfaceId'. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9_1/json/server_to_client.json
+++ b/specification/v0_9_1/json/server_to_client.json
@@ -53,7 +53,7 @@
         },
         "updateComponents": {
           "type": "object",
-          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one specified by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9_1/json/server_to_client.json
+++ b/specification/v0_9_1/json/server_to_client.json
@@ -114,7 +114,7 @@
         },
         "deleteSurface": {
           "type": "object",
-          "description": "Signals the client to delete the surface identified by 'surfaceId'. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
+          "description": "Signals the client to delete the surface identified by 'surfaceId'. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one specified by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9_1/json/server_to_client.json
+++ b/specification/v0_9_1/json/server_to_client.json
@@ -84,7 +84,7 @@
         },
         "updateDataModel": {
           "type": "object",
-          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one specified by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9_1/json/server_to_client.json
+++ b/specification/v0_9_1/json/server_to_client.json
@@ -53,7 +53,7 @@
         },
         "updateComponents": {
           "type": "object",
-          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",
@@ -84,7 +84,7 @@
         },
         "updateDataModel": {
           "type": "object",
-          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",
@@ -114,7 +114,7 @@
         },
         "deleteSurface": {
           "type": "object",
-          "description": "Signals the client to delete the surface identified by 'surfaceId'. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "description": "Signals the client to delete the surface identified by 'surfaceId'. A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface.",
           "properties": {
             "surfaceId": {
               "type": "string",


### PR DESCRIPTION
# Description

The `description` fields of `updateComponents`, `updateDataModel`, and `deleteSurface` in `server_to_client.json` (v0.9 and v0.9.1) state that createSurface message must have been previously sent with "the 'catalogId' that is in this message". But none of these message bodies has a `catalogId` property, and all three are `additionalProperties: false`, so the constraint
as written cannot be satisfied. Correlation is in fact by `surfaceId`.

This PR rewords the three descriptions to state the actual constraint:

> "A createSurface message MUST have been previously sent for the 'surfaceId' in this message; the surface's catalog is the one fixed by that createSurface."

Prose change only.

Fixes #2445

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
