### PR TITLE
[python] Dynamically generate dynamic types in Catalog.catalog_schema

### DIFF
--- a/conformance/conformance_schema.json
+++ b/conformance/conformance_schema.json
@@ -152,6 +152,14 @@
         "assertions": {
           "$ref": "#/$defs/AccessibilityAssertions",
           "description": "Accessibility assertions to verify."
+        },
+        "useBasicCatalog": {
+          "type": "boolean",
+          "description": "Whether to use the standard basic catalog implementation."
+        },
+        "expectFile": {
+          "type": "string",
+          "description": "File path to JSON file containing expected outcome object."
         }
       },
       "additionalProperties": false

--- a/conformance/core/catalog.yaml
+++ b/conformance/core/catalog.yaml
@@ -495,6 +495,7 @@
   action: catalog_schema
   protocolVersion: "v0.8"
   catalog:
+    catalogId: "https://a2ui.org/catalogs/v08/basic"
     components:
       Text:
         type: object
@@ -505,20 +506,32 @@
         properties:
           label: {type: string}
     theme:
-      primaryColor: {type: string}
+      type: object
+      properties:
+        primaryColor: {type: string}
   expect:
-    protocolVersion: "v0.8"
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    catalogId: "https://a2ui.org/catalogs/v08/basic"
     components:
-      Button:
-        type: object
-        properties:
-          label: {type: string}
       Text:
         type: object
         properties:
           text: {type: string}
-    styles:
-      primaryColor: {type: string}
+      Button:
+        type: object
+        properties:
+          label: {type: string}
+    $defs:
+      theme:
+        type: object
+        properties:
+          primaryColor: {type: string}
+      anyComponent:
+        oneOf:
+          - $ref: "#/components/Text"
+          - $ref: "#/components/Button"
+        discriminator:
+          propertyName: "component"
 
 - name: test_v09_catalog_schema_with_defs
   description: Tests serializing a v0.9 Catalog into JSON schema with generated $defs.anyComponent and $defs.theme.
@@ -554,8 +567,8 @@
       properties:
         primaryColor: {type: string}
   expect:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
     catalogId: "https://a2ui.org/catalogs/v09/basic"
-    protocolVersion: "v0.9"
     components:
       Button:
         type: object
@@ -580,19 +593,20 @@
               amount: {type: number}
             required: [amount]
         required: [call, args]
-    theme:
-      type: object
-      properties:
-        primaryColor: {type: string}
     $defs:
-      anyComponent:
-        oneOf:
-          - $ref: "#/components/Button"
-          - $ref: "#/components/Card"
       theme:
         type: object
         properties:
           primaryColor: {type: string}
+      anyComponent:
+        oneOf:
+          - $ref: "#/components/Button"
+          - $ref: "#/components/Card"
+        discriminator:
+          propertyName: "component"
+      anyFunction:
+        oneOf:
+          - $ref: "#/functions/formatCurrency"
 
 - name: test_v09_catalog_schema_no_theme
   description: Tests serializing a v0.9 Catalog without theme (omits $defs.theme).
@@ -607,6 +621,7 @@
           text: {type: string}
         required: [component, text]
   expect:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
     catalogId: "https://a2ui.org/catalogs/v09/simple"
     components:
       Text:
@@ -619,6 +634,8 @@
       anyComponent:
         oneOf:
           - $ref: "#/components/Text"
+        discriminator:
+          propertyName: "component"
 
 - name: test_v10_catalog_schema_basic
   description: Tests serializing a v1.0 Catalog into JSON schema with protocolVersion and $defs.anyComponent.
@@ -635,7 +652,7 @@
           text: {type: string}
         required: [id, component, text]
   expect:
-    protocolVersion: "v1.0"
+    $schema: "https://json-schema.org/draft/2020-12/schema"
     catalogId: "https://a2ui.org/catalogs/v10/basic"
     components:
       Text:
@@ -649,3 +666,26 @@
       anyComponent:
         oneOf:
           - $ref: "#/components/Text"
+        discriminator:
+          propertyName: "component"
+
+- name: test_v08_basic_catalog_schema
+  description: Tests serializing the v0.8 Python BasicCatalog class into JSON schema and verifying cat.catalog_schema matches converted_basic_catalog_v08.json.
+  action: catalog_schema
+  protocolVersion: "v0.8"
+  useBasicCatalog: true
+  expectFile: "conformance/test_data/converted_basic_catalog_v08.json"
+
+- name: test_v09_basic_catalog_schema
+  description: Tests serializing the v0.9 Python BasicCatalog class into JSON schema and verifying cat.catalog_schema matches converted_basic_catalog_v09.json.
+  action: catalog_schema
+  protocolVersion: "v0.9"
+  useBasicCatalog: true
+  expectFile: "conformance/test_data/converted_basic_catalog_v09.json"
+
+- name: test_v10_basic_catalog_schema
+  description: Tests serializing the v1.0 Python BasicCatalog class into JSON schema and verifying cat.catalog_schema matches converted_basic_catalog_v10.json.
+  action: catalog_schema
+  protocolVersion: "v1.0"
+  useBasicCatalog: true
+  expectFile: "conformance/test_data/converted_basic_catalog_v10.json"

--- a/conformance/test_data/converted_basic_catalog_v08.json
+++ b/conformance/test_data/converted_basic_catalog_v08.json
@@ -1,0 +1,925 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "catalogId": "https://a2ui.org/specification/v0_8/catalogs/basic/catalog.json",
+  "components": {
+    "Text": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Text"
+        },
+        "text": {
+          "$ref": "#/$defs/TextItem",
+          "description": "The text content to display. This can be a literal string or a reference to a value in the data model ('path', e.g., '/doc/title'). While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation."
+        },
+        "usageHint": {
+          "enum": [
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "caption",
+            "body"
+          ],
+          "type": "string",
+          "description": "A hint for the base text style. One of: - `h1`: Largest heading. - `h2`: Second largest heading. - `h3`: Third largest heading. - `h4`: Fourth largest heading. - `h5`: Fifth largest heading. - `caption`: Small text for captions. - `body`: Standard body text."
+        }
+      },
+      "required": [
+        "id",
+        "text",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Image": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Image"
+        },
+        "url": {
+          "$ref": "#/$defs/UrlItem",
+          "description": "The URL of the image to display. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/thumbnail/url')."
+        },
+        "altText": {
+          "$ref": "#/$defs/AltTextItem",
+          "description": "The alt text for the image. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/thumbnail/altText')."
+        },
+        "fit": {
+          "enum": [
+            "contain",
+            "cover",
+            "fill",
+            "none",
+            "scale-down"
+          ],
+          "type": "string",
+          "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property."
+        },
+        "usageHint": {
+          "enum": [
+            "icon",
+            "avatar",
+            "smallFeature",
+            "mediumFeature",
+            "largeFeature",
+            "header"
+          ],
+          "type": "string",
+          "description": "A hint for the image size and style. One of: - `icon`: Small square icon. - `avatar`: Circular avatar image. - `smallFeature`: Small feature image. - `mediumFeature`: Medium feature image. - `largeFeature`: Large feature image. - `header`: Full-width, full bleed, header image."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Icon": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Icon"
+        },
+        "name": {
+          "$ref": "#/$defs/NameItem"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Video": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Video"
+        },
+        "url": {
+          "$ref": "#/$defs/UrlItem",
+          "description": "The URL of the video to display. This can be a literal string or a reference to a value in the data model ('path', e.g. '/video/url')."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "AudioPlayer": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "AudioPlayer"
+        },
+        "url": {
+          "$ref": "#/$defs/UrlItem"
+        },
+        "description": {
+          "$ref": "#/$defs/DescriptionItem",
+          "description": "A description of the audio, such as a title or summary. This can be a literal string or a reference to a value in the data model ('path', e.g. '/song/title')."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Row": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Row"
+        },
+        "children": {
+          "$ref": "#/$defs/ChildrenItem"
+        },
+        "distribution": {
+          "enum": [
+            "center",
+            "end",
+            "spaceAround",
+            "spaceBetween",
+            "spaceEvenly",
+            "start"
+          ],
+          "type": "string",
+          "description": "Defines the arrangement of children along the main axis (horizontally). This corresponds to the CSS 'justify-content' property."
+        },
+        "alignment": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "description": "Defines the alignment of children along the cross axis (vertically). This corresponds to the CSS 'align-items' property."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Column": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Column"
+        },
+        "children": {
+          "$ref": "#/$defs/ChildrenItem"
+        },
+        "distribution": {
+          "enum": [
+            "center",
+            "end",
+            "spaceAround",
+            "spaceBetween",
+            "spaceEvenly",
+            "start"
+          ],
+          "type": "string",
+          "description": "Defines the arrangement of children along the main axis (vertically). This corresponds to the CSS 'justify-content' property."
+        },
+        "alignment": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "description": "Defines the alignment of children along the cross axis (horizontally). This corresponds to the CSS 'align-items' property."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "List": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "List"
+        },
+        "children": {
+          "$ref": "#/$defs/ChildrenItem"
+        },
+        "direction": {
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string",
+          "description": "The direction in which the list items are laid out."
+        },
+        "alignment": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "description": "Defines the alignment of children along the cross axis."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Card": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Card"
+        },
+        "child": {
+          "description": "The ID of the component to be rendered inside the card.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "child",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Tabs": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Tabs"
+        },
+        "tabItems": {
+          "description": "An array of objects, where each object defines a tab with a title and a child component.",
+          "items": {
+            "$ref": "#/$defs/TabItemItem"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "tabItems",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Divider": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Divider"
+        },
+        "axis": {
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string",
+          "description": "The orientation of the divider."
+        }
+      },
+      "required": [
+        "id",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Modal": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Modal"
+        },
+        "entryPointChild": {
+          "description": "The ID of the component that opens the modal when interacted with (e.g., a button).",
+          "type": "string"
+        },
+        "contentChild": {
+          "description": "The ID of the component to be displayed inside the modal.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "entryPointChild",
+        "contentChild",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Button": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Button"
+        },
+        "child": {
+          "description": "The ID of the component to display in the button, typically a Text component.",
+          "type": "string"
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Indicates if this button should be styled as the primary action."
+        },
+        "action": {
+          "$ref": "#/$defs/ActionItem"
+        }
+      },
+      "required": [
+        "id",
+        "child",
+        "action",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CheckBox": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "CheckBox"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelItem",
+          "description": "The text to display next to the checkbox. Defines the value as either a literal value or a path to data model ('path', e.g. '/option/label')."
+        },
+        "value": {
+          "$ref": "#/$defs/ValueItem",
+          "description": "The current state of the checkbox (true for checked, false for unchecked). This can be a literal boolean ('literalBoolean') or a reference to a value in the data model ('path', e.g. '/filter/open')."
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "TextField": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "TextField"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelItem",
+          "description": "The text label for the input field. This can be a literal string or a reference to a value in the data model ('path, e.g. '/user/name')."
+        },
+        "text": {
+          "$ref": "#/$defs/TextItem",
+          "description": "The value of the text field. This can be a literal string or a reference to a value in the data model ('path', e.g. '/user/name')."
+        },
+        "textFieldType": {
+          "enum": [
+            "date",
+            "longText",
+            "number",
+            "shortText",
+            "obscured"
+          ],
+          "type": "string",
+          "description": "The type of input field to display."
+        },
+        "validationRegexp": {
+          "type": "string",
+          "description": "A regular expression used for client-side validation of the input."
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "DateTimeInput": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "DateTimeInput"
+        },
+        "value": {
+          "$ref": "#/$defs/ValueItem",
+          "description": "The selected date and/or time value in ISO 8601 format. This can be a literal string ('literalString') or a reference to a value in the data model ('path', e.g. '/user/dob')."
+        },
+        "enableDate": {
+          "type": "boolean",
+          "description": "If true, allows the user to select a date."
+        },
+        "enableTime": {
+          "type": "boolean",
+          "description": "If true, allows the user to select a time."
+        }
+      },
+      "required": [
+        "id",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "MultipleChoice": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "MultipleChoice"
+        },
+        "selections": {
+          "$ref": "#/$defs/SelectionItem"
+        },
+        "options": {
+          "description": "An array of available options for the user to choose from.",
+          "items": {
+            "$ref": "#/$defs/OptionItem"
+          },
+          "type": "array"
+        },
+        "maxAllowedSelections": {
+          "type": "integer",
+          "description": "The maximum number of options that the user is allowed to select."
+        },
+        "variant": {
+          "enum": [
+            "checkbox",
+            "chips"
+          ],
+          "type": "string",
+          "description": "The display style of the component."
+        },
+        "filterable": {
+          "type": "boolean",
+          "description": "If true, displays a search input to filter the options."
+        }
+      },
+      "required": [
+        "id",
+        "selections",
+        "options",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Slider": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "component": {
+          "const": "Slider"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelItem",
+          "description": "The label for the slider. This can be a literal string or a reference to a value in the data model ('path')."
+        },
+        "value": {
+          "$ref": "#/$defs/ValueItem"
+        },
+        "minValue": {
+          "type": "number",
+          "description": "The minimum value of the slider."
+        },
+        "maxValue": {
+          "type": "number",
+          "description": "The maximum value of the slider."
+        }
+      },
+      "required": [
+        "id",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    }
+  },
+  "$defs": {
+    "theme": {
+      "properties": {
+        "font": {
+          "type": "string",
+          "description": "The primary font for the UI."
+        },
+        "primaryColor": {
+          "pattern": "^#[0-9a-fA-F]{6}$",
+          "type": "string",
+          "description": "The primary UI color as a hexadecimal code (e.g., '#00BFFF')."
+        }
+      },
+      "type": "object"
+    },
+    "ComponentId": {
+      "description": "The unique identifier for a component, used for both definitions and references within the same surface.",
+      "type": "string"
+    },
+    "TextItem": {
+      "additionalProperties": false,
+      "description": "The value of the text field. This can be a literal string or a reference to a value in the data model ('path', e.g. '/user/name').",
+      "properties": {
+        "literalString": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AltTextItem": {
+      "additionalProperties": false,
+      "description": "The alt text for the image. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/thumbnail/altText').",
+      "properties": {
+        "literalString": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UrlItem": {
+      "additionalProperties": false,
+      "description": "The URL of the audio to be played. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/song/url').",
+      "properties": {
+        "literalString": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "NameItem": {
+      "additionalProperties": false,
+      "description": "The name of the icon to display. This can be a literal string or a reference to a value in the data model ('path', e.g. '/form/submit').",
+      "properties": {
+        "literalString": {
+          "enum": [
+            "accountCircle",
+            "add",
+            "arrowBack",
+            "arrowForward",
+            "attachFile",
+            "calendarToday",
+            "call",
+            "camera",
+            "check",
+            "close",
+            "delete",
+            "download",
+            "edit",
+            "event",
+            "error",
+            "favorite",
+            "favoriteOff",
+            "folder",
+            "help",
+            "home",
+            "info",
+            "locationOn",
+            "lock",
+            "lockOpen",
+            "mail",
+            "menu",
+            "moreVert",
+            "moreHoriz",
+            "notificationsOff",
+            "notifications",
+            "payment",
+            "person",
+            "phone",
+            "photo",
+            "print",
+            "refresh",
+            "search",
+            "send",
+            "settings",
+            "share",
+            "shoppingCart",
+            "star",
+            "starHalf",
+            "starOff",
+            "upload",
+            "visibility",
+            "visibilityOff",
+            "warning"
+          ],
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DescriptionItem": {
+      "additionalProperties": false,
+      "description": "A description of the audio, such as a title or summary. This can be a literal string or a reference to a value in the data model ('path', e.g. '/song/title').",
+      "properties": {
+        "literalString": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ChildrenItem": {
+      "additionalProperties": false,
+      "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
+      "properties": {
+        "explicitList": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "$ref": "#/$defs/TemplateItem",
+          "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children."
+        }
+      },
+      "type": "object"
+    },
+    "TemplateItem": {
+      "additionalProperties": false,
+      "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
+      "properties": {
+        "componentId": {
+          "type": "string"
+        },
+        "dataBinding": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "componentId",
+        "dataBinding"
+      ],
+      "type": "object"
+    },
+    "TabItemItem": {
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/TitleItem"
+        },
+        "child": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "child"
+      ],
+      "type": "object"
+    },
+    "TitleItem": {
+      "additionalProperties": false,
+      "description": "The tab title. Defines the value as either a literal value or a path to data model value (e.g. '/options/title').",
+      "properties": {
+        "literalString": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ActionItem": {
+      "additionalProperties": false,
+      "description": "The client-side action to be dispatched when the button is clicked. It includes the action's name and an optional context payload.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "context": {
+          "items": {
+            "$ref": "#/$defs/ContextItem"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ContextItem": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/ValueItem",
+          "description": "Defines the value to be included in the context as either a literal value or a path to a data model value (e.g. '/user/name')."
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ValueItem": {
+      "additionalProperties": false,
+      "description": "The current value of the slider. This can be a literal number ('literalNumber') or a reference to a value in the data model ('path', e.g. '/restaurant/cost').",
+      "properties": {
+        "literalNumber": {
+          "type": "number"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "LabelItem": {
+      "additionalProperties": false,
+      "description": "The label for the slider. This can be a literal string or a reference to a value in the data model ('path').",
+      "properties": {
+        "literalString": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OptionItem": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/LabelItem",
+          "description": "The text to display for this option. This can be a literal string or a reference to a value in the data model (e.g. '/option/label')."
+        },
+        "value": {
+          "description": "The value to be associated with this option when selected.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "type": "object"
+    },
+    "SelectionItem": {
+      "additionalProperties": false,
+      "description": "The currently selected values for the component. This can be a literal array of strings or a path to an array in the data model('path', e.g. '/hotel/options').",
+      "properties": {
+        "literalArray": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/Image"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/Video"
+        },
+        {
+          "$ref": "#/components/AudioPlayer"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/List"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/Tabs"
+        },
+        {
+          "$ref": "#/components/Divider"
+        },
+        {
+          "$ref": "#/components/Modal"
+        },
+        {
+          "$ref": "#/components/Button"
+        },
+        {
+          "$ref": "#/components/CheckBox"
+        },
+        {
+          "$ref": "#/components/TextField"
+        },
+        {
+          "$ref": "#/components/DateTimeInput"
+        },
+        {
+          "$ref": "#/components/MultipleChoice"
+        },
+        {
+          "$ref": "#/components/Slider"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "component"
+      }
+    }
+  }
+}

--- a/conformance/test_data/converted_basic_catalog_v09.json
+++ b/conformance/test_data/converted_basic_catalog_v09.json
@@ -1,0 +1,1735 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+  "components": {
+    "Text": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Text"
+        },
+        "text": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation."
+        },
+        "variant": {
+          "enum": [
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "caption",
+            "body"
+          ],
+          "type": "string",
+          "default": "body",
+          "description": "A hint for the base text style."
+        }
+      },
+      "required": [
+        "id",
+        "text",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Image": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Image"
+        },
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the image to display."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "Accessibility text for the image."
+        },
+        "fit": {
+          "enum": [
+            "contain",
+            "cover",
+            "fill",
+            "none",
+            "scaleDown"
+          ],
+          "type": "string",
+          "default": "fill",
+          "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property."
+        },
+        "variant": {
+          "enum": [
+            "icon",
+            "avatar",
+            "smallFeature",
+            "mediumFeature",
+            "largeFeature",
+            "header"
+          ],
+          "type": "string",
+          "default": "mediumFeature",
+          "description": "A hint for the image size and style."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Icon": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Icon"
+        },
+        "name": {
+          "description": "The name of the icon to display.",
+          "oneOf": [
+            {
+              "enum": [
+                "accountCircle",
+                "add",
+                "arrowBack",
+                "arrowForward",
+                "attachFile",
+                "calendarToday",
+                "call",
+                "camera",
+                "check",
+                "close",
+                "delete",
+                "download",
+                "edit",
+                "event",
+                "error",
+                "fastForward",
+                "favorite",
+                "favoriteOff",
+                "folder",
+                "help",
+                "home",
+                "info",
+                "locationOn",
+                "lock",
+                "lockOpen",
+                "mail",
+                "menu",
+                "moreVert",
+                "moreHoriz",
+                "notificationsOff",
+                "notifications",
+                "pause",
+                "payment",
+                "person",
+                "phone",
+                "photo",
+                "play",
+                "print",
+                "refresh",
+                "rewind",
+                "search",
+                "send",
+                "settings",
+                "share",
+                "shoppingCart",
+                "skipNext",
+                "skipPrevious",
+                "star",
+                "starHalf",
+                "starOff",
+                "stop",
+                "upload",
+                "visibility",
+                "visibilityOff",
+                "volumeDown",
+                "volumeMute",
+                "volumeOff",
+                "volumeUp",
+                "warning"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/SvgPath"
+            },
+            {
+              "$ref": "#/$defs/DataBinding"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Video": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Video"
+        },
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the video to display."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "AudioPlayer": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "AudioPlayer"
+        },
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the audio to be played."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A description of the audio, such as a title or summary."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Row": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Row"
+        },
+        "children": {
+          "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ComponentId"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TemplateChildList"
+            }
+          ]
+        },
+        "justify": {
+          "enum": [
+            "center",
+            "end",
+            "spaceAround",
+            "spaceBetween",
+            "spaceEvenly",
+            "start",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "start",
+          "description": "Defines the arrangement of children along the main axis (horizontally). Use 'spaceBetween' to push items to the edges, or 'start'/'end'/'center' to pack them together."
+        },
+        "align": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "stretch",
+          "description": "Defines the alignment of children along the cross axis (vertically). This is similar to the CSS 'align-items' property, but uses camelCase values (e.g., 'start')."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Column": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Column"
+        },
+        "children": {
+          "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ComponentId"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TemplateChildList"
+            }
+          ]
+        },
+        "justify": {
+          "enum": [
+            "center",
+            "end",
+            "spaceAround",
+            "spaceBetween",
+            "spaceEvenly",
+            "start",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "start",
+          "description": "Defines the arrangement of children along the main axis (vertically). Use 'spaceBetween' to push items to the edges (e.g. header at top, footer at bottom), or 'start'/'end'/'center' to pack them together."
+        },
+        "align": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "stretch",
+          "description": "Defines the alignment of children along the cross axis (horizontally). This is similar to the CSS 'align-items' property."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "List": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "List"
+        },
+        "children": {
+          "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ComponentId"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TemplateChildList"
+            }
+          ]
+        },
+        "direction": {
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string",
+          "default": "vertical",
+          "description": "The direction in which the list items are laid out."
+        },
+        "align": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "stretch",
+          "description": "Defines the alignment of children along the cross axis."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Card": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Card"
+        },
+        "child": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID."
+        }
+      },
+      "required": [
+        "id",
+        "child",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Tabs": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Tabs"
+        },
+        "tabs": {
+          "description": "An array of objects, where each object defines a tab with a title and a child component.",
+          "items": {
+            "$ref": "#/$defs/TabItem"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "tabs",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Modal": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Modal"
+        },
+        "trigger": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the component that opens the modal when interacted with (e.g., a button)."
+        },
+        "content": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the component to be displayed inside the modal."
+        }
+      },
+      "required": [
+        "id",
+        "trigger",
+        "content",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Divider": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Divider"
+        },
+        "axis": {
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string",
+          "default": "horizontal",
+          "description": "The orientation of the divider."
+        }
+      },
+      "required": [
+        "id",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Button": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Button"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "child": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button."
+        },
+        "variant": {
+          "enum": [
+            "default",
+            "primary",
+            "borderless"
+          ],
+          "type": "string",
+          "default": "default",
+          "description": "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link."
+        },
+        "action": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ActionEventWrapper"
+            },
+            {
+              "$ref": "#/$defs/ActionFunctionCallWrapper"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "child",
+        "action",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "TextField": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "TextField"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text label for the input field."
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The value of the text field."
+        },
+        "variant": {
+          "enum": [
+            "longText",
+            "number",
+            "shortText",
+            "obscured"
+          ],
+          "type": "string",
+          "default": "shortText",
+          "description": "The type of input field to display."
+        },
+        "validationRegexp": {
+          "type": "string",
+          "description": "A regular expression used for client-side validation of the input."
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CheckBox": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "CheckBox"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text to display next to the checkbox."
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "The current state of the checkbox (true for checked, false for unchecked)."
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ChoicePicker": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "ChoicePicker"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The label for the group of options."
+        },
+        "variant": {
+          "enum": [
+            "multipleSelection",
+            "mutuallyExclusive"
+          ],
+          "type": "string",
+          "default": "mutuallyExclusive",
+          "description": "A hint for how the choice picker should be displayed and behave."
+        },
+        "options": {
+          "description": "The list of available options to choose from.",
+          "items": {
+            "$ref": "#/$defs/OptionItem"
+          },
+          "type": "array"
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicValue",
+          "description": "The list of currently selected values. This should be bound to a string array in the data model."
+        },
+        "displayStyle": {
+          "enum": [
+            "checkbox",
+            "chips"
+          ],
+          "type": "string",
+          "default": "checkbox",
+          "description": "The display style of the component."
+        },
+        "filterable": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, displays a search input to filter the options."
+        }
+      },
+      "required": [
+        "id",
+        "options",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Slider": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "Slider"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The label for the slider."
+        },
+        "min": {
+          "type": "number",
+          "default": 0,
+          "description": "The minimum value of the slider."
+        },
+        "max": {
+          "description": "The maximum value of the slider.",
+          "type": "number"
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The current value of the slider."
+        }
+      },
+      "required": [
+        "id",
+        "max",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "DateTimeInput": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        },
+        "component": {
+          "const": "DateTimeInput"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string."
+        },
+        "enableDate": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, allows the user to select a date."
+        },
+        "enableTime": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, allows the user to select a time."
+        },
+        "min": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The minimum allowed date/time in ISO 8601 format."
+        },
+        "max": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The maximum allowed date/time in ISO 8601 format."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text label for the input field."
+        }
+      },
+      "required": [
+        "id",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    }
+  },
+  "functions": {
+    "required": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "description": "The value to check."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "regex": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "pattern": {
+          "description": "The regex pattern to match against.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "length": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum allowed length."
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum allowed length."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "numeric": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "min": {
+          "type": "number",
+          "description": "The minimum allowed value."
+        },
+        "max": {
+          "type": "number",
+          "description": "The maximum allowed value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "email": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "formatString": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "formatNumber": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The number to format."
+        },
+        "decimals": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+        },
+        "grouping": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "formatCurrency": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The monetary amount."
+        },
+        "currency": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The ISO 4217 currency code (e.g., 'USD', 'EUR')."
+        },
+        "decimals": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+        },
+        "grouping": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+        }
+      },
+      "required": [
+        "value",
+        "currency"
+      ],
+      "type": "object"
+    },
+    "formatDate": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicValue",
+          "description": "The date to format."
+        },
+        "format": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A Unicode TR35 date pattern string.  Token Reference: - Year: 'yy' (26), 'yyyy' (2026) - Month: 'M' (1), 'MM' (01), 'MMM' (Jan), 'MMMM' (January) - Day: 'd' (1), 'dd' (01), 'E' (Tue), 'EEEE' (Tuesday) - Hour (12h): 'h' (1-12), 'hh' (01-12) - requires 'a' for AM/PM - Hour (24h): 'H' (0-23), 'HH' (00-23) - Military Time - Minute: 'mm' (00-59) - Second: 'ss' (00-59) - Period: 'a' (AM/PM)  Examples: - 'MMM dd, yyyy' -> 'Jan 16, 2026' - 'HH:mm' -> '14:30' (Military) - 'h:mm a' -> '2:30 PM' - 'EEEE, d MMMM' -> 'Friday, 16 January'"
+        }
+      },
+      "required": [
+        "value",
+        "format"
+      ],
+      "type": "object"
+    },
+    "pluralize": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The numeric value used to determine the plural category."
+        },
+        "zero": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'zero' category (e.g., 0 items)."
+        },
+        "one": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'one' category (e.g., 1 item)."
+        },
+        "two": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'two' category (used in Arabic, Welsh, etc.)."
+        },
+        "few": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'few' category (e.g., small groups in Slavic languages)."
+        },
+        "many": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'many' category (e.g., large groups in various languages)."
+        },
+        "other": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The default/fallback string (used for general plural cases)."
+        }
+      },
+      "required": [
+        "value",
+        "other"
+      ],
+      "type": "object"
+    },
+    "openUrl": {
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "description": "The URL to open.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "and": {
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "description": "The list of boolean values to evaluate.",
+          "items": {
+            "$ref": "#/$defs/DynamicBoolean"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "type": "object"
+    },
+    "or": {
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "description": "The list of boolean values to evaluate.",
+          "items": {
+            "$ref": "#/$defs/DynamicBoolean"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "type": "object"
+    },
+    "not": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "The boolean value to negate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "add": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "subtract": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "multiply": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "divide": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "equals": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {},
+        "b": {}
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "not_equals": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {},
+        "b": {}
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "greater_than": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "less_than": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "contains": {
+      "additionalProperties": false,
+      "properties": {
+        "string": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "substring": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "string",
+        "substring"
+      ],
+      "type": "object"
+    },
+    "starts_with": {
+      "additionalProperties": false,
+      "properties": {
+        "string": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "prefix": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "string",
+        "prefix"
+      ],
+      "type": "object"
+    },
+    "ends_with": {
+      "additionalProperties": false,
+      "properties": {
+        "string": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "suffix": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "string",
+        "suffix"
+      ],
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "theme": {
+      "additionalProperties": true,
+      "properties": {
+        "primaryColor": {
+          "pattern": "^#[0-9a-fA-F]{6}$",
+          "type": "string",
+          "description": "The primary brand color used for highlights (e.g., primary buttons, active borders). Renderers may generate variants of this color for different contexts. Format: Hexadecimal code (e.g., '#00BFFF')."
+        },
+        "iconUrl": {
+          "type": "string",
+          "description": "A URL for an image that identifies the agent or tool associated with the surface."
+        },
+        "agentDisplayName": {
+          "type": "string",
+          "description": "Text to be displayed next to the surface to identify the agent or tool that created it."
+        }
+      },
+      "type": "object"
+    },
+    "AccessibilityAttributes": {
+      "additionalProperties": false,
+      "description": "Attributes to enhance accessibility when using assistive technologies like screen readers.",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A short string, typically 1 to 3 words, used by assistive technologies to convey the purpose or intent of an element. For example, an input field might have an accessible label of 'User ID' or a button might be labeled 'Submit'."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "Additional information provided by assistive technologies about an element such as instructions, format requirements, or result of an action. For example, a mute button might have a label of 'Mute' and a description of 'Silences notifications about this conversation'."
+        }
+      },
+      "type": "object"
+    },
+    "ComponentId": {
+      "description": "The unique identifier for a component, used for both definitions and references within the same surface.",
+      "type": "string"
+    },
+    "DataBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A JSON Pointer path to a value in the data model.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "FunctionCall": {
+      "additionalProperties": false,
+      "properties": {
+        "call": {
+          "description": "The name of the function to call.",
+          "type": "string"
+        },
+        "args": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Arguments passed to the function."
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this function, overriding any surface-level default catalogId."
+        }
+      },
+      "required": [
+        "call"
+      ],
+      "type": "object",
+      "description": "Invokes a named function."
+    },
+    "SvgPath": {
+      "additionalProperties": false,
+      "properties": {
+        "svgPath": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "svgPath"
+      ],
+      "type": "object"
+    },
+    "TemplateChildList": {
+      "additionalProperties": false,
+      "description": "A template for generating a dynamic list of children from a data model list.\n\nThe `componentId` is the component to use as a template.",
+      "properties": {
+        "componentId": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "path": {
+          "description": "The path to the list of component property objects in the data model.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "componentId",
+        "path"
+      ],
+      "type": "object"
+    },
+    "TabItem": {
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The tab title."
+        },
+        "child": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the child component."
+        }
+      },
+      "required": [
+        "title",
+        "child"
+      ],
+      "type": "object"
+    },
+    "ActionEvent": {
+      "additionalProperties": false,
+      "description": "The event to dispatch to the server.",
+      "properties": {
+        "name": {
+          "description": "The name of the action to be dispatched to the server.",
+          "type": "string"
+        },
+        "context": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DynamicValue"
+          },
+          "type": "object",
+          "description": "A JSON object containing the key-value pairs for the action context. Values can be literals or paths. Use literal values unless the value must be dynamically bound to the data model. Do NOT use paths for static IDs."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ActionEventWrapper": {
+      "additionalProperties": false,
+      "description": "Triggers a server-side event.",
+      "properties": {
+        "event": {
+          "$ref": "#/$defs/ActionEvent"
+        }
+      },
+      "required": [
+        "event"
+      ],
+      "type": "object"
+    },
+    "ActionFunctionCallWrapper": {
+      "additionalProperties": false,
+      "description": "Executes a local client-side function.",
+      "properties": {
+        "functionCall": {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      },
+      "required": [
+        "functionCall"
+      ],
+      "type": "object"
+    },
+    "CheckRule": {
+      "additionalProperties": false,
+      "description": "A single validation rule applied to an input component.",
+      "properties": {
+        "condition": {
+          "$ref": "#/$defs/DynamicBoolean"
+        },
+        "message": {
+          "description": "The error message to display if the check fails.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "condition",
+        "message"
+      ],
+      "type": "object"
+    },
+    "OptionItem": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text to display for this option."
+        },
+        "value": {
+          "description": "The stable value associated with this option.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "type": "object"
+    },
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/Image"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/Video"
+        },
+        {
+          "$ref": "#/components/AudioPlayer"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/List"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/Tabs"
+        },
+        {
+          "$ref": "#/components/Modal"
+        },
+        {
+          "$ref": "#/components/Divider"
+        },
+        {
+          "$ref": "#/components/Button"
+        },
+        {
+          "$ref": "#/components/TextField"
+        },
+        {
+          "$ref": "#/components/CheckBox"
+        },
+        {
+          "$ref": "#/components/ChoicePicker"
+        },
+        {
+          "$ref": "#/components/Slider"
+        },
+        {
+          "$ref": "#/components/DateTimeInput"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "component"
+      }
+    },
+    "anyFunction": {
+      "oneOf": [
+        {
+          "$ref": "#/functions/required"
+        },
+        {
+          "$ref": "#/functions/regex"
+        },
+        {
+          "$ref": "#/functions/length"
+        },
+        {
+          "$ref": "#/functions/numeric"
+        },
+        {
+          "$ref": "#/functions/email"
+        },
+        {
+          "$ref": "#/functions/formatString"
+        },
+        {
+          "$ref": "#/functions/formatNumber"
+        },
+        {
+          "$ref": "#/functions/formatCurrency"
+        },
+        {
+          "$ref": "#/functions/formatDate"
+        },
+        {
+          "$ref": "#/functions/pluralize"
+        },
+        {
+          "$ref": "#/functions/openUrl"
+        },
+        {
+          "$ref": "#/functions/and"
+        },
+        {
+          "$ref": "#/functions/or"
+        },
+        {
+          "$ref": "#/functions/not"
+        },
+        {
+          "$ref": "#/functions/add"
+        },
+        {
+          "$ref": "#/functions/subtract"
+        },
+        {
+          "$ref": "#/functions/multiply"
+        },
+        {
+          "$ref": "#/functions/divide"
+        },
+        {
+          "$ref": "#/functions/equals"
+        },
+        {
+          "$ref": "#/functions/not_equals"
+        },
+        {
+          "$ref": "#/functions/greater_than"
+        },
+        {
+          "$ref": "#/functions/less_than"
+        },
+        {
+          "$ref": "#/functions/contains"
+        },
+        {
+          "$ref": "#/functions/starts_with"
+        },
+        {
+          "$ref": "#/functions/ends_with"
+        }
+      ]
+    },
+    "DynamicBoolean": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicNumber": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicString": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "items": {},
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        },
+        {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      ]
+    }
+  }
+}

--- a/conformance/test_data/converted_basic_catalog_v10.json
+++ b/conformance/test_data/converted_basic_catalog_v10.json
@@ -1,0 +1,1913 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "catalogId": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
+  "components": {
+    "Text": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Text"
+        },
+        "text": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation."
+        },
+        "variant": {
+          "enum": [
+            "caption",
+            "body"
+          ],
+          "type": "string",
+          "default": "body",
+          "description": "A hint for the base text style."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "text",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Image": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Image"
+        },
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the image to display."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "Accessibility text for the image."
+        },
+        "fit": {
+          "enum": [
+            "contain",
+            "cover",
+            "fill",
+            "none",
+            "scaleDown"
+          ],
+          "type": "string",
+          "default": "fill",
+          "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property."
+        },
+        "variant": {
+          "enum": [
+            "icon",
+            "avatar",
+            "smallFeature",
+            "mediumFeature",
+            "largeFeature",
+            "header"
+          ],
+          "type": "string",
+          "default": "mediumFeature",
+          "description": "A hint for the image size and style."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Icon": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Icon"
+        },
+        "name": {
+          "description": "The name of the icon to display.",
+          "oneOf": [
+            {
+              "enum": [
+                "accountCircle",
+                "add",
+                "arrowBack",
+                "arrowForward",
+                "attachFile",
+                "calendarToday",
+                "call",
+                "camera",
+                "check",
+                "close",
+                "delete",
+                "download",
+                "edit",
+                "event",
+                "error",
+                "fastForward",
+                "favorite",
+                "favoriteOff",
+                "folder",
+                "help",
+                "home",
+                "info",
+                "locationOn",
+                "lock",
+                "lockOpen",
+                "mail",
+                "menu",
+                "moreVert",
+                "moreHoriz",
+                "notificationsOff",
+                "notifications",
+                "pause",
+                "payment",
+                "person",
+                "phone",
+                "photo",
+                "play",
+                "print",
+                "refresh",
+                "rewind",
+                "search",
+                "send",
+                "settings",
+                "share",
+                "shoppingCart",
+                "skipNext",
+                "skipPrevious",
+                "star",
+                "starHalf",
+                "starOff",
+                "stop",
+                "upload",
+                "visibility",
+                "visibilityOff",
+                "volumeDown",
+                "volumeMute",
+                "volumeOff",
+                "volumeUp",
+                "warning"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/SvgPath"
+            },
+            {
+              "$ref": "#/$defs/DataBinding"
+            }
+          ]
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Video": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Video"
+        },
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the video to display."
+        },
+        "posterUrl": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the poster image to display before the video plays."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "AudioPlayer": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "AudioPlayer"
+        },
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL of the audio to be played."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A description of the audio, such as a title or summary."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "url",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Row": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Row"
+        },
+        "children": {
+          "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ComponentId"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TemplateChildList"
+            }
+          ]
+        },
+        "justify": {
+          "enum": [
+            "center",
+            "end",
+            "spaceAround",
+            "spaceBetween",
+            "spaceEvenly",
+            "start",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "start",
+          "description": "Defines the arrangement of children along the main axis (horizontally). Use 'spaceBetween' to push items to the edges, or 'start'/'end'/'center' to pack them together."
+        },
+        "align": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "stretch",
+          "description": "Defines the alignment of children along the cross axis (vertically). This is similar to the CSS 'align-items' property, but uses camelCase values (e.g., 'start')."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Column": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Column"
+        },
+        "children": {
+          "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ComponentId"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TemplateChildList"
+            }
+          ]
+        },
+        "justify": {
+          "enum": [
+            "center",
+            "end",
+            "spaceAround",
+            "spaceBetween",
+            "spaceEvenly",
+            "start",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "start",
+          "description": "Defines the arrangement of children along the main axis (vertically). Use 'spaceBetween' to push items to the edges (e.g. header at top, footer at bottom), or 'start'/'end'/'center' to pack them together."
+        },
+        "align": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "stretch",
+          "description": "Defines the alignment of children along the cross axis (horizontally). This is similar to the CSS 'align-items' property."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "List": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "List"
+        },
+        "children": {
+          "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ComponentId"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TemplateChildList"
+            }
+          ]
+        },
+        "direction": {
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string",
+          "default": "vertical",
+          "description": "The direction in which the list items are laid out."
+        },
+        "align": {
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ],
+          "type": "string",
+          "default": "stretch",
+          "description": "Defines the alignment of children along the cross axis."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "children",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Card": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Card"
+        },
+        "child": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "child",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Tabs": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Tabs"
+        },
+        "tabs": {
+          "description": "An array of objects, where each object defines a tab with a title and a child component.",
+          "items": {
+            "$ref": "#/$defs/TabItem"
+          },
+          "type": "array"
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "tabs",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Modal": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Modal"
+        },
+        "trigger": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the component that opens the modal when interacted with (e.g., a button)."
+        },
+        "content": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the component to be displayed inside the modal."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "trigger",
+        "content",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Divider": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Divider"
+        },
+        "axis": {
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "type": "string",
+          "default": "horizontal",
+          "description": "The orientation of the divider."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Button": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Button"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "child": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button."
+        },
+        "variant": {
+          "enum": [
+            "default",
+            "primary",
+            "borderless"
+          ],
+          "type": "string",
+          "default": "default",
+          "description": "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link."
+        },
+        "action": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ActionEventWrapper"
+            },
+            {
+              "$ref": "#/$defs/ActionFunctionCallWrapper"
+            }
+          ]
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "child",
+        "action",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "TextField": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "TextField"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text label for the input field."
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The value of the text field."
+        },
+        "placeholder": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The placeholder text for the input field."
+        },
+        "variant": {
+          "enum": [
+            "longText",
+            "number",
+            "shortText",
+            "obscured"
+          ],
+          "type": "string",
+          "default": "shortText",
+          "description": "The type of input field to display."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CheckBox": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "CheckBox"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text to display next to the checkbox."
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "The current state of the checkbox (true for checked, false for unchecked)."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "label",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ChoicePicker": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "ChoicePicker"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The label for the group of options."
+        },
+        "variant": {
+          "enum": [
+            "multipleSelection",
+            "mutuallyExclusive"
+          ],
+          "type": "string",
+          "default": "mutuallyExclusive",
+          "description": "A hint for how the choice picker should be displayed and behave."
+        },
+        "options": {
+          "description": "The list of available options to choose from.",
+          "items": {
+            "$ref": "#/$defs/OptionItem"
+          },
+          "type": "array"
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicValue",
+          "description": "The list of currently selected values. This should be bound to a string array in the data model."
+        },
+        "displayStyle": {
+          "enum": [
+            "checkbox",
+            "chips"
+          ],
+          "type": "string",
+          "default": "checkbox",
+          "description": "The display style of the component."
+        },
+        "filterable": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, displays a search input to filter the options."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "options",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Slider": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "Slider"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The label for the slider."
+        },
+        "min": {
+          "type": "number",
+          "default": 0,
+          "description": "The minimum value of the slider."
+        },
+        "max": {
+          "description": "The maximum value of the slider.",
+          "type": "number"
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The current value of the slider."
+        },
+        "steps": {
+          "type": "integer",
+          "description": "The number of discrete divisions in the slider range. If specified, the slider will snap to discrete values."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "max",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "DateTimeInput": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this component, overriding any surface-level default catalogId."
+        },
+        "accessibility": {
+          "$ref": "#/$defs/AccessibilityAttributes"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Optional component-level metadata for vendor extensions."
+        },
+        "component": {
+          "const": "DateTimeInput"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/CheckRule"
+          },
+          "type": "array",
+          "description": "A list of checks to perform. These are function calls that must return a boolean indicating validity."
+        },
+        "value": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string."
+        },
+        "enableDate": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, allows the user to select a date."
+        },
+        "enableTime": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, allows the user to select a time."
+        },
+        "min": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The minimum allowed date/time in ISO 8601 format."
+        },
+        "max": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The maximum allowed date/time in ISO 8601 format."
+        },
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text label for the input field."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      },
+      "required": [
+        "id",
+        "value",
+        "component"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    }
+  },
+  "functions": {
+    "required": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "description": "The value to check."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "regex": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "pattern": {
+          "description": "The regex pattern to match against.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "length": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum allowed length."
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum allowed length."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "numeric": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "min": {
+          "type": "number",
+          "description": "The minimum allowed value."
+        },
+        "max": {
+          "type": "number",
+          "description": "The maximum allowed value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "email": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "@index": {
+      "additionalProperties": false,
+      "properties": {
+        "offset": {
+          "$ref": "#/$defs/DynamicNumber",
+          "default": 0,
+          "description": "Optional. An offset to add to the 0-based index (e.g., 1 for 1-based indexing). Defaults to 0."
+        }
+      },
+      "type": "object"
+    },
+    "formatString": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "formatNumber": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The number to format."
+        },
+        "decimals": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+        },
+        "grouping": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "formatCurrency": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The monetary amount."
+        },
+        "currency": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The ISO 4217 currency code (e.g., 'USD', 'EUR')."
+        },
+        "decimals": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+        },
+        "grouping": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+        }
+      },
+      "required": [
+        "value",
+        "currency"
+      ],
+      "type": "object"
+    },
+    "formatDate": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicValue",
+          "description": "The date to format."
+        },
+        "format": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A Unicode TR35 date pattern string.  Token Reference: - Year: 'yy' (26), 'yyyy' (2026) - Month: 'M' (1), 'MM' (01), 'MMM' (Jan), 'MMMM' (January) - Day: 'd' (1), 'dd' (01), 'E' (Tue), 'EEEE' (Tuesday) - Hour (12h): 'h' (1-12), 'hh' (01-12) - requires 'a' for AM/PM - Hour (24h): 'H' (0-23), 'HH' (00-23) - Military Time - Minute: 'mm' (00-59) - Second: 'ss' (00-59) - Period: 'a' (AM/PM)  Examples: - 'MMM dd, yyyy' -> 'Jan 16, 2026' - 'HH:mm' -> '14:30' (Military) - 'h:mm a' -> '2:30 PM' - 'EEEE, d MMMM' -> 'Friday, 16 January'"
+        }
+      },
+      "required": [
+        "value",
+        "format"
+      ],
+      "type": "object"
+    },
+    "pluralize": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicNumber",
+          "description": "The numeric value used to determine the plural category."
+        },
+        "zero": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'zero' category (e.g., 0 items)."
+        },
+        "one": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'one' category (e.g., 1 item)."
+        },
+        "two": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'two' category (used in Arabic, Welsh, etc.)."
+        },
+        "few": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'few' category (e.g., small groups in Slavic languages)."
+        },
+        "many": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "String for the 'many' category (e.g., large groups in various languages)."
+        },
+        "other": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The default/fallback string (used for general plural cases)."
+        }
+      },
+      "required": [
+        "value",
+        "other"
+      ],
+      "type": "object"
+    },
+    "openUrl": {
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The URL to open."
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "and": {
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "description": "The list of boolean values to evaluate.",
+          "items": {
+            "$ref": "#/$defs/DynamicBoolean"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "type": "object"
+    },
+    "or": {
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "description": "The list of boolean values to evaluate.",
+          "items": {
+            "$ref": "#/$defs/DynamicBoolean"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "type": "object"
+    },
+    "not": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "The boolean value to negate."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "add": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "subtract": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "multiply": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "divide": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "equals": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {},
+        "b": {}
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "not_equals": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {},
+        "b": {}
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "greater_than": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "less_than": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/DynamicNumber"
+        },
+        "b": {
+          "$ref": "#/$defs/DynamicNumber"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    },
+    "contains": {
+      "additionalProperties": false,
+      "properties": {
+        "string": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "substring": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "string",
+        "substring"
+      ],
+      "type": "object"
+    },
+    "starts_with": {
+      "additionalProperties": false,
+      "properties": {
+        "string": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "prefix": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "string",
+        "prefix"
+      ],
+      "type": "object"
+    },
+    "ends_with": {
+      "additionalProperties": false,
+      "properties": {
+        "string": {
+          "$ref": "#/$defs/DynamicString"
+        },
+        "suffix": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "string",
+        "suffix"
+      ],
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "AccessibilityAttributes": {
+      "additionalProperties": false,
+      "description": "Attributes to enhance accessibility when using assistive technologies like screen readers or model understanding.",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "A short string, typically 1 to 3 words, used by assistive technologies to convey the purpose or intent of an element. For example, an input field might have an accessible label of 'User ID' or a button might be labeled 'Submit'."
+        },
+        "description": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "Additional information provided by assistive technologies about an element such as instructions, format requirements, or result of an action. For example, a mute button might have a label of 'Mute' and a description of 'Silences notifications about this conversation'."
+        },
+        "live": {
+          "enum": [
+            "off",
+            "polite",
+            "assertive"
+          ],
+          "type": "string",
+          "default": "off",
+          "description": "Controls screen reader announcements for dynamic updates (WAI-ARIA aria-live). 'polite' waits for user pause; 'assertive' interrupts immediately for alerts."
+        },
+        "hidden": {
+          "$ref": "#/$defs/DynamicBoolean",
+          "description": "Hides the element and its children from assistive technologies when true. Default is false."
+        }
+      },
+      "type": "object"
+    },
+    "ComponentId": {
+      "description": "The unique identifier for a component, used for both definitions and references within the same surface.",
+      "type": "string"
+    },
+    "DataBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A JSON Pointer path to a value in the data model.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "FunctionCall": {
+      "additionalProperties": false,
+      "properties": {
+        "call": {
+          "description": "The name of the function to call.",
+          "type": "string"
+        },
+        "args": {
+          "additionalProperties": true,
+          "type": "object",
+          "description": "Arguments passed to the function."
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "The catalog ID for this function, overriding any surface-level default catalogId."
+        }
+      },
+      "required": [
+        "call"
+      ],
+      "type": "object",
+      "description": "Invokes a named function."
+    },
+    "SvgPath": {
+      "additionalProperties": false,
+      "properties": {
+        "svgPath": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      },
+      "required": [
+        "svgPath"
+      ],
+      "type": "object"
+    },
+    "TemplateChildList": {
+      "additionalProperties": false,
+      "description": "A template for generating a dynamic list of children from a data model list.\n\nThe `componentId` is the component to use as a template.",
+      "properties": {
+        "componentId": {
+          "$ref": "#/$defs/ComponentId"
+        },
+        "path": {
+          "description": "The path to the list of component property objects in the data model.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "componentId",
+        "path"
+      ],
+      "type": "object"
+    },
+    "TabItem": {
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The tab title."
+        },
+        "child": {
+          "$ref": "#/$defs/ComponentId",
+          "description": "The ID of the child component."
+        }
+      },
+      "required": [
+        "title",
+        "child"
+      ],
+      "type": "object"
+    },
+    "ActionEvent": {
+      "additionalProperties": false,
+      "description": "The event to dispatch to the agent.",
+      "properties": {
+        "name": {
+          "description": "The name of the action to be dispatched to the agent.",
+          "type": "string"
+        },
+        "userMessage": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "An optional human-readable message describing the action performed by the user, to present in conversation history or user feedback."
+        },
+        "context": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DynamicValue"
+          },
+          "type": "object",
+          "description": "A JSON object containing the key-value pairs for the action context. Values can be literals or paths. Use literal values unless the value must be dynamically bound to the data model. Do NOT use paths for static IDs."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ActionEventWrapper": {
+      "additionalProperties": false,
+      "description": "Triggers an agent-side event.",
+      "properties": {
+        "event": {
+          "$ref": "#/$defs/ActionEvent"
+        }
+      },
+      "required": [
+        "event"
+      ],
+      "type": "object"
+    },
+    "ActionFunctionCallWrapper": {
+      "additionalProperties": false,
+      "description": "Executes a renderer or agent-side function.",
+      "properties": {
+        "functionCall": {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      },
+      "required": [
+        "functionCall"
+      ],
+      "type": "object"
+    },
+    "CheckRule": {
+      "additionalProperties": false,
+      "description": "A single validation check rule applied to an input component. The condition function or path evaluates to a structured validation result object.",
+      "properties": {
+        "condition": {
+          "$ref": "#/$defs/DynamicValue",
+          "description": "Path or function call evaluating to a structured validation result object."
+        },
+        "message": {
+          "type": "string",
+          "description": "Optional fallback error message."
+        }
+      },
+      "required": [
+        "condition"
+      ],
+      "type": "object"
+    },
+    "OptionItem": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/DynamicString",
+          "description": "The text to display for this option."
+        },
+        "value": {
+          "description": "The stable value associated with this option.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "type": "object"
+    },
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/Image"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/Video"
+        },
+        {
+          "$ref": "#/components/AudioPlayer"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/List"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/Tabs"
+        },
+        {
+          "$ref": "#/components/Modal"
+        },
+        {
+          "$ref": "#/components/Divider"
+        },
+        {
+          "$ref": "#/components/Button"
+        },
+        {
+          "$ref": "#/components/TextField"
+        },
+        {
+          "$ref": "#/components/CheckBox"
+        },
+        {
+          "$ref": "#/components/ChoicePicker"
+        },
+        {
+          "$ref": "#/components/Slider"
+        },
+        {
+          "$ref": "#/components/DateTimeInput"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "component"
+      }
+    },
+    "anyFunction": {
+      "oneOf": [
+        {
+          "$ref": "#/functions/required"
+        },
+        {
+          "$ref": "#/functions/regex"
+        },
+        {
+          "$ref": "#/functions/length"
+        },
+        {
+          "$ref": "#/functions/numeric"
+        },
+        {
+          "$ref": "#/functions/email"
+        },
+        {
+          "$ref": "#/functions/@index"
+        },
+        {
+          "$ref": "#/functions/formatString"
+        },
+        {
+          "$ref": "#/functions/formatNumber"
+        },
+        {
+          "$ref": "#/functions/formatCurrency"
+        },
+        {
+          "$ref": "#/functions/formatDate"
+        },
+        {
+          "$ref": "#/functions/pluralize"
+        },
+        {
+          "$ref": "#/functions/openUrl"
+        },
+        {
+          "$ref": "#/functions/and"
+        },
+        {
+          "$ref": "#/functions/or"
+        },
+        {
+          "$ref": "#/functions/not"
+        },
+        {
+          "$ref": "#/functions/add"
+        },
+        {
+          "$ref": "#/functions/subtract"
+        },
+        {
+          "$ref": "#/functions/multiply"
+        },
+        {
+          "$ref": "#/functions/divide"
+        },
+        {
+          "$ref": "#/functions/equals"
+        },
+        {
+          "$ref": "#/functions/not_equals"
+        },
+        {
+          "$ref": "#/functions/greater_than"
+        },
+        {
+          "$ref": "#/functions/less_than"
+        },
+        {
+          "$ref": "#/functions/contains"
+        },
+        {
+          "$ref": "#/functions/starts_with"
+        },
+        {
+          "$ref": "#/functions/ends_with"
+        }
+      ]
+    },
+    "DynamicBoolean": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicNumber": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicString": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        }
+      ]
+    },
+    "DynamicValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "items": {},
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        },
+        {
+          "$ref": "#/$defs/FunctionCall"
+        },
+        {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      ]
+    }
+  }
+}

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -12,14 +12,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import sys
-from typing import Any, Callable, Dict, Generic, List, Optional, Union, cast
+from typing import Any, Callable, Dict, Final, Generic, List, Optional, Set, Union, cast
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar
 else:
     from typing_extensions import TypeVar
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
+
+
+def _generate_dynamic_type_def(type_cls: Any) -> Dict[str, Any]:
+    raw_schema = TypeAdapter(type_cls).json_schema()
+    if "$defs" in raw_schema:
+        del raw_schema["$defs"]
+    if "title" in raw_schema:
+        del raw_schema["title"]
+    if "description" in raw_schema:
+        del raw_schema["description"]
+    if "anyOf" in raw_schema:
+        items = raw_schema["anyOf"]
+        has_num = any(
+            isinstance(it, dict) and it.get("type") == "number" for it in items
+        )
+        if has_num:
+            items = [
+                it
+                for it in items
+                if not (isinstance(it, dict) and it.get("type") == "integer")
+            ]
+        raw_schema["oneOf"] = items
+        del raw_schema["anyOf"]
+    return raw_schema
+
+
+def _get_dynamic_types_defs() -> Dict[str, Any]:
+    from ..schema.common_types import (
+        DataBinding,
+        DynamicBoolean,
+        DynamicNumber,
+        DynamicString,
+        FunctionCall,
+    )
+    from ..schema.v1_0.common_types import DynamicValue
+
+    return {
+        "ComponentId": {
+            "description": (
+                "The unique identifier for a component, used for both"
+                " definitions and references within the same surface."
+            ),
+            "type": "string",
+        },
+        "DynamicString": _generate_dynamic_type_def(DynamicString),
+        "DynamicNumber": _generate_dynamic_type_def(DynamicNumber),
+        "DynamicBoolean": _generate_dynamic_type_def(DynamicBoolean),
+        "DynamicValue": _generate_dynamic_type_def(DynamicValue),
+        "DataBinding": _generate_dynamic_type_def(DataBinding),
+        "FunctionCall": _generate_dynamic_type_def(FunctionCall),
+    }
+
 
 from ..exceptions import A2uiCatalogError
 from .functions import (
@@ -52,12 +105,273 @@ def _is_version_at_least_1_0(protocol_version: Union[str, Any]) -> bool:
         return False
 
 
+def load_preserved_type_refs() -> Set[str]:
+    """Dynamically loads all common type names defined in schema/common_types.py and versioned submodules."""
+    import importlib
+    import a2ui.core.schema as schema_pkg
+
+    excluded = {
+        "sys",
+        "annotations",
+        "Any",
+        "Dict",
+        "List",
+        "Optional",
+        "Union",
+        "Tuple",
+        "Set",
+        "Literal",
+        "Annotated",
+        "BaseModel",
+        "ConfigDict",
+        "Field",
+        "AfterValidator",
+        "GetCoreSchemaHandler",
+        "ValidationInfo",
+        "CoreSchema",
+        "PydanticUndefined",
+        "field_validator",
+        "TypeVar",
+        "Generic",
+        "Callable",
+    }
+
+    modules_to_check: List[str] = ["a2ui.core.schema.common_types"]
+
+    protocol_version_enum = getattr(schema_pkg, "ProtocolVersion", None) or getattr(
+        schema_pkg, "A2uiProtocolVersion", None
+    )
+    if protocol_version_enum:
+        for ver_enum in protocol_version_enum:
+            raw_ver = str(ver_enum.value).lstrip("vV")
+            major_minor = "_".join(raw_ver.split(".")[:2])
+            mod_name = f"{schema_pkg.__name__}.v{major_minor}.common_types"
+            if mod_name not in modules_to_check:
+                modules_to_check.append(mod_name)
+
+    type_refs: Set[str] = set()
+    for modname in modules_to_check:
+        try:
+            mod = importlib.import_module(modname)
+            for attr in dir(mod):
+                if not attr.startswith("_") and attr not in excluded:
+                    type_refs.add(attr)
+        except ImportError:
+            pass
+
+    return type_refs
+
+
+PRESERVED_TYPE_REFS: Final[Set[str]] = load_preserved_type_refs()
+
+
+def _query_json_pointer(doc: Dict[str, Any], pointer: str) -> Any:
+    """Queries a JSON Pointer string starting with '#/' against a root dictionary."""
+    if not pointer.startswith("#/"):
+        return None
+    parts = pointer[2:].split("/")
+    curr: Any = doc
+    for part in parts:
+        part = part.replace("~1", "/").replace("~0", "~")
+        if isinstance(curr, dict) and part in curr:
+            curr = curr[part]
+        else:
+            return None
+    return curr
+
+
+def inline_local_refs(
+    node: Any, root_catalog: Dict[str, Any], visited: Optional[Set[str]] = None
+) -> Any:
+    """Recursively inlines local JSON references (pointers starting with '#/') into schema objects."""
+    if visited is None:
+        visited = set()
+
+    if isinstance(node, dict):
+        if (
+            "$ref" in node
+            and isinstance(node["$ref"], str)
+            and node["$ref"].startswith("#/")
+        ):
+            ref_path = node["$ref"]
+            ref_name = ref_path.split("/")[-1]
+            if ref_name in PRESERVED_TYPE_REFS:
+                return node
+
+            if ref_path in visited:
+                return node  # Prevent stack overflow on circular references
+
+            new_visited = set(visited)
+            new_visited.add(ref_path)
+
+            resolved_node = _query_json_pointer(root_catalog, ref_path)
+            if resolved_node is not None:
+                resolved_node = inline_local_refs(
+                    resolved_node, root_catalog, new_visited
+                )
+                merged = {k: v for k, v in node.items() if k != "$ref"}
+                if isinstance(resolved_node, dict):
+                    res = dict(resolved_node)
+                    for k, v in merged.items():
+                        if (
+                            k in res
+                            and isinstance(res[k], dict)
+                            and isinstance(v, dict)
+                        ):
+                            res[k] = {**res[k], **v}
+                        elif (
+                            k in res
+                            and isinstance(res[k], list)
+                            and isinstance(v, list)
+                        ):
+                            res[k] = res[k] + [x for x in v if x not in res[k]]
+                        else:
+                            res[k] = v
+                    return res
+                return resolved_node
+
+        return {k: inline_local_refs(v, root_catalog, visited) for k, v in node.items()}
+
+    elif isinstance(node, list):
+        return [inline_local_refs(item, root_catalog, visited) for item in node]
+
+    return node
+
+
+def _is_ref(item: Any, target_ref: str) -> bool:
+    return isinstance(item, dict) and item.get("$ref") == target_ref
+
+
+def _is_type(item: Any, target_type: str) -> bool:
+    return isinstance(item, dict) and item.get("type") == target_type
+
+
+def _clean_schema_node(
+    node: Any,
+    referenced_dynamics: Optional[Set[str]] = None,
+    is_properties_dict: bool = False,
+    is_union_container: bool = False,
+) -> Any:
+    """Recursively cleans auto-generated Pydantic schema attributes (titles, null types, redundant anyOf wrappers, dynamic value expansions)."""
+    if referenced_dynamics is None:
+        referenced_dynamics = set()
+
+    if isinstance(node, dict):
+        cleaned = {}
+        for k, v in node.items():
+            if k == "title" and not is_properties_dict:
+                continue
+            cleaned[k] = _clean_schema_node(
+                v,
+                referenced_dynamics=referenced_dynamics,
+                is_properties_dict=(k == "properties"),
+                is_union_container=(k in ("anyComponent", "anyFunction")),
+            )
+
+        if (
+            "$ref" in cleaned
+            and isinstance(cleaned["$ref"], str)
+            and cleaned["$ref"].startswith("#/$defs/")
+        ):
+            ref_target = cleaned["$ref"].split("/")[-1]
+            referenced_dynamics.add(ref_target)
+
+        if "default" in cleaned and cleaned["default"] is None:
+            del cleaned["default"]
+
+        union_key = (
+            "anyOf" if "anyOf" in cleaned else ("oneOf" if "oneOf" in cleaned else None)
+        )
+        if union_key and isinstance(cleaned[union_key], list):
+            items = [
+                item
+                for item in cleaned[union_key]
+                if not (isinstance(item, dict) and item.get("type") == "null")
+            ]
+            if len(items) == 1 and not is_union_container:
+                single_item = items[0]
+                parent_attrs = {k: v for k, v in cleaned.items() if k != union_key}
+                if isinstance(single_item, dict):
+                    merged = dict(single_item)
+                    for k, v in parent_attrs.items():
+                        if k not in merged:
+                            merged[k] = v
+                    return _clean_schema_node(
+                        merged,
+                        referenced_dynamics=referenced_dynamics,
+                        is_properties_dict=False,
+                    )
+                else:
+                    return single_item
+            else:
+                has_databinding = any(
+                    _is_ref(it, "#/$defs/DataBinding") for it in items
+                )
+                has_func_call = any(_is_ref(it, "#/$defs/FunctionCall") for it in items)
+                if has_databinding and has_func_call:
+                    str_type = any(_is_type(it, "string") for it in items)
+                    num_type = any(
+                        _is_type(it, "number") or _is_type(it, "integer")
+                        for it in items
+                    )
+                    bool_type = any(_is_type(it, "boolean") for it in items)
+                    array_or_obj = any(
+                        isinstance(it, dict)
+                        and (
+                            it.get("type") in ("array", "object")
+                            or "additionalProperties" in it
+                        )
+                        for it in items
+                    )
+
+                    types_count = sum([str_type, num_type, bool_type, array_or_obj])
+
+                    target_def = None
+                    if types_count > 1:
+                        target_def = "DynamicValue"
+                    elif str_type:
+                        target_def = "DynamicString"
+                    elif num_type:
+                        target_def = "DynamicNumber"
+                    elif bool_type:
+                        target_def = "DynamicBoolean"
+                    else:
+                        target_def = "DynamicValue"
+
+                    if target_def:
+                        referenced_dynamics.add(target_def)
+                        parent_attrs = {
+                            k: v for k, v in cleaned.items() if k != union_key
+                        }
+                        res = {"$ref": f"#/$defs/{target_def}"}
+                        res.update(parent_attrs)
+                        return res
+
+                if union_key == "anyOf":
+                    del cleaned["anyOf"]
+                    cleaned["oneOf"] = items
+                else:
+                    cleaned["oneOf"] = items
+
+        return cleaned
+    elif isinstance(node, list):
+        return [
+            _clean_schema_node(
+                item,
+                referenced_dynamics=referenced_dynamics,
+                is_properties_dict=False,
+            )
+            for item in node
+        ]
+    return node
+
+
 TComponent = TypeVar("TComponent", bound=ComponentApi, default=Any)
 TFunction = TypeVar("TFunction", bound=FunctionApi, default=Any)
 
 
 class Catalog(Generic[TComponent, TFunction]):
-    """A unified collection of available components and functions."""
+    """A versioned set of component and function API definitions."""
 
     def __init__(
         self,
@@ -65,14 +379,12 @@ class Catalog(Generic[TComponent, TFunction]):
         protocol_version: Optional[str] = None,
         components: Optional[List[TComponent]] = None,
         functions: Optional[List[TFunction]] = None,
-        theme_schema: Dict[str, Any] = {},
+        theme_schema: Optional[Dict[str, Any]] = None,
         instructions: Optional[str] = None,
     ):
-        if not catalog_id:
-            raise ValueError("catalog_id must be provided.")
-        self.catalog_id = catalog_id
         if not protocol_version:
             raise ValueError("protocol_version must be provided.")
+        self.catalog_id = catalog_id
         self.protocol_version = protocol_version
         self.instructions = instructions
 
@@ -94,8 +406,7 @@ class Catalog(Generic[TComponent, TFunction]):
                 )
             self.functions[fn.name] = fn
 
-        self.theme_schema = theme_schema
-        self._catalog_schema: Optional[Dict[str, Any]] = None
+        self.theme_schema = theme_schema or {}
         self._component_ref_map: Optional[Dict[str, ComponentRefSpec]] = None
 
     @property
@@ -104,9 +415,139 @@ class Catalog(Generic[TComponent, TFunction]):
         return self.catalog_id
 
     @property
-    def catalog_schema(self) -> Optional[Dict[str, Any]]:
-        """Returns the raw JSON Schema if loaded via from_json(), else None."""
-        return self._catalog_schema
+    def catalog_schema(self) -> Dict[str, Any]:
+        """Dynamically reconstructs the unified catalog JSON Schema on the fly."""
+        schema: Dict[str, Any] = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "catalogId": self.catalog_id,
+        }
+
+        if self.instructions:
+            schema["instructions"] = self.instructions
+
+        defs: Dict[str, Any] = {}
+        if self.theme_schema:
+            defs["theme"] = self.theme_schema
+
+        if self.components:
+            for comp in self.components.values():
+                s = comp.schema
+                if (
+                    isinstance(s, dict)
+                    and "$defs" in s
+                    and isinstance(s["$defs"], dict)
+                ):
+                    for def_name, def_schema in s["$defs"].items():
+                        if def_name not in defs:
+                            defs[def_name] = def_schema
+
+        if self.functions:
+            for fn in self.functions.values():
+                s = fn.schema
+                if isinstance(s, type) and hasattr(s, "model_json_schema"):
+                    s = s.model_json_schema()
+                if (
+                    isinstance(s, dict)
+                    and "$defs" in s
+                    and isinstance(s["$defs"], dict)
+                ):
+                    for def_name, def_schema in s["$defs"].items():
+                        if def_name not in defs:
+                            defs[def_name] = def_schema
+
+        if self.components:
+            comp_schemas: Dict[str, Any] = {}
+            for name, comp in self.components.items():
+                s = comp.schema
+                if isinstance(s, dict):
+                    s = copy.deepcopy(s)
+                    if "$defs" in s:
+                        del s["$defs"]
+                    if "properties" in s and "component" in s["properties"]:
+                        comp_const = name
+                        if (
+                            isinstance(s["properties"]["component"], dict)
+                            and "const" in s["properties"]["component"]
+                        ):
+                            comp_const = s["properties"]["component"]["const"]
+                        s["properties"]["component"] = {"const": comp_const}
+                        if "required" not in s or not isinstance(s["required"], list):
+                            s["required"] = []
+                        if "component" not in s["required"]:
+                            s["required"].append("component")
+                    if "unevaluatedProperties" not in s:
+                        if "additionalProperties" in s:
+                            s["unevaluatedProperties"] = s.pop("additionalProperties")
+                comp_schemas[name] = s
+            schema["components"] = comp_schemas
+
+        if self.functions:
+            fn_schemas: Dict[str, Any] = {}
+            for name, fn in self.functions.items():
+                s = fn.schema
+                if isinstance(s, type) and hasattr(s, "model_json_schema"):
+                    s = s.model_json_schema()
+                if isinstance(s, dict):
+                    s = copy.deepcopy(s)
+                    if "$defs" in s:
+                        del s["$defs"]
+                fn_schemas[name] = s
+            schema["functions"] = fn_schemas
+
+        if self.components:
+            any_comp_refs = [
+                {"$ref": f"#/components/{name}"} for name in self.components.keys()
+            ]
+            defs["anyComponent"] = {
+                "oneOf": any_comp_refs,
+                "discriminator": {"propertyName": "component"},
+            }
+
+        if self.functions:
+            any_fn_refs = [
+                {"$ref": f"#/functions/{name}"} for name in self.functions.keys()
+            ]
+            defs["anyFunction"] = {
+                "oneOf": any_fn_refs,
+            }
+
+        if defs:
+            schema["$defs"] = defs
+
+        referenced_dynamics: Set[str] = set()
+        cleaned_schema = cast(
+            Dict[str, Any],
+            _clean_schema_node(schema, referenced_dynamics=referenced_dynamics),
+        )
+
+        if referenced_dynamics:
+            if "$defs" not in cleaned_schema:
+                cleaned_schema["$defs"] = {}
+            if any(
+                d in referenced_dynamics
+                for d in (
+                    "DynamicString",
+                    "DynamicNumber",
+                    "DynamicBoolean",
+                    "DynamicValue",
+                )
+            ):
+                referenced_dynamics.add("DataBinding")
+                referenced_dynamics.add("FunctionCall")
+            dynamic_defs = _get_dynamic_types_defs()
+            for dyn in sorted(referenced_dynamics):
+                if dyn in dynamic_defs:
+                    if dyn not in cleaned_schema["$defs"]:
+                        cleaned_schema["$defs"][dyn] = dynamic_defs[dyn]
+                    elif isinstance(cleaned_schema["$defs"][dyn], dict) and isinstance(
+                        dynamic_defs[dyn], dict
+                    ):
+                        cleaned_schema["$defs"][dyn] = {
+                            **dynamic_defs[dyn],
+                            **cleaned_schema["$defs"][dyn],
+                        }
+
+        return cleaned_schema
 
     def get_component(self, name: str) -> Optional[TComponent]:
         """Directly retrieves a component by name."""
@@ -154,9 +595,13 @@ class Catalog(Generic[TComponent, TFunction]):
         if not p_ver:
             raise ValueError("protocol_version must be provided.")
 
-        components_map = catalog_schema.get("components", {})
+        inlined_catalog_schema = inline_local_refs(catalog_schema, catalog_schema)
+
+        components_map = inlined_catalog_schema.get("components", {})
         any_comp_refs = (
-            catalog_schema.get("$defs", {}).get("anyComponent", {}).get("oneOf", [])
+            inlined_catalog_schema.get("$defs", {})
+            .get("anyComponent", {})
+            .get("oneOf", [])
         )
         permitted_names = set()
         for item in any_comp_refs:
@@ -184,15 +629,18 @@ class Catalog(Generic[TComponent, TFunction]):
                 )
 
         functions = []
-        raw_functions = catalog_schema.get("functions", {})
+        raw_functions = inlined_catalog_schema.get("functions", {})
         any_func_refs = (
-            catalog_schema.get("$defs", {}).get("anyFunction", {}).get("oneOf", [])
+            inlined_catalog_schema.get("$defs", {})
+            .get("anyFunction", {})
+            .get("oneOf", [])
         )
         permitted_func_names = set()
         for item in any_func_refs:
-            ref = item.get("$ref", "")
-            if ref.startswith("#/functions/"):
-                permitted_func_names.add(ref.split("/")[-1])
+            if isinstance(item, dict):
+                ref = item.get("$ref", "")
+                if isinstance(ref, str) and ref.startswith("#/functions/"):
+                    permitted_func_names.add(ref.split("/")[-1])
 
         if isinstance(raw_functions, dict):
             for name, spec in raw_functions.items():
@@ -215,8 +663,9 @@ class Catalog(Generic[TComponent, TFunction]):
             protocol_version=p_ver,
             components=components,
             functions=functions,
-            theme_schema=catalog_schema.get("theme") or {},
-            instructions=catalog_schema.get("instructions"),
+            theme_schema=inlined_catalog_schema.get("theme")
+            or inlined_catalog_schema.get("$defs", {}).get("theme")
+            or {},
+            instructions=inlined_catalog_schema.get("instructions"),
         )
-        cat._catalog_schema = catalog_schema
         return cat

--- a/python/a2ui_core/src/a2ui/core/schema/common_types.py
+++ b/python/a2ui_core/src/a2ui/core/schema/common_types.py
@@ -33,7 +33,7 @@ class SingleReference(str, ComponentReference):
 
         return core_schema.no_info_after_validator_function(
             cls,
-            core_schema.str_schema(),
+            core_schema.str_schema(ref="ComponentId"),
             serialization=core_schema.plain_serializer_function_ser_schema(str),
         )
 

--- a/python/a2ui_core/tests/test_catalog.py
+++ b/python/a2ui_core/tests/test_catalog.py
@@ -597,3 +597,98 @@ def test_mixed_catalog_validation():
         root_id="c1",
         config=ValidationConfig(allow_orphan_components=True),
     )
+
+
+# ==============================================================================
+# 9. Dynamic Schema & Reference Inlining Tests
+# ==============================================================================
+
+
+def test_query_json_pointer():
+    from a2ui.core.catalog.catalog import _query_json_pointer
+
+    doc = {
+        "$defs": {
+            "Item": {"type": "string"},
+            "escaped/name~prop": "value",
+        }
+    }
+    assert _query_json_pointer(doc, "#/$defs/Item") == {"type": "string"}
+    assert _query_json_pointer(doc, "#/$defs/escaped~1name~0prop") == "value"
+    assert _query_json_pointer(doc, "#/$defs/NonExistent") is None
+    assert _query_json_pointer(doc, "invalid_pointer") is None
+
+
+def test_inline_local_refs():
+    from a2ui.core.catalog.catalog import inline_local_refs
+
+    root_catalog = {
+        "$defs": {
+            "CatalogComponentCommon": {"properties": {"weight": {"type": "number"}}},
+            "CircularRef": {"$ref": "#/$defs/CircularRef"},
+        }
+    }
+
+    schema = {
+        "$ref": "#/$defs/CatalogComponentCommon",
+        "properties": {"text": {"type": "string"}},
+        "preserved": {"$ref": "#/$defs/ComponentId"},
+    }
+
+    inlined = inline_local_refs(schema, root_catalog)
+
+    # CatalogComponentCommon properties should be merged into inlined schema
+    assert inlined["properties"]["weight"] == {"type": "number"}
+    assert inlined["properties"]["text"] == {"type": "string"}
+    # Preserved type refs should not be resolved
+    assert inlined["preserved"] == {"$ref": "#/$defs/ComponentId"}
+
+    # Circular ref should not stack overflow
+    circular_inlined = inline_local_refs({"$ref": "#/$defs/CircularRef"}, root_catalog)
+    assert circular_inlined == {"$ref": "#/$defs/CircularRef"}
+
+
+def test_load_preserved_type_refs():
+    from a2ui.core.catalog.catalog import load_preserved_type_refs, PRESERVED_TYPE_REFS
+
+    type_refs = load_preserved_type_refs()
+    assert isinstance(type_refs, set)
+    assert "ComponentId" in type_refs
+    assert "ChildList" in type_refs
+    assert "Action" in type_refs
+    assert "DataBinding" in type_refs
+    assert PRESERVED_TYPE_REFS == type_refs
+
+
+def test_computed_catalog_schema():
+    from a2ui.core.catalog import Catalog, ComponentApi, FunctionApi
+
+    comp = ComponentApi(
+        "Text", {"type": "object", "properties": {"text": {"type": "string"}}}
+    )
+    fn = FunctionApi("openUrl", return_type="any", schema={"type": "object"})
+
+    cat = Catalog(
+        catalog_id="https://a2ui.org/computed-catalog",
+        protocol_version="v1.0",
+        components=[comp],
+        functions=[fn],
+        theme_schema={"primaryColor": "#000"},
+        instructions="Sample instructions",
+    )
+
+    schema = cat.catalog_schema
+
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["catalogId"] == "https://a2ui.org/computed-catalog"
+    assert schema["instructions"] == "Sample instructions"
+    assert "Text" in schema["components"]
+    assert "openUrl" in schema["functions"]
+    assert schema["$defs"]["theme"] == {"primaryColor": "#000"}
+    assert schema["$defs"]["anyComponent"] == {
+        "oneOf": [{"$ref": "#/components/Text"}],
+        "discriminator": {"propertyName": "component"},
+    }
+    assert schema["$defs"]["anyFunction"] == {
+        "oneOf": [{"$ref": "#/functions/openUrl"}],
+    }

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -598,19 +598,61 @@ def validate_from_json_case(case: Dict[str, Any]) -> None:
 
 
 def validate_catalog_schema_case(case: Dict[str, Any]) -> None:
-    c_schema = (
-        case.get("catalogSchema") or case.get("catalog") or case.get("schema") or case
-    )
-    c_id = resolve_catalog_id(case) or "https://a2ui.org/catalogs/basic"
     p_ver = resolve_protocol_version(case)
-    expect_err = case.get("expectError")
+    if case.get("useBasicCatalog") or case.get("catalog") == "BasicCatalog":
+        if p_ver == "v1.0":
+            from a2ui.core.basic_catalog.v1_0 import BasicCatalog
 
-    if expect_err:
-        with assert_raises(expect_err):
-            Catalog.from_json(c_schema, catalog_id=c_id, protocol_version=p_ver)
+            cat: Catalog[Any, Any] = BasicCatalog()
+        elif p_ver == "v0.9":
+            from a2ui.core.basic_catalog.v0_9 import BasicCatalog
+
+            cat = BasicCatalog()
+        elif p_ver == "v0.8":
+            from a2ui.core.basic_catalog.v0_8 import BasicCatalog
+
+            cat = BasicCatalog()
+        else:
+            raise ValueError(f"BasicCatalog not supported for version {p_ver}")
     else:
-        cat = Catalog.from_json(c_schema, catalog_id=c_id, protocol_version=p_ver)
-        assert cat is not None
+        c_path = case.get("catalogPath") or case.get("catalogFile")
+        if c_path:
+            full_p = os.path.abspath(os.path.join(CONFORMANCE_ROOT, "../", c_path))
+            with open(full_p, "r", encoding="utf-8") as f:
+                c_schema = json.load(f)
+        else:
+            c_schema = (
+                case.get("catalogSchema")
+                or case.get("catalog")
+                or case.get("schema")
+                or case
+            )
+        c_id = (
+            resolve_catalog_id(case)
+            or (c_schema.get("catalogId") if isinstance(c_schema, dict) else None)
+            or "https://a2ui.org/catalogs/basic"
+        )
+        expect_err = case.get("expectError")
+
+        if expect_err:
+            with assert_raises(expect_err):
+                Catalog.from_json(c_schema, catalog_id=c_id, protocol_version=p_ver)
+            return
+        else:
+            cat = Catalog.from_json(c_schema, catalog_id=c_id, protocol_version=p_ver)
+
+    assert cat is not None
+
+    exp_path = case.get("expectPath") or case.get("expectFile")
+    if exp_path:
+        full_exp_p = os.path.abspath(os.path.join(CONFORMANCE_ROOT, "../", exp_path))
+        with open(full_exp_p, "r", encoding="utf-8") as f:
+            expected = json.load(f)
+    else:
+        expected = case.get("expect")
+
+    if expected is not None:
+        assert cat.catalog_schema == expected
 
 
 def validate_resolve_path_case(case: Dict[str, Any]) -> None:


### PR DESCRIPTION
- Remove hard-coded DYNAMIC_TYPES_DEFS in favor of dynamic schema generation using Pydantic TypeAdapter for DynamicString, DynamicNumber, DynamicBoolean, and DynamicValue.
- Compact expanded dynamic unions into $ref references pointing to top-level $defs.
- Update union item matching logic to correctly identify DynamicNumber even when both number and integer types are present in Pydantic schema.
- Preserve unevaluatedProperties / additionalProperties on component schemas based on underlying definition.
- Add required 'component' field to all component schemas.
- Re-generate converted_basic_catalog_v08.json, converted_basic_catalog_v09.json, and converted_basic_catalog_v10.json test data.

Fixes https://github.com/a2ui-project/a2ui/issues/1626

TAG=agy
CONV=707c9b6b-b2da-4940-ba6e-67f0b4f1d563