### PR TITLE
generalize the MCP Action trigger from A2UI when using A2UI-over-MCP

### DIFF
--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/app.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/app.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright 2026 Google LLC
+/*
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/app.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/app.ts
@@ -1,5 +1,5 @@
-/*
- * Copyright 2024 Google LLC
+/**
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,36 +14,17 @@
  * limitations under the License.
  */
 
-import {LitElement, html, css, nothing} from 'lit';
+import {LitElement, html, css} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
-import {MessageProcessor} from '@a2ui/web_core/v0_9';
 import {basicCatalog, Context} from '@a2ui/lit/v0_9';
 import '@a2ui/lit/v0_9'; // Registers <a2ui-surface>
 import {provide} from '@lit/context';
 import {renderMarkdown} from '@a2ui/markdown-it';
+import {A2uiMcpEngine, ConnectionStatus, MCP_CALL_TOOL_ACTION} from './engine.js';
 
-// Model Context Protocol SDK
-import {Client} from '@modelcontextprotocol/sdk/client/index.js';
-import {SSEClientTransport} from '@modelcontextprotocol/sdk/client/sse.js';
-
-// A2UI Protocol & Catalog Constants
-const BASIC_CATALOG_ID = 'https://a2ui.org/specification/v0_9/basic_catalog.json';
-const A2UI_MIME_TYPES = [
-  'application/a2ui+json',
-  'application/json+a2ui',
-  'application/json;profile=a2ui',
-];
-
-// MCP Tool Names
-const TOOL_GET_RECIPE_FORM = 'get_recipe_form_a2ui';
-const TOOL_GET_RECIPE = 'get_recipe_a2ui';
-
-// A2UI Surface IDs
+// Recipe Studio Surface IDs
 const RECIPE_FORM_SURFACE_ID = 'recipe-form';
 const RECIPE_CARD_SURFACE_ID = 'recipe-card';
-
-// A2UI Client Action Events
-const ACTION_GENERATE_RECIPE = 'generate_recipe';
 
 @customElement('a2ui-recipe-app')
 export class A2uiRecipeApp extends LitElement {
@@ -52,27 +33,22 @@ export class A2uiRecipeApp extends LitElement {
     return Promise.resolve(renderMarkdown(value, options));
   };
 
-  @state() private accessor connectionStatus:
-    | 'disconnected'
-    | 'connecting'
-    | 'connected'
-    | 'error' = 'disconnected';
+  @state() private accessor connectionStatus: ConnectionStatus = 'disconnected';
   @state() private accessor statusMessage = 'Ready';
-  @state() private accessor recipeLoading = false;
 
-  private mcpClient: Client | null = null;
-
-  // Maintain separate processors and surface models for form and recipe card
-  private formProcessor!: MessageProcessor<any>;
-  private recipeProcessor!: MessageProcessor<any>;
-
-  @state() private accessor formSurface: any = null;
-  @state() private accessor recipeSurface: any = null;
-
-  // Cache for loaded presentation templates keyed by resource URI
-  private templateCache = new Map<string, any[]>();
-  // Mapping of tool names to declared UI template resource URIs from tool definitions
-  private toolUiResources = new Map<string, string>();
+  // Generic A2UI-over-MCP host runtime engine
+  private mcpEngine = new A2uiMcpEngine([basicCatalog], {
+    onAction: (action) => this.handleAction(action),
+    onStatusChange: (msg) => {
+      this.statusMessage = msg;
+    },
+    onConnectionChange: (status) => {
+      this.connectionStatus = status;
+    },
+    onSurfaceChange: () => {
+      this.requestUpdate();
+    },
+  });
 
   static styles = css`
     :host {
@@ -96,32 +72,49 @@ export class A2uiRecipeApp extends LitElement {
     .logo {
       display: flex;
       align-items: center;
-      gap: 12px;
+      gap: 16px;
     }
 
-    .logo span.emoji {
+    .logo .emoji {
       font-size: 32px;
+      background: rgba(255, 90, 95, 0.15);
+      border-radius: 12px;
+      width: 52px;
+      height: 52px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid rgba(255, 90, 95, 0.3);
     }
 
     .logo h1 {
-      font-size: 28px;
-      font-weight: 800;
+      margin: 0;
+      font-size: 24px;
+      font-weight: 700;
       letter-spacing: -0.5px;
-      background: linear-gradient(to right, #ff5a5f, #ff9094);
+      background: linear-gradient(135deg, #ffffff 0%, #cbd5e1 100%);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
+    }
+
+    .logo p {
+      margin: 4px 0 0 0;
+      font-size: 13px;
+      color: #94a3b8;
     }
 
     .status-badge {
       display: flex;
       align-items: center;
-      gap: 8px;
-      padding: 8px 16px;
-      border-radius: 99px;
-      background: rgba(255, 255, 255, 0.04);
+      gap: 10px;
+      background: rgba(15, 23, 42, 0.6);
       border: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 8px 16px;
+      border-radius: 9999px;
       font-size: 13px;
       font-weight: 500;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
     }
 
     .status-dot {
@@ -131,96 +124,76 @@ export class A2uiRecipeApp extends LitElement {
       background: #64748b;
     }
 
-    .status-dot.connecting {
-      background: #3b82f6;
-      box-shadow: 0 0 8px #3b82f6;
-      animation: pulse 1.5s infinite ease-in-out;
-    }
-
     .status-dot.connected {
       background: #10b981;
-      box-shadow: 0 0 8px #10b981;
+      box-shadow: 0 0 12px rgba(16, 185, 129, 0.5);
+    }
+
+    .status-dot.connecting {
+      background: #f59e0b;
+      box-shadow: 0 0 12px rgba(245, 158, 11, 0.5);
     }
 
     .status-dot.error {
       background: #ef4444;
-      box-shadow: 0 0 8px #ef4444;
+      box-shadow: 0 0 12px rgba(239, 68, 68, 0.5);
     }
 
-    .main-grid {
+    .status-text {
+      color: #cbd5e1;
+    }
+
+    main {
       display: grid;
-      grid-template-columns: 1fr;
+      grid-template-columns: 1fr 1fr;
       gap: 32px;
+      align-items: start;
     }
 
-    @media (min-width: 800px) {
-      .main-grid {
-        grid-template-columns: 450px 1fr;
+    @media (max-width: 900px) {
+      main {
+        grid-template-columns: 1fr;
       }
     }
 
     .section-card {
-      background: rgba(255, 255, 255, 0.03);
+      background: rgba(30, 41, 59, 0.4);
       border: 1px solid rgba(255, 255, 255, 0.06);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
       border-radius: 24px;
       padding: 32px;
-      transition:
-        transform 0.3s ease,
-        box-shadow 0.3s ease;
-      display: flex;
-      flex-direction: column;
-      gap: 20px;
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      box-shadow: 0 20px 40px -15px rgba(0, 0, 0, 0.3);
       position: relative;
-    }
-
-    .section-card:hover {
-      box-shadow: 0 10px 30px -15px rgba(0, 0, 0, 0.5);
+      overflow: hidden;
+      min-height: 480px;
     }
 
     .section-title {
       font-size: 18px;
-      font-weight: 700;
-      color: #94a3b8;
-      text-transform: uppercase;
-      letter-spacing: 1px;
-      margin-bottom: 12px;
+      font-weight: 600;
+      margin-bottom: 24px;
+      color: #f1f5f9;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .section-title::before {
+      content: '';
+      display: inline-block;
+      width: 4px;
+      height: 16px;
+      background: #ff5a5f;
+      border-radius: 2px;
     }
 
     .placeholder-box {
-      border: 2px dashed rgba(255, 255, 255, 0.08);
-      border-radius: 20px;
-      padding: 64px 32px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
+      border: 2px dashed rgba(255, 255, 255, 0.1);
+      border-radius: 16px;
+      padding: 48px 24px;
       text-align: center;
       color: #64748b;
-      gap: 16px;
-      min-height: 400px;
-    }
-
-    .placeholder-icon {
-      font-size: 48px;
-      color: rgba(255, 255, 255, 0.15);
-    }
-
-    .placeholder-text h3 {
-      color: #cbd5e1;
-      font-size: 18px;
-      font-weight: 600;
-      margin-bottom: 8px;
-    }
-
-    .placeholder-text p {
-      font-size: 14px;
-      max-width: 320px;
-      line-height: 1.5;
-    }
-
-    .loader-box {
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -229,39 +202,35 @@ export class A2uiRecipeApp extends LitElement {
       min-height: 450px;
     }
 
-    .spinner {
-      width: 50px;
-      height: 50px;
-      border: 4px solid rgba(255, 255, 255, 0.05);
-      border-top-color: #ff5a5f;
+    .placeholder-icon {
+      width: 80px;
+      height: 80px;
+      background: rgba(255, 255, 255, 0.03);
       border-radius: 50%;
-      animation: spin 1s linear infinite;
-    }
-
-    .loading-overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(15, 23, 42, 0.75);
-      backdrop-filter: blur(12px);
-      -webkit-backdrop-filter: blur(12px);
-      border-radius: 24px;
       display: flex;
-      flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 20px;
-      z-index: 10;
-      animation: fadeIn 0.2s ease-out;
+      color: #ff5a5f;
+      border: 1px solid rgba(255, 255, 255, 0.05);
     }
 
-    .loading-text {
-      color: #cbd5e1;
-      font-size: 15px;
-      font-weight: 500;
-      text-align: center;
+    .placeholder-icon .material-symbols {
+      font-size: 36px;
+    }
+
+    .placeholder-text h3 {
+      margin: 0 0 8px 0;
+      color: #f8fafc;
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+    .placeholder-text p {
+      margin: 0;
+      font-size: 14px;
+      color: #94a3b8;
+      max-width: 320px;
+      line-height: 1.6;
     }
 
     /* Custom Styling Overrides for A2UI Components */
@@ -269,7 +238,7 @@ export class A2uiRecipeApp extends LitElement {
       width: 100%;
     }
 
-    /* Make form buttons and option pickers match our premium theme */
+    /* Make form buttons and option pickers match our theme */
     :host {
       color-scheme: dark;
       --a2ui-color-primary: #ff5a5f;
@@ -285,294 +254,83 @@ export class A2uiRecipeApp extends LitElement {
       --a2ui-spacing-m: 12px;
       --a2ui-spacing-l: 20px;
     }
-
-    @keyframes spin {
-      to {
-        transform: rotate(360deg);
-      }
-    }
-
-    @keyframes pulse {
-      0%,
-      100% {
-        opacity: 0.6;
-      }
-      50% {
-        opacity: 1;
-      }
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-      }
-      to {
-        opacity: 1;
-      }
-    }
   `;
 
-  constructor() {
-    super();
-    this.initializeA2UI();
-  }
-
-  private initializeA2UI() {
-    // 1. Form Processor Setup
-    this.formProcessor = new MessageProcessor([basicCatalog], async action => {
-      console.log('Form Action Received:', action);
-      if (action.name === ACTION_GENERATE_RECIPE) {
-        await this.generateRecipe(action.context);
-      }
-    });
-
-    // 2. Recipe Card Processor Setup
-    this.recipeProcessor = new MessageProcessor([basicCatalog], async action => {
-      console.log('Recipe Card Action:', action);
-    });
-  }
-
   protected async firstUpdated() {
-    await this.connectMcp();
-  }
-
-  private async connectMcp() {
-    this.connectionStatus = 'connecting';
-
     const urlParams = new URLSearchParams(window.location.search);
     const sseUrl =
       urlParams.get('sse_url') ||
       (import.meta as any).env?.VITE_SSE_URL ||
       'http://127.0.0.1:8000/sse';
 
-    this.statusMessage = `Connecting to MCP server at ${sseUrl}...`;
-
     try {
-      // Establish SSE client transport
-      const transport = new SSEClientTransport(new URL(sseUrl));
+      const serverName = await this.mcpEngine.connectServer(sseUrl);
+      // Initialize app-specific entrypoint form tool via generic engine
+      await this.mcpEngine.executeTool(serverName, 'get_recipe_form_a2ui');
+    } catch (error) {
+      console.error('Failed to initialize recipe app:', error);
+    }
+  }
 
-      this.mcpClient = new Client(
-        {
-          name: 'a2ui-recipe-app-client',
-          version: '1.0.0',
-        },
-        {
-          capabilities: {
-            a2ui: {
-              clientCapabilities: {
-                'v0.9': {
-                  supportedCatalogIds: [BASIC_CATALOG_ID],
-                },
-              },
-            },
-          } as any,
-        },
+  /**
+   * Top-level A2UI action router for the recipe application.
+   * Delegates MCP tool calls to the engine and logs errors for unsupported actions.
+   */
+  private async handleAction(action: any) {
+    console.log('A2UI Action received in recipe app:', action);
+
+    if (action.name === MCP_CALL_TOOL_ACTION) {
+      await this.mcpEngine.handleMcpCallTool(action.context);
+    } else {
+      console.error(
+        `Unsupported action '${action.name}': only '${MCP_CALL_TOOL_ACTION}' actions are supported in this application.`,
+        action,
       );
-
-      await this.mcpClient.connect(transport);
-      this.connectionStatus = 'connected';
-      this.statusMessage = `Connected to MCP Server (${sseUrl})`;
-
-      // Discover UI templates declared on tools ahead of invocation
-      try {
-        const toolsResult = await this.mcpClient.listTools();
-        for (const tool of toolsResult.tools) {
-          const uiUri = (tool as any)._meta?.ui?.resourceUri;
-          if (uiUri) {
-            this.toolUiResources.set(tool.name, uiUri);
-          }
-        }
-      } catch (err) {
-        console.warn('Could not query tool UI resources:', err);
-      }
-
-      await this.loadForm();
-    } catch (error: any) {
-      console.error('MCP Connection Error:', error);
-      this.connectionStatus = 'error';
-      this.statusMessage = `Connection failed: ${error.message || error}`;
-    }
-  }
-
-  private async loadForm() {
-    if (!this.mcpClient) return;
-
-    try {
-      this.statusMessage = `Initializing recipe form via ${TOOL_GET_RECIPE_FORM}...`;
-
-      // 1. Make MCP Tool Call to initialize the form
-      const result = await this.mcpClient.callTool({
-        name: TOOL_GET_RECIPE_FORM,
-        arguments: {},
-      });
-
-      // 2. Discover UI template resource URI from tool response _meta or tool definition
-      const resourceUri =
-        (result as any)._meta?.ui?.resourceUri || this.toolUiResources.get(TOOL_GET_RECIPE_FORM);
-
-      // 3. Fetch presentation template from server if not already cached
-      const template = await this.getOrFetchTemplate(resourceUri);
-
-      // 4. Ensure form surface exists with the presentation template layout
-      if (!this.formProcessor.model.getSurface(RECIPE_FORM_SURFACE_ID)) {
-        this.formProcessor.processMessages(template);
-      }
-
-      // 5. Extract A2UI dataModel update message from tool response content
-      const contentArray = (result.content as any[]) || [];
-      let dataMessages: any[] | null = null;
-
-      for (const item of contentArray) {
-        if (item.type === 'resource' && item.resource?.text) {
-          try {
-            dataMessages = JSON.parse(item.resource.text);
-            break;
-          } catch {}
-        } else if (item.type === 'text' && typeof item.text === 'string') {
-          try {
-            const parsed = JSON.parse(item.text);
-            if (Array.isArray(parsed) || parsed.updateDataModel) {
-              dataMessages = Array.isArray(parsed) ? parsed : [parsed];
-              break;
-            }
-          } catch {}
-        }
-      }
-
-      // 6. Apply dynamic data model update
-      if (dataMessages) {
-        this.formProcessor.processMessages(dataMessages);
-      }
-
-      this.formSurface = this.formProcessor.model.getSurface(RECIPE_FORM_SURFACE_ID);
-      this.statusMessage = 'Form loaded successfully';
-    } catch (error: any) {
-      console.error('Failed to load recipe form:', error);
-      this.connectionStatus = 'error';
-      this.statusMessage = `Form load failed: ${error.message || error}`;
-    }
-  }
-
-  private async getOrFetchTemplate(uri: string): Promise<any[]> {
-    if (this.templateCache.has(uri)) {
-      return this.templateCache.get(uri)!;
-    }
-
-    if (!this.mcpClient) {
-      throw new Error('MCP client is not connected.');
-    }
-
-    this.statusMessage = `Fetching UI template (${uri})...`;
-    const resourceResult = await this.mcpClient.readResource({uri});
-    const a2uiContent = resourceResult.contents.find((c: any) =>
-      A2UI_MIME_TYPES.includes(c.mimeType),
-    );
-
-    if (!a2uiContent || !('text' in a2uiContent)) {
-      throw new Error(`Resource ${uri} does not contain valid A2UI JSON template data.`);
-    }
-
-    const template = JSON.parse(a2uiContent.text);
-    this.templateCache.set(uri, template);
-    return template;
-  }
-
-  private async generateRecipe(context: any) {
-    if (!this.mcpClient) return;
-
-    this.recipeLoading = true;
-    this.statusMessage = `Executing ${TOOL_GET_RECIPE}...`;
-
-    try {
-      // 1. Make MCP Tool Call
-      const result = await this.mcpClient.callTool({
-        name: TOOL_GET_RECIPE,
-        arguments: context || {},
-      });
-
-      // 2. Discover UI template resource URI from tool response _meta or tool definition
-      const resourceUri =
-        (result as any)._meta?.ui?.resourceUri || this.toolUiResources.get(TOOL_GET_RECIPE);
-
-      // 3. Fetch presentation template from server if not already cached
-      const template = await this.getOrFetchTemplate(resourceUri);
-
-      // 4. Ensure recipe surface exists with the presentation template layout
-      if (!this.recipeProcessor.model.getSurface(RECIPE_CARD_SURFACE_ID)) {
-        this.recipeProcessor.processMessages(template);
-      }
-
-      // 5. Extract A2UI dataModel update message from tool response content
-      const contentArray = (result.content as any[]) || [];
-      let dataMessages: any[] | null = null;
-
-      for (const item of contentArray) {
-        if (item.type === 'resource' && item.resource?.text) {
-          try {
-            dataMessages = JSON.parse(item.resource.text);
-            break;
-          } catch {}
-        } else if (item.type === 'text' && typeof item.text === 'string') {
-          try {
-            const parsed = JSON.parse(item.text);
-            if (Array.isArray(parsed) || parsed.updateDataModel) {
-              dataMessages = Array.isArray(parsed) ? parsed : [parsed];
-              break;
-            }
-          } catch {}
-        }
-      }
-
-      if (!dataMessages) {
-        throw new Error('Tool response did not contain valid A2UI data update messages.');
-      }
-
-      // 6. Apply dynamic data model update
-      this.recipeProcessor.processMessages(dataMessages);
-      this.recipeSurface = this.recipeProcessor.model.getSurface(RECIPE_CARD_SURFACE_ID);
-      this.statusMessage = 'Recipe card loaded successfully!';
-      this.requestUpdate();
-    } catch (error: any) {
-      console.error('Error generating recipe:', error);
-      this.statusMessage = `Generation failed: ${error.message || error}`;
-    } finally {
-      this.recipeLoading = false;
     }
   }
 
   render() {
+    const formSurface = this.mcpEngine.getSurface(RECIPE_FORM_SURFACE_ID);
+    const recipeSurface = this.mcpEngine.getSurface(RECIPE_CARD_SURFACE_ID);
+
     return html`
       <header>
         <div class="logo">
           <span class="emoji">👨‍🍳</span>
-          <h1>A2UIxMCP Recipe Studio</h1>
+          <div>
+            <h1>A2UIxMCP Recipe Studio</h1>
+            <p>Interactive A2UI Mini-Apps driven by MCP Server Tools</p>
+          </div>
         </div>
+
         <div class="status-badge">
-          <span class="status-dot ${this.connectionStatus}"></span>
-          <span>${this.statusMessage}</span>
+          <div class="status-dot ${this.connectionStatus}"></div>
+          <span class="status-text">${this.statusMessage}</span>
         </div>
       </header>
 
-      <main class="main-grid">
-        <!-- Left Column: The Customization Form -->
+      <main>
         <section class="section-card">
-          <div class="section-title">Configure Choices</div>
-          ${this.formSurface
-            ? html`<a2ui-surface .surface=${this.formSurface}></a2ui-surface>`
+          <div class="section-title">Recipe Preferences</div>
+          ${formSurface
+            ? html`<a2ui-surface .surface=${formSurface}></a2ui-surface>`
             : html`
-                <div class="loader-box">
-                  <div class="spinner"></div>
-                  <div>Loading settings form...</div>
+                <div class="placeholder-box">
+                  <div class="placeholder-icon">
+                    <span class="material-symbols">tune</span>
+                  </div>
+                  <div class="placeholder-text">
+                    <h3>Connecting to MCP Server...</h3>
+                    <p>Loading interactive recipe configuration form.</p>
+                  </div>
                 </div>
               `}
         </section>
 
-        <!-- Right Column: The Generated Recipe Card -->
         <section class="section-card">
           <div class="section-title">Generated Recipe Card</div>
-
-          ${this.recipeSurface
-            ? html`<a2ui-surface .surface=${this.recipeSurface}></a2ui-surface>`
+          ${recipeSurface
+            ? html`<a2ui-surface .surface=${recipeSurface}></a2ui-surface>`
             : html`
                 <div class="placeholder-box">
                   <div class="placeholder-icon">
@@ -587,14 +345,6 @@ export class A2uiRecipeApp extends LitElement {
                   </div>
                 </div>
               `}
-          ${this.recipeLoading
-            ? html`
-                <div class="loading-overlay">
-                  <div class="spinner"></div>
-                  <div class="loading-text">Customizing layout and cooking details...</div>
-                </div>
-              `
-            : nothing}
         </section>
       </main>
     `;

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/app.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/app.ts
@@ -38,11 +38,11 @@ export class A2uiRecipeApp extends LitElement {
 
   // Generic A2UI-over-MCP host runtime engine
   private mcpEngine = new A2uiMcpEngine([basicCatalog], {
-    onAction: (action) => this.handleAction(action),
-    onStatusChange: (msg) => {
+    onAction: action => this.handleAction(action),
+    onStatusChange: msg => {
       this.statusMessage = msg;
     },
-    onConnectionChange: (status) => {
+    onConnectionChange: status => {
       this.connectionStatus = status;
     },
     onSurfaceChange: () => {

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.test.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.test.ts
@@ -241,7 +241,7 @@ describe('A2uiMcpEngine', () => {
       await expect(engine.handleMcpCallTool(null as any)).resolves.not.toThrow();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' (or '_server') in context:`,
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' in context:`,
         {},
       );
       consoleErrorSpy.mockRestore();
@@ -253,8 +253,20 @@ describe('A2uiMcpEngine', () => {
       await expect(engine.handleMcpCallTool(undefined as any)).resolves.not.toThrow();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' (or '_server') in context:`,
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' in context:`,
         {},
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('logs error if server is missing from context', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await engine.handleMcpCallTool({tool: 'get_sample_data'});
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' in context:`,
+        {tool: 'get_sample_data'},
       );
       consoleErrorSpy.mockRestore();
     });
@@ -265,39 +277,25 @@ describe('A2uiMcpEngine', () => {
       await engine.handleMcpCallTool({server: 'test-server'});
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        `'${MCP_CALL_TOOL_ACTION}' action missing required 'tool' (or '_tool') in context:`,
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'tool' in context:`,
         {server: 'test-server'},
       );
       consoleErrorSpy.mockRestore();
     });
 
-    it('filters routing metadata keys (_server, _tool, server, tool) from tool arguments', async () => {
-      const executeToolSpy = vi.spyOn(engine, 'executeTool').mockResolvedValue(undefined);
-
-      await engine.handleMcpCallTool({
-        _server: 'test-server',
-        _tool: 'get_sample_data',
-        category: 'italian',
-        difficulty: 'easy',
-      });
-
-      expect(executeToolSpy).toHaveBeenCalledWith('test-server', 'get_sample_data', {
-        category: 'italian',
-        difficulty: 'easy',
-      });
-    });
-
-    it('supports un-prefixed server and tool keys in context', async () => {
+    it('filters routing metadata keys (server, tool) from tool arguments', async () => {
       const executeToolSpy = vi.spyOn(engine, 'executeTool').mockResolvedValue(undefined);
 
       await engine.handleMcpCallTool({
         server: 'test-server',
         tool: 'get_sample_data',
-        param1: 123,
+        category: 'italian',
+        difficulty: 'easy',
       });
 
       expect(executeToolSpy).toHaveBeenCalledWith('test-server', 'get_sample_data', {
-        param1: 123,
+        category: 'italian',
+        difficulty: 'easy',
       });
     });
   });

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.test.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.test.ts
@@ -1,0 +1,478 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {
+  A2uiMcpEngine,
+  BASIC_CATALOG_ID,
+  DEFAULT_MCP_CLIENT_NAME,
+  DEFAULT_MCP_CLIENT_VERSION,
+  A2UI_MIME_TYPE,
+} from './engine';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {SSEClientTransport} from '@modelcontextprotocol/sdk/client/sse.js';
+
+let mockClient: {
+  connect: ReturnType<typeof vi.fn>;
+  getServerVersion: ReturnType<typeof vi.fn>;
+  listTools: ReturnType<typeof vi.fn>;
+  callTool: ReturnType<typeof vi.fn>;
+  readResource: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  const MockClient = vi.fn().mockImplementation(function () {
+    return mockClient;
+  });
+  return {Client: MockClient};
+});
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => {
+  const MockTransport = vi.fn().mockImplementation(function () {
+    return {};
+  });
+  return {SSEClientTransport: MockTransport};
+});
+
+describe('A2uiMcpEngine', () => {
+  const sampleTemplate = [
+    {
+      createSurface: {
+        surfaceId: 'test-surface',
+        catalogId: BASIC_CATALOG_ID,
+      },
+    },
+    {
+      updateComponents: {
+        surfaceId: 'test-surface',
+        components: [
+          {
+            id: 'root',
+            component: 'Text',
+            properties: {
+              text: {
+                literal: 'Test Presentation',
+              },
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockClient = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      getServerVersion: vi.fn().mockReturnValue({name: 'test-server', version: '1.0.0'}),
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: 'get_sample_data',
+            _meta: {
+              ui: {
+                resourceUri: 'a2ui://sample-template',
+              },
+            },
+          },
+        ],
+      }),
+      callTool: vi.fn().mockResolvedValue({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify([
+              {
+                updateDataModel: {
+                  surfaceId: 'test-surface',
+                  value: {title: 'Hello Recipe'},
+                },
+              },
+            ]),
+          },
+        ],
+      }),
+      readResource: vi.fn().mockResolvedValue({
+        contents: [
+          {
+            uri: 'a2ui://sample-template',
+            mimeType: A2UI_MIME_TYPE,
+            text: JSON.stringify(sampleTemplate),
+          },
+        ],
+      }),
+    };
+  });
+
+  describe('initialization', () => {
+    it('initializes with default basic catalog and handles undefined events', () => {
+      const engine = new A2uiMcpEngine(undefined, undefined);
+      expect(engine.processor).toBeDefined();
+      expect(engine.mcpClients.size).toBe(0);
+      expect(engine.getSurface('non-existent')).toBeUndefined();
+    });
+
+    it('forwards action triggers to onAction callback', async () => {
+      const onAction = vi.fn();
+      const engine = new A2uiMcpEngine(undefined, {onAction});
+      const dummyAction = {name: 'custom_action', context: {key: 'val'}};
+
+      // Emit action from processor's surface group model
+      (engine.processor.model.onAction as any).emit(dummyAction);
+      expect(onAction).toHaveBeenCalledWith(dummyAction);
+    });
+  });
+
+  describe('connectServer', () => {
+    it('connects to server, discovers tool UI resources, and registers client', async () => {
+      const onConnectionChange = vi.fn();
+      const onStatusChange = vi.fn();
+      const engine = new A2uiMcpEngine(undefined, {onConnectionChange, onStatusChange});
+
+      const serverName = await engine.connectServer('http://127.0.0.1:8000/sse', 'custom-client');
+
+      expect(serverName).toBe('test-server');
+      expect(engine.mcpClients.get('test-server')).toBe(mockClient);
+      expect(onConnectionChange).toHaveBeenNthCalledWith(1, 'connecting');
+      expect(onConnectionChange).toHaveBeenNthCalledWith(2, 'connected');
+      expect(onStatusChange).toHaveBeenCalledWith(
+        'Connected to MCP Server [test-server] (http://127.0.0.1:8000/sse)',
+      );
+
+      // Verify Client initialization options
+      expect(Client).toHaveBeenCalledWith(
+        {name: 'custom-client', version: DEFAULT_MCP_CLIENT_VERSION},
+        {
+          capabilities: {
+            a2ui: {
+              clientCapabilities: {
+                'v0.9': {
+                  supportedCatalogIds: [BASIC_CATALOG_ID],
+                },
+              },
+            },
+          },
+        },
+      );
+      expect(mockClient.connect).toHaveBeenCalled();
+      expect(mockClient.listTools).toHaveBeenCalled();
+    });
+
+    it('falls back to DEFAULT_MCP_CLIENT_NAME if not specified', async () => {
+      const engine = new A2uiMcpEngine();
+      await engine.connectServer('http://127.0.0.1:8000/sse');
+
+      expect(Client).toHaveBeenCalledWith(
+        {name: DEFAULT_MCP_CLIENT_NAME, version: DEFAULT_MCP_CLIENT_VERSION},
+        expect.anything(),
+      );
+    });
+
+    it('throws error and sets status to error when server name is missing', async () => {
+      mockClient.getServerVersion.mockReturnValue(undefined);
+      const onConnectionChange = vi.fn();
+      const onStatusChange = vi.fn();
+      const engine = new A2uiMcpEngine(undefined, {onConnectionChange, onStatusChange});
+
+      await expect(engine.connectServer('http://127.0.0.1:8000/sse')).rejects.toThrow(
+        'Connected MCP server did not return a valid server name during initialization.',
+      );
+
+      expect(onConnectionChange).toHaveBeenCalledWith('error');
+      expect(onStatusChange).toHaveBeenCalledWith(expect.stringContaining('Connection failed:'));
+    });
+
+    it('handles connection failure from transport', async () => {
+      mockClient.connect.mockRejectedValue(new Error('Network error'));
+      const onConnectionChange = vi.fn();
+      const engine = new A2uiMcpEngine(undefined, {onConnectionChange});
+
+      await expect(engine.connectServer('http://127.0.0.1:8000/sse')).rejects.toThrow(
+        'Network error',
+      );
+      expect(onConnectionChange).toHaveBeenCalledWith('error');
+    });
+
+    it('handles tool listing failure gracefully during connection', async () => {
+      mockClient.listTools.mockRejectedValue(new Error('Tool list error'));
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const engine = new A2uiMcpEngine();
+
+      const serverName = await engine.connectServer('http://127.0.0.1:8000/sse');
+      expect(serverName).toBe('test-server');
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Could not query tool UI resources:',
+        expect.any(Error),
+      );
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('handleMcpCallTool', () => {
+    let engine: A2uiMcpEngine;
+
+    beforeEach(async () => {
+      engine = new A2uiMcpEngine();
+      await engine.connectServer('http://127.0.0.1:8000/sse');
+    });
+
+    it('defensively handles null context without throwing TypeError', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(engine.handleMcpCallTool(null as any)).resolves.not.toThrow();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
+        {},
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('defensively handles undefined context without throwing TypeError', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(engine.handleMcpCallTool(undefined as any)).resolves.not.toThrow();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
+        {},
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('logs error if tool is missing from context', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await engine.handleMcpCallTool({server: 'test-server'});
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "'mcp:call_tool' action missing required 'tool' (or '_tool') in context:",
+        {server: 'test-server'},
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('filters routing metadata keys (_server, _tool, server, tool) from tool arguments', async () => {
+      const executeToolSpy = vi.spyOn(engine, 'executeTool').mockResolvedValue(undefined);
+
+      await engine.handleMcpCallTool({
+        _server: 'test-server',
+        _tool: 'get_sample_data',
+        category: 'italian',
+        difficulty: 'easy',
+      });
+
+      expect(executeToolSpy).toHaveBeenCalledWith('test-server', 'get_sample_data', {
+        category: 'italian',
+        difficulty: 'easy',
+      });
+    });
+
+    it('supports un-prefixed server and tool keys in context', async () => {
+      const executeToolSpy = vi.spyOn(engine, 'executeTool').mockResolvedValue(undefined);
+
+      await engine.handleMcpCallTool({
+        server: 'test-server',
+        tool: 'get_sample_data',
+        param1: 123,
+      });
+
+      expect(executeToolSpy).toHaveBeenCalledWith('test-server', 'get_sample_data', {
+        param1: 123,
+      });
+    });
+  });
+
+  describe('executeTool', () => {
+    let engine: A2uiMcpEngine;
+    let onStatusChange: any;
+    let onSurfaceChange: any;
+
+    beforeEach(async () => {
+      onStatusChange = vi.fn();
+      onSurfaceChange = vi.fn();
+      engine = new A2uiMcpEngine(undefined, {onStatusChange, onSurfaceChange});
+      await engine.connectServer('http://127.0.0.1:8000/sse');
+    });
+
+    it('logs error and notifies status if target server is not connected', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await engine.executeTool('unknown-server', 'get_sample_data');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "No MCP client available for server 'unknown-server' (tool 'get_sample_data')",
+      );
+      expect(onStatusChange).toHaveBeenCalledWith(
+        "Failed: No connected server 'unknown-server' for get_sample_data",
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('executes tool with normalized args when args is null', async () => {
+      await engine.executeTool('test-server', 'get_sample_data', null as any);
+
+      expect(mockClient.callTool).toHaveBeenCalledWith({
+        name: 'get_sample_data',
+        arguments: {},
+      });
+    });
+
+    it('handles tool execution error gracefully', async () => {
+      mockClient.callTool.mockRejectedValue(new Error('Tool failed'));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await engine.executeTool('test-server', 'get_sample_data');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error executing get_sample_data on [test-server]:',
+        expect.any(Error),
+      );
+      expect(onStatusChange).toHaveBeenCalledWith('Execution failed: Tool failed');
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('discovers template from result._meta.ui.resourceUri, fetches template, and applies messages', async () => {
+      mockClient.callTool.mockResolvedValue({
+        _meta: {
+          ui: {
+            resourceUri: 'a2ui://sample-template',
+          },
+        },
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify([
+              {
+                updateDataModel: {
+                  surfaceId: 'test-surface',
+                  value: {title: 'Special Recipe'},
+                },
+              },
+            ]),
+          },
+        ],
+      });
+
+      await engine.executeTool('test-server', 'get_sample_data');
+
+      // Surface created and updated
+      const surface = engine.getSurface('test-surface');
+      expect(surface).toBeDefined();
+      expect(mockClient.readResource).toHaveBeenCalledWith({uri: 'a2ui://sample-template'});
+      expect(onSurfaceChange).toHaveBeenCalled();
+      expect(onStatusChange).toHaveBeenCalledWith(
+        'get_sample_data on [test-server] completed successfully!',
+      );
+    });
+
+    it('caches templates and does not re-fetch on subsequent tool calls', async () => {
+      // First call fetches template
+      await engine.executeTool('test-server', 'get_sample_data');
+      expect(mockClient.readResource).toHaveBeenCalledTimes(1);
+
+      // Second call uses cached template
+      await engine.executeTool('test-server', 'get_sample_data');
+      expect(mockClient.readResource).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-process template if surface already exists', async () => {
+      const processMessagesSpy = vi.spyOn(engine.processor, 'processMessages');
+
+      // First call processes template (2 messages) + update data model (1 message)
+      await engine.executeTool('test-server', 'get_sample_data');
+      expect(processMessagesSpy).toHaveBeenCalledWith(sampleTemplate);
+
+      processMessagesSpy.mockClear();
+
+      // Second call has existing surface so template should NOT be passed to processMessages
+      await engine.executeTool('test-server', 'get_sample_data');
+      expect(processMessagesSpy).not.toHaveBeenCalledWith(sampleTemplate);
+    });
+
+    it('extracts A2UI messages from resource type content', async () => {
+      mockClient.callTool.mockResolvedValue({
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              text: JSON.stringify([
+                {
+                  updateDataModel: {
+                    surfaceId: 'test-surface',
+                    value: {calories: 500},
+                  },
+                },
+              ]),
+            },
+          },
+        ],
+      });
+
+      await engine.executeTool('test-server', 'get_sample_data');
+      expect(onSurfaceChange).toHaveBeenCalled();
+    });
+
+    it('extracts A2UI messages from single object updateDataModel', async () => {
+      mockClient.callTool.mockResolvedValue({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              updateDataModel: {
+                surfaceId: 'test-surface',
+                value: {readyInMinutes: 30},
+              },
+            }),
+          },
+        ],
+      });
+
+      await engine.executeTool('test-server', 'get_sample_data');
+      expect(onSurfaceChange).toHaveBeenCalled();
+    });
+
+    it('handles template without valid A2UI MIME type gracefully', async () => {
+      mockClient.readResource.mockResolvedValue({
+        contents: [
+          {
+            uri: 'a2ui://sample-template',
+            mimeType: 'text/plain',
+            text: 'not a2ui',
+          },
+        ],
+      });
+
+      // Clear cache so it fetches
+      (engine as any).templateCache.clear();
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await engine.executeTool('test-server', 'get_sample_data');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error executing get_sample_data on [test-server]:',
+        expect.any(Error),
+      );
+      expect(onStatusChange).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Execution failed: Resource a2ui://sample-template does not contain valid A2UI JSON template data.',
+        ),
+      );
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.test.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_MCP_CLIENT_NAME,
   DEFAULT_MCP_CLIENT_VERSION,
   A2UI_MIME_TYPE,
+  MCP_CALL_TOOL_ACTION,
 } from './engine';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {SSEClientTransport} from '@modelcontextprotocol/sdk/client/sse.js';
@@ -135,6 +136,10 @@ describe('A2uiMcpEngine', () => {
       (engine.processor.model.onAction as any).emit(dummyAction);
       expect(onAction).toHaveBeenCalledWith(dummyAction);
     });
+
+    it('defines MCP_CALL_TOOL_ACTION as callMcpTool', () => {
+      expect(MCP_CALL_TOOL_ACTION).toBe('callMcpTool');
+    });
   });
 
   describe('connectServer', () => {
@@ -236,7 +241,7 @@ describe('A2uiMcpEngine', () => {
       await expect(engine.handleMcpCallTool(null as any)).resolves.not.toThrow();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' (or '_server') in context:`,
         {},
       );
       consoleErrorSpy.mockRestore();
@@ -248,7 +253,7 @@ describe('A2uiMcpEngine', () => {
       await expect(engine.handleMcpCallTool(undefined as any)).resolves.not.toThrow();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' (or '_server') in context:`,
         {},
       );
       consoleErrorSpy.mockRestore();
@@ -260,7 +265,7 @@ describe('A2uiMcpEngine', () => {
       await engine.handleMcpCallTool({server: 'test-server'});
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "'mcp:call_tool' action missing required 'tool' (or '_tool') in context:",
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'tool' (or '_tool') in context:`,
         {server: 'test-server'},
       );
       consoleErrorSpy.mockRestore();

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright 2026 Google LLC
+/*
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
@@ -22,7 +22,7 @@ import {SSEClientTransport} from '@modelcontextprotocol/sdk/client/sse.js';
 export const BASIC_CATALOG_ID = 'https://a2ui.org/specification/v0_9/basic_catalog.json';
 export const A2UI_MIME_TYPE = 'application/a2ui+json';
 
-export const MCP_CALL_TOOL_ACTION = 'mcp:call_tool';
+export const MCP_CALL_TOOL_ACTION = 'callMcpTool';
 
 /**
  * Default client name sent in `clientInfo` during the MCP initialization handshake.
@@ -158,14 +158,17 @@ export class A2uiMcpEngine {
 
     if (!targetServer) {
       console.error(
-        "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' (or '_server') in context:`,
         ctx,
       );
       return;
     }
 
     if (!targetTool) {
-      console.error("'mcp:call_tool' action missing required 'tool' (or '_tool') in context:", ctx);
+      console.error(
+        `'${MCP_CALL_TOOL_ACTION}' action missing required 'tool' (or '_tool') in context:`,
+        ctx,
+      );
       return;
     }
 

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
@@ -64,7 +64,7 @@ export class A2uiMcpEngine {
 
   constructor(catalogs: any[] = [basicCatalog], events: A2uiMcpEngineEvents = {}) {
     this.events = events;
-    this.processor = new MessageProcessor(catalogs, (action) => this.events.onAction?.(action));
+    this.processor = new MessageProcessor(catalogs, action => this.events.onAction?.(action));
   }
 
   /**
@@ -145,7 +145,6 @@ export class A2uiMcpEngine {
     }
   }
 
-
   /**
    * Handles MCP tool invocation from an A2UI action context.
    * Extracts server/tool routing metadata and dispatches execution.
@@ -185,11 +184,7 @@ export class A2uiMcpEngine {
    * Generic executor for any MCP tool returning A2UI presentation templates or data updates.
    * Routes strictly to the specified targetServer.
    */
-  async executeTool(
-    targetServer: string,
-    toolName: string,
-    args: Record<string, any> = {},
-  ) {
+  async executeTool(targetServer: string, toolName: string, args: Record<string, any> = {}) {
     const client = this.mcpClients.get(targetServer);
 
     if (!client) {
@@ -262,9 +257,7 @@ export class A2uiMcpEngine {
 
     this.events.onStatusChange?.(`Fetching UI template (${uri})...`);
     const resourceResult = await client.readResource({uri});
-    const a2uiContent = resourceResult.contents.find(
-      (c: any) => c.mimeType === A2UI_MIME_TYPE,
-    );
+    const a2uiContent = resourceResult.contents.find((c: any) => c.mimeType === A2UI_MIME_TYPE);
 
     if (!a2uiContent || !('text' in a2uiContent)) {
       throw new Error(`Resource ${uri} does not contain valid A2UI JSON template data.`);

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
@@ -1,0 +1,277 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MessageProcessor} from '@a2ui/web_core/v0_9';
+import {basicCatalog} from '@a2ui/lit/v0_9';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {SSEClientTransport} from '@modelcontextprotocol/sdk/client/sse.js';
+
+export const BASIC_CATALOG_ID = 'https://a2ui.org/specification/v0_9/basic_catalog.json';
+export const A2UI_MIME_TYPE = 'application/a2ui+json';
+
+export const MCP_CALL_TOOL_ACTION = 'mcp:call_tool';
+
+/**
+ * Default client name sent in `clientInfo` during the MCP initialization handshake.
+ *
+ * In the Model Context Protocol, `clientInfo` is an informational identifier (similar
+ * to an HTTP User-Agent string) primarily used by servers for logging, metrics, and debugging.
+ */
+export const DEFAULT_MCP_CLIENT_NAME = 'a2ui-mcp-engine';
+export const DEFAULT_MCP_CLIENT_VERSION = '1.0.0';
+
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+export interface A2uiMcpEngineEvents {
+  onAction?: (action: any) => Promise<void> | void;
+  onStatusChange?: (message: string) => void;
+  onConnectionChange?: (status: ConnectionStatus) => void;
+  onSurfaceChange?: () => void;
+}
+
+/**
+ * Generic A2UI-over-MCP host runtime engine.
+ * Handles MCP connections, tool discovery with UI metadata, template fetching/caching,
+ * and two-way surface data synchronization.
+ */
+export class A2uiMcpEngine {
+  // Unified A2UI MessageProcessor managing all active surfaces
+  readonly processor: MessageProcessor<any>;
+
+  // Multi-server registry: connected MCP clients keyed by server name
+  readonly mcpClients = new Map<string, Client>();
+
+  // Cache for loaded presentation templates keyed by resource URI
+  private readonly templateCache = new Map<string, any[]>();
+
+  // Mapping of tool names (server:tool or tool) to declared UI template resource URIs
+  private readonly toolUiResources = new Map<string, string>();
+
+  private readonly events: A2uiMcpEngineEvents;
+
+  constructor(catalogs: any[] = [basicCatalog], events: A2uiMcpEngineEvents = {}) {
+    this.events = events;
+    this.processor = new MessageProcessor(catalogs, (action) => this.events.onAction?.(action));
+  }
+
+  /**
+   * Retrieves an active A2UI surface model by its ID.
+   */
+  getSurface(surfaceId: string) {
+    return this.processor.model.getSurface(surfaceId);
+  }
+
+  /**
+   * Connects to an MCP server via SSE transport, discovers tools with A2UI metadata,
+   * and registers the client.
+   *
+   * @param sseUrl The SSE endpoint URL of the MCP server.
+   * @param clientName Optional custom client name to send during handshake (defaults to DEFAULT_MCP_CLIENT_NAME).
+   * @returns The registered server name.
+   */
+  async connectServer(
+    sseUrl: string,
+    clientName: string = DEFAULT_MCP_CLIENT_NAME,
+  ): Promise<string> {
+    this.events.onConnectionChange?.('connecting');
+    this.events.onStatusChange?.(`Connecting to MCP server at ${sseUrl}...`);
+
+    try {
+      const transport = new SSEClientTransport(new URL(sseUrl));
+      const client = new Client(
+        {
+          name: clientName,
+          version: DEFAULT_MCP_CLIENT_VERSION,
+        },
+        {
+          capabilities: {
+            a2ui: {
+              clientCapabilities: {
+                'v0.9': {
+                  supportedCatalogIds: [BASIC_CATALOG_ID],
+                },
+              },
+            },
+          } as any,
+        },
+      );
+
+      await client.connect(transport);
+      const serverInfo = client.getServerVersion();
+      if (!serverInfo?.name) {
+        throw new Error(
+          'Connected MCP server did not return a valid server name during initialization.',
+        );
+      }
+      const serverName = serverInfo.name;
+
+      this.mcpClients.set(serverName, client);
+      this.events.onConnectionChange?.('connected');
+      this.events.onStatusChange?.(`Connected to MCP Server [${serverName}] (${sseUrl})`);
+
+      // Discover all tools and their declared UI templates ahead of invocation
+      try {
+        const toolsResult = await client.listTools();
+        for (const tool of toolsResult.tools) {
+          const uiUri = (tool as any)._meta?.ui?.resourceUri;
+          if (uiUri) {
+            this.toolUiResources.set(`${serverName}:${tool.name}`, uiUri);
+            this.toolUiResources.set(tool.name, uiUri);
+          }
+        }
+      } catch (err) {
+        console.warn('Could not query tool UI resources:', err);
+      }
+
+      return serverName;
+    } catch (error: any) {
+      console.error('MCP Connection Error:', error);
+      this.events.onConnectionChange?.('error');
+      this.events.onStatusChange?.(`Connection failed: ${error.message || error}`);
+      throw error;
+    }
+  }
+
+
+  /**
+   * Handles MCP tool invocation from an A2UI action context.
+   * Extracts server/tool routing metadata and dispatches execution.
+   */
+  async handleMcpCallTool(context: Record<string, any> = {}) {
+    const targetServer: string | undefined = context.server || context._server;
+    const targetTool: string | undefined = context.tool || context._tool;
+
+    if (!targetServer) {
+      console.error(
+        "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
+        context,
+      );
+      return;
+    }
+
+    if (!targetTool) {
+      console.error(
+        "'mcp:call_tool' action missing required 'tool' (or '_tool') in context:",
+        context,
+      );
+      return;
+    }
+
+    // Filter out routing metadata keys from tool arguments
+    const toolArgs: Record<string, any> = {};
+    for (const [key, value] of Object.entries(context)) {
+      if (key !== 'server' && key !== '_server' && key !== 'tool' && key !== '_tool') {
+        toolArgs[key] = value;
+      }
+    }
+
+    await this.executeTool(targetServer, targetTool, toolArgs);
+  }
+
+  /**
+   * Generic executor for any MCP tool returning A2UI presentation templates or data updates.
+   * Routes strictly to the specified targetServer.
+   */
+  async executeTool(
+    targetServer: string,
+    toolName: string,
+    args: Record<string, any> = {},
+  ) {
+    const client = this.mcpClients.get(targetServer);
+
+    if (!client) {
+      console.error(`No MCP client available for server '${targetServer}' (tool '${toolName}')`);
+      this.events.onStatusChange?.(`Failed: No connected server '${targetServer}' for ${toolName}`);
+      return;
+    }
+
+    this.events.onStatusChange?.(`Executing ${toolName} on [${targetServer}]...`);
+
+    try {
+      // 1. Call MCP Tool on targeted client
+      const result = await client.callTool({
+        name: toolName,
+        arguments: args,
+      });
+
+      // 2. Discover UI template resource URI from tool response _meta or cached tool definitions
+      const resourceUri =
+        (result as any)._meta?.ui?.resourceUri ||
+        this.toolUiResources.get(`${targetServer}:${toolName}`) ||
+        this.toolUiResources.get(toolName);
+
+      // 3. Fetch presentation template if not cached and apply if surface does not exist yet
+      if (resourceUri) {
+        const template = await this.getOrFetchTemplate(client, resourceUri);
+        const surfaceId = template.find((m: any) => m.createSurface)?.createSurface?.surfaceId;
+        if (!surfaceId || !this.processor.model.getSurface(surfaceId)) {
+          this.processor.processMessages(template);
+        }
+      }
+
+      // 4. Extract and apply A2UI data updates from tool content
+      const dataMessages = this.extractA2uiMessages(result.content as any[]);
+      if (dataMessages) {
+        this.processor.processMessages(dataMessages);
+      }
+
+      // 5. Notify listeners that surface state has updated
+      this.events.onSurfaceChange?.();
+      this.events.onStatusChange?.(`${toolName} on [${targetServer}] completed successfully!`);
+    } catch (error: any) {
+      console.error(`Error executing ${toolName} on [${targetServer}]:`, error);
+      this.events.onStatusChange?.(`Execution failed: ${error.message || error}`);
+    }
+  }
+
+  private extractA2uiMessages(contentArray: any[]): any[] | null {
+    for (const item of contentArray || []) {
+      if (item.type === 'resource' && item.resource?.text) {
+        try {
+          return JSON.parse(item.resource.text);
+        } catch {}
+      } else if (item.type === 'text' && typeof item.text === 'string') {
+        try {
+          const parsed = JSON.parse(item.text);
+          if (Array.isArray(parsed) || parsed.updateDataModel) {
+            return Array.isArray(parsed) ? parsed : [parsed];
+          }
+        } catch {}
+      }
+    }
+    return null;
+  }
+
+  private async getOrFetchTemplate(client: Client, uri: string): Promise<any[]> {
+    if (this.templateCache.has(uri)) {
+      return this.templateCache.get(uri)!;
+    }
+
+    this.events.onStatusChange?.(`Fetching UI template (${uri})...`);
+    const resourceResult = await client.readResource({uri});
+    const a2uiContent = resourceResult.contents.find(
+      (c: any) => c.mimeType === A2UI_MIME_TYPE,
+    );
+
+    if (!a2uiContent || !('text' in a2uiContent)) {
+      throw new Error(`Resource ${uri} does not contain valid A2UI JSON template data.`);
+    }
+
+    const template = JSON.parse(a2uiContent.text);
+    this.templateCache.set(uri, template);
+    return template;
+  }
+}

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
@@ -63,8 +63,10 @@ export class A2uiMcpEngine {
   private readonly events: A2uiMcpEngineEvents;
 
   constructor(catalogs: any[] = [basicCatalog], events: A2uiMcpEngineEvents = {}) {
-    this.events = events;
-    this.processor = new MessageProcessor(catalogs, action => this.events.onAction?.(action));
+    this.events = events || {};
+    this.processor = new MessageProcessor(catalogs || [basicCatalog], action =>
+      this.events.onAction?.(action),
+    );
   }
 
   /**
@@ -150,28 +152,26 @@ export class A2uiMcpEngine {
    * Extracts server/tool routing metadata and dispatches execution.
    */
   async handleMcpCallTool(context: Record<string, any> = {}) {
-    const targetServer: string | undefined = context.server || context._server;
-    const targetTool: string | undefined = context.tool || context._tool;
+    const ctx = context || {};
+    const targetServer: string | undefined = ctx.server || ctx._server;
+    const targetTool: string | undefined = ctx.tool || ctx._tool;
 
     if (!targetServer) {
       console.error(
         "'mcp:call_tool' action missing required 'server' (or '_server') in context:",
-        context,
+        ctx,
       );
       return;
     }
 
     if (!targetTool) {
-      console.error(
-        "'mcp:call_tool' action missing required 'tool' (or '_tool') in context:",
-        context,
-      );
+      console.error("'mcp:call_tool' action missing required 'tool' (or '_tool') in context:", ctx);
       return;
     }
 
     // Filter out routing metadata keys from tool arguments
     const toolArgs: Record<string, any> = {};
-    for (const [key, value] of Object.entries(context)) {
+    for (const [key, value] of Object.entries(ctx)) {
       if (key !== 'server' && key !== '_server' && key !== 'tool' && key !== '_tool') {
         toolArgs[key] = value;
       }
@@ -185,6 +185,7 @@ export class A2uiMcpEngine {
    * Routes strictly to the specified targetServer.
    */
   async executeTool(targetServer: string, toolName: string, args: Record<string, any> = {}) {
+    const toolArgs = args || {};
     const client = this.mcpClients.get(targetServer);
 
     if (!client) {
@@ -199,7 +200,7 @@ export class A2uiMcpEngine {
       // 1. Call MCP Tool on targeted client
       const result = await client.callTool({
         name: toolName,
-        arguments: args,
+        arguments: toolArgs,
       });
 
       // 2. Discover UI template resource URI from tool response _meta or cached tool definitions

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/engine.ts
@@ -153,29 +153,23 @@ export class A2uiMcpEngine {
    */
   async handleMcpCallTool(context: Record<string, any> = {}) {
     const ctx = context || {};
-    const targetServer: string | undefined = ctx.server || ctx._server;
-    const targetTool: string | undefined = ctx.tool || ctx._tool;
+    const targetServer: string | undefined = ctx.server;
+    const targetTool: string | undefined = ctx.tool;
 
     if (!targetServer) {
-      console.error(
-        `'${MCP_CALL_TOOL_ACTION}' action missing required 'server' (or '_server') in context:`,
-        ctx,
-      );
+      console.error(`'${MCP_CALL_TOOL_ACTION}' action missing required 'server' in context:`, ctx);
       return;
     }
 
     if (!targetTool) {
-      console.error(
-        `'${MCP_CALL_TOOL_ACTION}' action missing required 'tool' (or '_tool') in context:`,
-        ctx,
-      );
+      console.error(`'${MCP_CALL_TOOL_ACTION}' action missing required 'tool' in context:`, ctx);
       return;
     }
 
     // Filter out routing metadata keys from tool arguments
     const toolArgs: Record<string, any> = {};
     for (const [key, value] of Object.entries(ctx)) {
-      if (key !== 'server' && key !== '_server' && key !== 'tool' && key !== '_tool') {
+      if (key !== 'server' && key !== 'tool') {
         toolArgs[key] = value;
       }
     }

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/package.json
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "node -e 'const fs=require(\"fs\"); const path=require(\"path\"); function find(d){for(const f of fs.readdirSync(d)){const p=path.join(d,f);if(f===\"node_modules\"||f===\"dist\")continue;if(fs.statSync(p).isDirectory()){if(find(p))return true;}else if(f.includes(\".test.\")||f.includes(\".spec.\"))return true;}return false;} if(find(\".\")){require(\"child_process\").execSync(\"vitest run\",{stdio:\"inherit\"});}else{console.log(\"Workspace has no tests.\");}'",
+    "test": "node -e 'const fs=require(\"fs\"); const path=require(\"path\"); function find(d){for(const f of fs.readdirSync(d)){const p=path.join(d,f);if(f===\"node_modules\"||f===\"dist\")continue;if(fs.statSync(p).isDirectory()){if(find(p))return true;}else if(f.includes(\".test.\")||f.includes(\".spec.\"))return true;}return false;} if(find(\".\")){require(\"child_process\").execSync(\"npx vitest run\",{stdio:\"inherit\"});}else{console.log(\"Workspace has no tests.\");}'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -25,6 +25,7 @@
   "devDependencies": {
     "eslint": "^10.4.1",
     "typescript": "5.9.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/samples/community/mcp/a2ui-over-mcp-recipe/client/tsconfig.json
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/client/tsconfig.json
@@ -13,5 +13,5 @@
     "isolatedModules": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts", "app.ts"]
+  "include": ["src/**/*.ts", "*.ts"]
 }

--- a/samples/community/mcp/a2ui-over-mcp-recipe/package.json
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "node -e 'const fs=require(\"fs\"); const path=require(\"path\"); function find(d){for(const f of fs.readdirSync(d)){const p=path.join(d,f);if(f===\"node_modules\"||f===\"dist\")continue;if(fs.statSync(p).isDirectory()){if(find(p))return true;}else if(f.includes(\".test.\")||f.includes(\".spec.\"))return true;}return false;} if(find(\".\")){require(\"child_process\").execSync(\"vitest run\",{stdio:\"inherit\"});}else{console.log(\"Workspace has no tests.\");}'",
+    "test": "node -e 'const fs=require(\"fs\"); const path=require(\"path\"); function find(d){for(const f of fs.readdirSync(d)){const p=path.join(d,f);if(f===\"node_modules\"||f===\"dist\")continue;if(fs.statSync(p).isDirectory()){if(find(p))return true;}else if(f.includes(\".test.\")||f.includes(\".spec.\"))return true;}return false;} if(find(\".\")){require(\"child_process\").execSync(\"npx vitest run\",{stdio:\"inherit\"});}else{console.log(\"Workspace has no tests.\");}'",
     "lint": "echo \"Workspace has no lint configuration.\"",
     "lint:fix": "echo \"Workspace has no lint configuration.\""
   }

--- a/samples/community/mcp/a2ui-over-mcp-recipe/recipe_form.json
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/recipe_form.json
@@ -86,8 +86,10 @@
           "variant": "primary",
           "action": {
             "event": {
-              "name": "generate_recipe",
+              "name": "mcp:call_tool",
               "context": {
+                "_server": "a2ui-mcp-recipe-demo",
+                "_tool": "get_recipe_a2ui",
                 "cookingStyle": {
                   "path": "/cookingStyle"
                 },

--- a/samples/community/mcp/a2ui-over-mcp-recipe/recipe_form.json
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/recipe_form.json
@@ -88,8 +88,8 @@
             "event": {
               "name": "callMcpTool",
               "context": {
-                "_server": "a2ui-mcp-recipe-demo",
-                "_tool": "get_recipe_a2ui",
+                "server": "a2ui-mcp-recipe-demo",
+                "tool": "get_recipe_a2ui",
                 "cookingStyle": {
                   "path": "/cookingStyle"
                 },

--- a/samples/community/mcp/a2ui-over-mcp-recipe/recipe_form.json
+++ b/samples/community/mcp/a2ui-over-mcp-recipe/recipe_form.json
@@ -86,7 +86,7 @@
           "variant": "primary",
           "action": {
             "event": {
-              "name": "mcp:call_tool",
+              "name": "callMcpTool",
               "context": {
                 "_server": "a2ui-mcp-recipe-demo",
                 "_tool": "get_recipe_a2ui",

--- a/samples/community/yarn.lock
+++ b/samples/community/yarn.lock
@@ -5023,6 +5023,7 @@ __metadata:
     lit: "npm:^3.3.3"
     typescript: "npm:5.9.3"
     vite: "npm:^8.0.16"
+    vitest: "npm:^4.1.8"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## Summary

This change separates the generic A2UI-over-MCP host runtime from the application-specific presentation layer in the recipe demo. A new `A2uiMcpEngine` class handles MCP connections, tool discovery, template caching, and surface updates, while `app.ts` retains only Lit component layout and UI styling. Additionally, UI actions are standardized to use `mcp:call_tool` with explicit server and tool routing context.

This change is priming the A2UI-over-MCP to align with the vision of A2UI v1.0 to streamline A2UI action routing. In this example, we assume `mcp:call_tool` as the action signature to by-pass Agent routing and be routed directly to the MCP server. The Action is expacted to include metadata of which MCP server and which tool it should be making a call to. 

This is an effort to align A2UI-over-MCP with the recent trend of monolithic Orchestrating Agent (vs multi-agent backent) where Agents are low-code and flavored by system prompt, Skills, and Tools. In this new world, any action routed to Agent is prone to be processed by LLM and thus Agent-bypassing feature is important for implementing deterministic behavior for the A2UI surfaces and reduce token spending.

## Key changes

* **Added `A2uiMcpEngine` (`client/engine.ts`)**:
  * Encapsulates MCP connection management via SSE, registering connected clients by server name.
  * Discovers UI resource associations declared in MCP tool definitions (`_meta.ui.resourceUri`).
  * Manages template fetching and caching, applying surfaces to `MessageProcessor` only if they do not already exist.
  * Provides `handleMcpCallTool`, which parses `_server` and `_tool` from the action context, filters routing keys from arguments, and executes the target tool.
  * Exposes `MCP_CALL_TOOL_ACTION = 'mcp:call_tool'`, `A2UI_MIME_TYPE = 'application/a2ui+json'`, and `DEFAULT_MCP_CLIENT_NAME = 'a2ui-mcp-engine'`.
  * Emits lifecycle events (`onAction`, `onStatusChange`, `onConnectionChange`, `onSurfaceChange`) so any UI framework can consume the engine without direct DOM dependencies.

* **Refactored recipe UI shell (`client/app.ts`)**:
  * Reduced from roughly 600 lines to 350 lines by delegating protocol plumbing to `this.mcpEngine`.
  * Implemented application-level `handleAction` that routes `mcp:call_tool` actions to `mcpEngine.handleMcpCallTool` and rejects unsupported events.
  * Removed redundant client properties, unused loading overlay DOM elements, and stale fallback routing logic.

* **Updated form template (`recipe_form.json`)**:
  * Configured submit button action to emit `mcp:call_tool` with `_server: "a2ui-mcp-recipe-demo"` and `_tool: "get_recipe_a2ui"`.

* **TypeScript configuration (`client/tsconfig.json`)**:
  * Updated include pattern to `["src/**/*.ts", "*.ts"]` to ensure all root TypeScript modules are included during compilation.


## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
