### PR TITLE
fix(eval): include strategy & format in failure reports and autofix un-prefixed versions

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_lexer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_lexer.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /usr/local/google/home/jsimionato/development/a2ui_workspaces/issue-2465/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 from antlr4 import *
 from io import StringIO
 import sys

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_parser.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /usr/local/google/home/jsimionato/development/a2ui_workspaces/issue-2465/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_visitor.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_visitor.py
@@ -1,10 +1,9 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /usr/local/google/home/jsimionato/development/a2ui_workspaces/issue-2465/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 from antlr4 import *
 if "." in __name__:
     from .express_parser import ExpressParser
 else:
-    from express_parser import ExpressParser
-
+    from .express_parser import ExpressParser
 
 # This class defines a complete generic visitor for a parse tree produced by ExpressParser.
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
@@ -34,7 +34,7 @@ def parse_and_fix(payload: str) -> List[Dict[str, Any]]:
     normalized_payload = _normalize_smart_quotes(payload)
     try:
         a2ui_json = _parse(normalized_payload)
-        return a2ui_json
+        return _fix_message_versions(a2ui_json)
     except (
         json.JSONDecodeError,
         ValueError,
@@ -43,7 +43,22 @@ def parse_and_fix(payload: str) -> List[Dict[str, Any]]:
         logger.warning(f"Initial A2UI payload validation failed: {e}")
         updated_payload = _remove_trailing_commas(normalized_payload)
         a2ui_json = _parse(updated_payload)
-        return a2ui_json
+        return _fix_message_versions(a2ui_json)
+
+
+def _fix_message_versions(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Normalizes version strings in A2UI messages (e.g. '0.9' -> 'v0.9', '0.9.1' -> 'v0.9.1', '1.0' -> 'v1.0')."""
+    if not isinstance(messages, list):
+        return messages
+
+    for msg in messages:
+        if isinstance(msg, dict) and "version" in msg:
+            ver = msg["version"]
+            if isinstance(ver, str) and ver and ver[0].isdigit():
+                fixed_ver = f"v{ver}"
+                logger.info(f"Fixed un-prefixed version string '{ver}' to '{fixed_ver}'")
+                msg["version"] = fixed_ver
+    return messages
 
 
 def _parse(payload: str) -> List[Dict[str, Any]]:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/parser/payload_fixer.py
@@ -56,7 +56,9 @@ def _fix_message_versions(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             ver = msg["version"]
             if isinstance(ver, str) and ver and ver[0].isdigit():
                 fixed_ver = f"v{ver}"
-                logger.info(f"Fixed un-prefixed version string '{ver}' to '{fixed_ver}'")
+                logger.info(
+                    f"Fixed un-prefixed version string '{ver}' to '{fixed_ver}'"
+                )
                 msg["version"] = fixed_ver
     return messages
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/constants.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/constants.py
@@ -101,6 +101,7 @@ The generated response MUST follow these rules:
 - Each A2UI JSON block MUST be wrapped in `{A2UI_OPEN_TAG}` and `{A2UI_CLOSE_TAG}` tags.
 - Between or around these blocks, you can provide conversational text.
 - The JSON part MUST be a single, raw JSON object (usually a list of A2UI messages) and MUST validate against the provided A2UI JSON SCHEMA.
+- Message Version Format: The `version` property in each message MUST include the leading 'v' prefix matching the schema (e.g., "v0.9", "v0.9.1", or "v1.0"). Do NOT omit the 'v' prefix.
 - Top-Down Component Ordering: Within the `components` list of a message:
     - The 'root' component MUST be the FIRST element.
     - Parent components MUST appear before their child components.

--- a/agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py
+++ b/agent_sdks/python/a2ui_agent/tests/parser/test_payload_fixer.py
@@ -54,3 +54,12 @@ class TestPayloadFixer(unittest.TestCase):
         self.assertEqual(len(res), 1)
         components = res[0]['createSurface']['components']
         self.assertEqual(components[0]['text'], 'Hello world')
+
+    def test_fix_unprefixed_version(self):
+        """Verify parse_and_fix normalizes missing 'v' prefix on message version strings."""
+        payload_09 = r'[{"version": "0.9", "createSurface": {"surfaceId": "default"}}]'
+        payload_10 = r'[{"version": "1.0", "createSurface": {"surfaceId": "default"}}]'
+        res_09 = parse_and_fix(payload_09)
+        res_10 = parse_and_fix(payload_10)
+        self.assertEqual(res_09[0]['version'], 'v0.9')
+        self.assertEqual(res_10[0]['version'], 'v1.0')

--- a/eval/a2ui_eval/dataset.py
+++ b/eval/a2ui_eval/dataset.py
@@ -243,6 +243,7 @@ def load_a2ui_dataset(
                         "allowed_surface_ids": (
                             item.get("allowed_surface_ids") or ["main"]
                         ),
+                        "format_name": format_name or "direct_json",
                     },
                 )
             )

--- a/eval/bin/report_evals.py
+++ b/eval/bin/report_evals.py
@@ -50,6 +50,41 @@ def extract_accuracy(log_data: dict[str, Any]) -> float:
     return float(accuracy)
 
 
+def extract_strategy(log_data: dict[str, Any]) -> tuple[str, str]:
+    """Extracts evaluation strategy name and human-readable inference format from log data.
+
+    Args:
+        log_data: Dictionary containing parsed evaluation log data.
+
+    Returns:
+        A tuple of (strategy_name, format_description).
+    """
+    eval_spec = log_data.get("eval", {}) or {}
+    task_args = eval_spec.get("task_args", {}) or {}
+    strategy = task_args.get("strategy")
+    if not strategy:
+        samples = log_data.get("samples", []) or []
+        for sample in samples:
+            meta = sample.get("metadata", {}) or {}
+            if "strategy" in meta:
+                strategy = meta["strategy"]
+                break
+            if "format_name" in meta:
+                strategy = meta["format_name"]
+                break
+
+    strategy = strategy or "direct"
+    format_map = {
+        "direct": "Direct JSON (direct_json)",
+        "subagent_tool": "Direct JSON (direct_json via tool call)",
+        "express": "Express (express)",
+        "elemental": "Elemental (elemental)",
+        "atom": "Atom (atom)",
+    }
+    format_desc = format_map.get(strategy, f"{strategy}")
+    return strategy, format_desc
+
+
 def print_results_summary(log_data: dict[str, Any]) -> None:
     """Prints a summary of the evaluation results for each sample grouped by dataset.
 
@@ -57,7 +92,9 @@ def print_results_summary(log_data: dict[str, Any]) -> None:
         log_data: Dictionary containing parsed evaluation log data.
     """
     samples = log_data.get("samples", [])
+    strategy, format_desc = extract_strategy(log_data)
     print("\n=== Evaluation Results Summary ===")
+    print(f"Strategy: {strategy} | Inference Format: {format_desc}")
 
     # Group by dataset
     datasets: dict[str, list[dict[str, Any]]] = {}
@@ -158,12 +195,14 @@ def generate_markdown_summary(
     eval_spec = log_data.get("eval", {}) or {}
     task_name = eval_spec.get("task", "Unknown Task")
     model_name = eval_spec.get("model", "Unknown Model")
+    strategy, format_desc = extract_strategy(log_data)
 
     status_str = "PASS" if accuracy_percentage >= threshold else "FAIL"
 
     lines = []
     lines.append(f"### Evaluation Summary: {task_name}")
     lines.append(f"- **Status**: {status_str}")
+    lines.append(f"- **Inference Format / Strategy**: `{strategy}` ({format_desc})")
     lines.append(f"- **Model**: `{model_name}`")
     lines.append(
         f"- **Pass Percentage**: `{accuracy_percentage:.2f}%` (Threshold:"

--- a/eval/bin/run_ci_evals.py
+++ b/eval/bin/run_ci_evals.py
@@ -79,6 +79,8 @@ def build_main_command(args: argparse.Namespace, seed: str) -> list[str]:
         cmd.extend(["--datasets", args.datasets])
     if getattr(args, "max_samples", None) and args.max_samples != 0:
         cmd.extend(["--limit", str(args.max_samples)])
+    if getattr(args, "strategies", None):
+        cmd.extend(["--strategies", args.strategies])
     return cmd
 
 
@@ -96,6 +98,12 @@ def main() -> None:
         type=str,
         default=None,
         help="Comma-separated list of datasets to evaluate",
+    )
+    parser.add_argument(
+        "--strategies",
+        type=str,
+        default=None,
+        help="Evaluation strategies to run (e.g., 'direct,subagent_tool,express')",
     )
     parser.add_argument(
         "--max-samples",

--- a/eval/main.py
+++ b/eval/main.py
@@ -129,7 +129,9 @@ def main() -> None:
 
     # Parse and validate strategies
     selected_strategies = []
-    raw_strategies = args.strategies if args.strategies else ["direct", "subagent_tool"]
+    raw_strategies = (
+        args.strategies if args.strategies else ["direct", "subagent_tool", "express"]
+    )
     for item in raw_strategies:
         for s in item.split(","):
             s_clean = s.strip()

--- a/eval/tasks.py
+++ b/eval/tasks.py
@@ -100,6 +100,9 @@ def a2ui_v0_9_1_eval(
         version=active_version,
         format_name=format_name,
     )
+    for sample in dataset_obj.samples:
+        if sample.metadata is not None:
+            sample.metadata["strategy"] = strategy
 
     return Task(
         dataset=dataset_obj,
@@ -159,6 +162,9 @@ def a2ui_v1_0_eval(
         version=active_version,
         format_name=format_name,
     )
+    for sample in dataset_obj.samples:
+        if sample.metadata is not None:
+            sample.metadata["strategy"] = strategy
 
     return Task(
         dataset=dataset_obj,

--- a/eval/tests/test_run_ci_evals.py
+++ b/eval/tests/test_run_ci_evals.py
@@ -21,7 +21,12 @@ import pytest
 # Add bin directory to path to import run_ci_evals
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../bin")))
 from run_ci_evals import check_threshold, build_main_command
-from report_evals import extract_accuracy, print_results_summary, generate_markdown_summary
+from report_evals import (
+    extract_accuracy,
+    extract_strategy,
+    print_results_summary,
+    generate_markdown_summary,
+)
 from typing import Any
 import argparse
 
@@ -101,6 +106,19 @@ def test_build_main_command_no_limit() -> None:
     assert "--limit" not in cmd
 
 
+def test_build_main_command_with_strategies() -> None:
+    args = argparse.Namespace(
+        model="google/gemini-3-flash-preview",
+        max_samples=100,
+        grading_model="google/gemini-3.5-flash",
+        strategies="direct,express",
+    )
+    seed = "20260507"
+    cmd = build_main_command(args, seed)
+    assert "--strategies" in cmd
+    assert cmd[cmd.index("--strategies") + 1] == "direct,express"
+
+
 def test_print_results_summary_valid(capsys: pytest.CaptureFixture[str]) -> None:
     log_data: dict[str, Any] = {
         "samples": [
@@ -173,9 +191,23 @@ def test_print_results_summary_fail(capsys: pytest.CaptureFixture[str]) -> None:
     assert "    Incorrect" in captured.out
 
 
+def test_extract_strategy() -> None:
+    log_data: dict[str, Any] = {
+        "eval": {"task_args": {"strategy": "express"}},
+        "samples": [],
+    }
+    strategy, desc = extract_strategy(log_data)
+    assert strategy == "express"
+    assert "Express (express)" in desc
+
+
 def test_generate_markdown_summary_valid() -> None:
     log_data: dict[str, Any] = {
-        "eval": {"task": "test_task", "model": "test_model"},
+        "eval": {
+            "task": "test_task",
+            "model": "test_model",
+            "task_args": {"strategy": "direct"},
+        },
         "samples": [{
             "id": 1,
             "metadata": {"name": "sample_1", "evaluation_duration_seconds": 5.0},
@@ -188,6 +220,7 @@ def test_generate_markdown_summary_valid() -> None:
     summary = generate_markdown_summary(log_data, 100.0, 90.0)
     assert "### Evaluation Summary: test_task" in summary
     assert "- **Status**: PASS" in summary
+    assert "- **Inference Format / Strategy**: `direct` (Direct JSON (direct_json))" in summary
     assert "- **Model**: `test_model`" in summary
     assert "- **Pass Percentage**: `100.00%` (Threshold: `90.00%`)" in summary
     assert "| sample_1 | PASS | C | 5.00s | PASS |" in summary

--- a/eval/tests/test_run_ci_evals.py
+++ b/eval/tests/test_run_ci_evals.py
@@ -220,7 +220,10 @@ def test_generate_markdown_summary_valid() -> None:
     summary = generate_markdown_summary(log_data, 100.0, 90.0)
     assert "### Evaluation Summary: test_task" in summary
     assert "- **Status**: PASS" in summary
-    assert "- **Inference Format / Strategy**: `direct` (Direct JSON (direct_json))" in summary
+    assert (
+        "- **Inference Format / Strategy**: `direct` (Direct JSON (direct_json))"
+        in summary
+    )
     assert "- **Model**: `test_model`" in summary
     assert "- **Pass Percentage**: `100.00%` (Threshold: `90.00%`)" in summary
     assert "| sample_1 | PASS | C | 5.00s | PASS |" in summary


### PR DESCRIPTION
### Summary & Rationale

Improves evaluation reporting and Direct JSON parsing robustness across the A2UI evaluation framework.

Specifically:
1. **Explicit Inference Format in Failure Issues/Reports**: Updated evaluation log reporting (`report_evals.py` & `create_issue.sh`) so that filed GitHub issues and markdown evaluation summaries (`eval_summary.md`) clearly display the exact strategy and inference format (e.g., `direct_json`, `express`, `elemental`, etc.) that failed.
2. **Autofix Un-prefixed Version Strings**: Updated `payload_fixer.py` to automatically normalize message `version` strings generated by LLMs missing the 'v' prefix (e.g., "0.9" -> "v0.9", "1.0" -> "v1.0"), resolving schema validation errors when models omit the prefix.
3. **Prompt Instruction Clarity**: Explicitly documented the required 'v' version prefix rule in `DEFAULT_WORKFLOW_RULES` in `constants.py`.
4. **Default Evaluation Strategies**: Included `express` format alongside `direct` and `subagent_tool` in default evaluation strategy runs in `main.py` and supported `--strategies` in `run_ci_evals.py`.

### Key Changes

- **Python SDK (`agent_sdks/python/a2ui_agent`)**:
  - `src/a2ui/parser/payload_fixer.py`: Added `_fix_message_versions()` to autofix missing 'v' prefixes on message version fields.
  - `src/a2ui/schema/constants.py`: Updated `DEFAULT_WORKFLOW_RULES` with explicit version prefix formatting rules.
  - `tests/parser/test_payload_fixer.py`: Added unit test `test_fix_unprefixed_version`.
- **Evaluation Framework (`eval/`)**:
  - `a2ui_eval/dataset.py` & `tasks.py`: Recorded `format_name` and `strategy` in sample metadata.
  - `bin/report_evals.py`: Added `extract_strategy()` to include `- **Inference Format / Strategy**: ...` in console outputs and `eval_summary.md`.
  - `bin/run_ci_evals.py` & `main.py`: Added `express` to default strategies and supported `--strategies` argument.
  - `tests/test_run_ci_evals.py`: Updated test suite and added `test_build_main_command_with_strategies()` and `test_extract_strategy()`.

### Verification & Testing

- Executed `a2ui_agent` unit tests: `uv run python -m pytest` in `agent_sdks/python/a2ui_agent` (748 passed).
- Executed `eval` unit tests: `uv run python -m pytest` in `eval` (23 passed).
- Verified formatting compliance via `./scripts/fix_format.sh`.