### PR TITLE
fix(renderers): scope ChoicePicker radio group names to the surface

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.spec.ts
@@ -90,6 +90,25 @@ describe('ChoicePickerComponent', () => {
     expect(options[0].textContent).toContain('Opt 1');
   });
 
+  it('should scope radio group names to the surface', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      variant: createBoundProperty<string | undefined>('mutuallyExclusive'),
+      options: createBoundProperty<{label: DynamicString; value: string}[]>([
+        {label: 'Opt 1', value: '1'},
+        {label: 'Opt 2', value: '2'},
+      ]),
+      value: createBoundProperty(['1']),
+    });
+    fixture.detectChanges();
+
+    // Radio names are document-scoped while component ids are only
+    // surface-scoped: the name must combine both so that pickers with the
+    // same component id on different surfaces stay in separate groups.
+    const input = fixture.nativeElement.querySelector('input[type="radio"]');
+    expect(input.name).toBe('test-surface-test-choice-picker');
+  });
+
   it('should call onUpdate when option selected', () => {
     const onUpdateSpy = jasmine.createSpy('onUpdate');
     setComponentProps(fixture, {

--- a/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
@@ -60,7 +60,7 @@ import {ChoicePickerApi} from '@a2ui/web_core/v0_9/basic_catalog';
             <label class="a2ui-option-label">
               <input
                 [type]="isMultiple() ? 'checkbox' : 'radio'"
-                [name]="componentId()"
+                [name]="radioGroupName()"
                 [value]="option.value"
                 [checked]="isSelected(option.value)"
                 (change)="onCheckChange(option.value, $event)"
@@ -131,6 +131,13 @@ export class ChoicePickerComponent extends BasicCatalogComponent<typeof ChoicePi
   readonly options = computed(() => this.props()['options']?.value() || []);
   readonly variant = computed(() => this.props()['variant']?.value());
   readonly selectedValue = computed(() => this.props()['value']?.value());
+
+  /**
+   * Radio input names are document-scoped while component ids are only
+   * surface-scoped, so the group name must combine the surface id with the
+   * component id to keep pickers on different surfaces in separate groups.
+   */
+  readonly radioGroupName = computed(() => `${this.surfaceId()}-${this.componentId()}`);
 
   isMultiple(): boolean {
     return this.variant() === 'multipleSelection';

--- a/renderers/react/src/v0_9/catalog/basic/components/ChoicePicker.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/ChoicePicker.tsx
@@ -85,7 +85,11 @@ export const ChoicePicker = createComponentImplementation(ChoicePickerApi, ({pro
                 type={isMutuallyExclusive ? 'radio' : 'checkbox'}
                 checked={isSelected}
                 onChange={() => onToggle(opt.value)}
-                name={isMutuallyExclusive ? `choice-${context.componentModel.id}` : undefined}
+                name={
+                  isMutuallyExclusive
+                    ? `choice-${context.surfaceId}-${context.componentModel.id}`
+                    : undefined
+                }
               />
               <span className={styles.optionText}>{opt.label}</span>
             </label>

--- a/renderers/web_core/src/v0_9/rendering/component-context.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/component-context.test.ts
@@ -77,4 +77,17 @@ describe('ComponentContext', () => {
     const context = new ComponentContext(mockSurface, componentId);
     assert.deepStrictEqual(context.theme, {});
   });
+
+  it('exposes the surface id, so document-scoped names can disambiguate same-id components across surfaces', () => {
+    const surface2 = new SurfaceModel('surface2', {} as any);
+    const componentModel2 = new ComponentModel(componentId, 'TestComponent', {});
+    surface2.componentsModel.addComponent(componentModel2);
+
+    const context1 = new ComponentContext(mockSurface, componentId);
+    const context2 = new ComponentContext(surface2, componentId);
+
+    assert.strictEqual(context1.surfaceId, 'surface1');
+    assert.strictEqual(context2.surfaceId, 'surface2');
+    assert.strictEqual(context1.componentModel.id, context2.componentModel.id);
+  });
 });

--- a/renderers/web_core/src/v0_9/rendering/component-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/component-context.ts
@@ -36,6 +36,12 @@ export class ComponentContext {
   readonly surfaceComponents: SurfaceComponentsModel;
   /** The theme configuration for the surface this component belongs to. */
   readonly theme: any;
+  /**
+   * The id of the surface this component belongs to. Component ids are only
+   * unique within a surface, so document-scoped HTML constructs (e.g. radio
+   * input `name` groups) must combine this with the component id.
+   */
+  readonly surfaceId: string;
 
   /**
    * Creates a new component context.
@@ -52,6 +58,7 @@ export class ComponentContext {
     this.componentModel = model;
     this.surfaceComponents = surface.componentsModel;
     this.theme = surface.theme;
+    this.surfaceId = surface.id;
 
     this.dataContext = new DataContext(surface, dataModelBasePath);
     this._actionDispatcher = action => surface.dispatchAction(action, this.componentModel.id);


### PR DESCRIPTION
## Problem

As reported in #2447: the React and Angular renderers name `ChoicePicker`'s radio inputs using only the A2UI component id. HTML radio `name`s are **document-scoped** — every radio sharing a name forms one mutually exclusive group — but A2UI component ids are only **surface-scoped** (per `common_types.json` `ComponentId`, and the protocol guarantees id reuse across surfaces since every surface contains an `id: "root"`).

When two live surfaces each render a ChoicePicker with the same component id, their radios merge into one document-wide group. The browser's one-dot-per-group rule fights the renderers' controlled inputs: selections lose their dot, and arrow-key navigation hops between the two surfaces' radios.

## Fix

- Expose `surfaceId` on `ComponentContext` (web_core) — the constructor already receives the `SurfaceModel`, whose `id` is the document-unique surface identifier.
- React: `name={`choice-${context.surfaceId}-${context.componentModel.id}`}`
- Angular: `radioGroupName` computed combining the `surfaceId()` and `componentId()` inputs.

Radio groups are now unique per surface+component, so same-id pickers on different surfaces no longer interfere. Non-radio (checkbox) rendering is unchanged — Angular previously applied the name to checkboxes too, which was inert for grouping.

## Testing

- web_core: new `ComponentContext` test asserting `surfaceId` distinguishes same-id components across surfaces. Full suite: **350/351 pass** locally — the single failure (`pluralize`, ICU plural rules) reproduces on unmodified `main` with the same dependency set and is unrelated.
- Angular: new spec asserting the rendered radio name is `test-surface-test-choice-picker` (follows the existing `setInput('surfaceId', ...)` pattern).
- React: template-only change, no component test harness exists for it in this repo.

Fixes #2447