### PR TITLE
docs(lit): annotate light DOM migration as a breaking change in changelog

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.10.4
 
-- (v0_9) Migrate Basic Catalog components and surface rendering from Shadow DOM to Light DOM. [#2204](https://github.com/a2ui-project/a2ui/pull/2204)
+- **BREAKING CHANGE**: (v0_9) Migrate Basic Catalog components and surface rendering from Shadow DOM to Light DOM. Recommended migration: query component elements directly using Light DOM selectors (e.g. `element.querySelector()`) rather than `element.shadowRoot`, and ensure global stylesheets do not unintentionally conflict with component internal class names. [#2204](https://github.com/a2ui-project/a2ui/pull/2204)
 
 ## 0.10.3
 


### PR DESCRIPTION
## Summary

Addresses review feedback from @ditman on [#2204](https://github.com/a2ui-project/a2ui/pull/2204) by explicitly annotating the Light DOM migration in `@a2ui/lit` as a `**BREAKING CHANGE**` under the `## 0.10.4` release in `renderers/lit/CHANGELOG.md`.

## Changes

- Annotated `## 0.10.4` in `renderers/lit/CHANGELOG.md` with `**BREAKING CHANGE**:`.
- Provided concise migration guidance for consumers (query component elements directly using Light DOM selectors such as `element.querySelector()` instead of `element.shadowRoot`, and ensure global stylesheets do not unintentionally conflict with component internal class names).

## Pre-launch Checklist

- [x] I read the [Contributors Guide].
- [x] I updated `CHANGELOG.md` in all packages I touched.
- [x] My pull request is addressable and concise.