### PR TITLE
feat(python): implement Step 2.4A composition constraints and data model deletion

### DIFF
--- a/conformance/core/composition_constraints.yaml
+++ b/conformance/core/composition_constraints.yaml
@@ -67,6 +67,7 @@
                 component: ColumnHeader
   expectError:
     category: "ValidationError"
+    code: "UNALLOWED_PARENT"
     message: "Component 'invalid_header' (ColumnHeader) cannot be placed under parent 'root' (Row). Allowed parents: ['Column']."
 
 - name: test_composition_unallowed_child_error
@@ -95,4 +96,5 @@
                 component: Video
   expectError:
     category: "ValidationError"
+    code: "UNALLOWED_CHILD"
     message: "Container 'root' (RestrictedBox) cannot contain child 'v1' (Video). Allowed children: ['Text', 'Button']."

--- a/conformance/core/data_deletion.yaml
+++ b/conformance/core/data_deletion.yaml
@@ -130,3 +130,29 @@
         dataModel:
           settings:
             theme: "dark"
+
+- name: test_data_deletion_all_keys_empty_data_model
+  description: Verifies deleting the only top-level key via value=null results in an empty dataModel.
+  catalog:
+    protocolVersion: "v1.0"
+  action: validate
+  steps:
+    - payload:
+        - version: "v1.0"
+          createSurface:
+            surfaceId: "s1"
+            catalogId: "basic"
+            dataModel:
+              user:
+                profile:
+                  name: "Alice"
+    - payload:
+        - version: "v1.0"
+          updateDataModel:
+            surfaceId: "s1"
+            path: "/user"
+            value: null
+  expect:
+    surfaces:
+      s1:
+        dataModel: {}

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import re
 import sys
 from typing import Any, Callable, Dict, Final, Generic, List, Optional, Set, Union, cast
 
@@ -172,7 +173,7 @@ def _query_json_pointer(doc: Dict[str, Any], pointer: str) -> Any:
     parts = pointer[2:].split("/")
     curr: Any = doc
     for part in parts:
-        part = part.replace("~1", "/").replace("~0", "~")
+        part = re.sub(r"~([01])", lambda m: "/" if m.group(1) == "1" else "~", part)
         if isinstance(curr, dict) and part in curr:
             curr = curr[part]
         else:

--- a/python/a2ui_core/src/a2ui/core/state/validation_helpers.py
+++ b/python/a2ui_core/src/a2ui/core/state/validation_helpers.py
@@ -238,10 +238,20 @@ def validate_composition_constraints(
                 parent_id = parent_info["parent_id"]
 
             if parent_type not in allowed_parents:
-                raise A2uiValidationError(
+                msg = (
                     f"Component '{comp_id}' ({model.type}) cannot be placed"
                     f" under parent '{parent_id}' ({parent_type}). Allowed parents:"
                     f" {allowed_parents}."
+                )
+                raise A2uiValidationError(
+                    msg,
+                    details=[
+                        A2uiErrorDetail(
+                            path=f"components.{comp_id}",
+                            code="UNALLOWED_PARENT",
+                            message=msg,
+                        )
+                    ],
                 )
 
         allowed_children = getattr(component_api, "allowed_children", None)
@@ -250,8 +260,18 @@ def validate_composition_constraints(
             for child_id in children:
                 child_type = type_map.get(child_id)
                 if child_type and child_type not in allowed_children:
-                    raise A2uiValidationError(
+                    msg = (
                         f"Component '{comp_id}' ({model.type}) cannot contain child"
                         f" '{child_id}' ({child_type}). Allowed children:"
                         f" {allowed_children}."
+                    )
+                    raise A2uiValidationError(
+                        msg,
+                        details=[
+                            A2uiErrorDetail(
+                                path=f"components.{comp_id}",
+                                code="UNALLOWED_CHILD",
+                                message=msg,
+                            )
+                        ],
                     )

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -59,13 +59,6 @@ SKIP_TEST_NAMES: Set[str] = {
     "test_index_function_outside_loop_error",
     "test_validation_result_dynamic_object_return",
     "test_validation_result_boolean_fallback",
-    "test_pointer_escape_characters",
-    "test_pointer_array_indexing",
-    "test_pointer_auto_vivification",
-    "test_data_deletion_value_null",
-    "test_data_deletion_nested_pointer_sibling_preservation",
-    "test_data_deletion_top_level_key",
-    "test_data_deletion_parent_object_recursive",
 }
 
 # Transition skip list containing specific test suite files or basenames to skip entirely.
@@ -405,6 +398,15 @@ def assert_raises(expect_error: Any):
         assert (
             match
         ), f"Expected error '{message}' not found in exception '{excinfo.value}'"
+
+    if isinstance(expect_error, dict) and expect_error.get("code"):
+        expected_code = expect_error["code"]
+        err_details = getattr(excinfo.value, "details", [])
+        detail_codes = [d.code for d in err_details] if err_details else []
+        assert expected_code in detail_codes or expected_code in str(excinfo.value), (
+            f"Expected error code '{expected_code}' not found in exception details"
+            f" ({detail_codes}) or message ('{excinfo.value}')"
+        )
 
 
 CONFORMANCE_CASES = load_conformance_cases()


### PR DESCRIPTION
## Summary
- Update `validate_composition_constraints` in `validation_helpers.py` to attach structured `A2uiErrorDetail` with `UNALLOWED_PARENT` and `UNALLOWED_CHILD` error codes.
- Update `conformance/core/composition_constraints.yaml` to include explicit `UNALLOWED_PARENT` and `UNALLOWED_CHILD` error codes in `expectError`.
- Add `test_data_deletion_all_keys_empty_data_model` test case to `conformance/core/data_deletion.yaml`.
- Unskip data deletion, composition constraint, and JSON pointer conformance test cases in `test_conformance.py`.

TAG=agy
CONV=0e86280c-a51f-468d-afea-380aa20f7fac