### PR TITLE
release: prepare web SDK packages for release

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.6
+
 - (v0_9) Implement `createComponentImplementation` helper and deprecate `extraComponents` and `functions` in `BasicCatalogOptions` to align with the core API. [#2060](https://github.com/a2ui-project/a2ui/pull/2060)
 
 ## 0.10.5

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.4
+
 - (v0_9) Migrate Basic Catalog components and surface rendering from Shadow DOM to Light DOM. [#2204](https://github.com/a2ui-project/a2ui/pull/2204)
 
 ## 0.10.3

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/lit",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A2UI Lit Library",
   "author": "Google",
   "license": "Apache-2.0",

--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.3
+
 - (v0_9) Component implementations may supply a `view` that renders from a resolved `ComponentNode` (see `NodeViewProps` and `useSignalValue`) ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `A2uiSurface` renders through the node layer: each component re-renders only when its own data changes. Implementations without a `view` keep rendering through `render` ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).
 - **BREAKING CHANGE**: (v0_9) On schema-marked references, `buildChild`'s `basePath` argument selects among the instances the payload creates; it no longer creates an instance at a caller-chosen path. The rendered notice for such a request names the paths where instances exist and reports `UNRESOLVED_CHILD_REFERENCE` through `onError` ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).

--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.10.3
+## 0.11.0
 
 - (v0_9) Component implementations may supply a `view` that renders from a resolved `ComponentNode` (see `NodeViewProps` and `useSignalValue`) ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `A2uiSurface` renders through the node layer: each component re-renders only when its own data changes. Implementations without a `view` keep rendering through `render` ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/react",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "Apache-2.0",
   "description": "React renderer for A2UI (Agent-to-User Interface)",
   "homepage": "https://a2ui.org/",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/react",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "React renderer for A2UI (Agent-to-User Interface)",
   "homepage": "https://a2ui.org/",

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.7
+
 - (v0_9) The child-reference marker on `ComponentIdSchema` and `ChildListSchema` now lives in the schema's metadata, so `.describe()` and other schema-rebuilding methods no longer drop it. Hand-authored `REF:` descriptions are still recognized ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).
 
 - (v0_9) Add the node layer: `NodeResolver` resolves a surface's components and data into a live tree of read-only `ComponentNode`s, with dynamic properties resolved to `ResolvedBinding`/`WritableBinding` and distinct pending, unknown-type, and cyclic placeholder states. Sibling instance ids are always distinct, unresolvable and cyclic references are reported through `onError` once per component and data path while the condition persists, model events delivered late reconcile against current model state, and child-reference detection covers `ChildList` unions and plain arrays of component ids ([#2077](https://github.com/a2ui-project/a2ui/pull/2077), [#2393](https://github.com/a2ui-project/a2ui/pull/2393)).

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "A2UI Core Library",
   "homepage": "https://a2ui.org/",
   "repository": {


### PR DESCRIPTION
### Summary

Prepares the A2UI Web/TypeScript SDK packages for public release by updating package version numbers and moving unreleased items into version release sections in `CHANGELOG.md`.

### Packages Released

- **`@a2ui/web_core`**: `0.10.6` -> `0.10.7`
- **`@a2ui/lit`**: `0.10.3` -> `0.10.4`
- **`@a2ui/angular`**: `0.10.5` -> `0.10.6`
- **`@a2ui/react`**: `0.10.2` -> `0.10.3`

### Verification

- Package versions incremented using `./renderers/scripts/increment_version.mjs`.
- All `CHANGELOG.md` headings updated cleanly.