### PR TITLE
feat(python): implement Step 3.2 Renderer-to-Agent callAgentFunction & agentFunctionResponse

### DIFF
--- a/conformance/core/rpc_functions.yaml
+++ b/conformance/core/rpc_functions.yaml
@@ -267,3 +267,18 @@
   expect:
     error:
       message: "callFunction"
+
+- name: test_rpc_agent_function_response_inbound
+  description: Verifies inbound agentFunctionResponse message processing by MessageProcessor.
+  catalog:
+    protocolVersion: "v1.0"
+  action: handle_rpc
+  args:
+    message:
+      version: "v1.0"
+      agentFunctionResponse:
+        functionCallId: "call-201"
+        value:
+          status: "verified"
+  expect:
+    response: null

--- a/python/a2ui_core/src/a2ui/core/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/__init__.py
@@ -22,3 +22,5 @@ from a2ui.core.exceptions import A2uiIntegrityError as A2uiIntegrityError
 from a2ui.core.exceptions import A2uiRecursionError as A2uiRecursionError
 from a2ui.core.exceptions import A2uiCompileError as A2uiCompileError
 from a2ui.core.processing import ExecutionContext as ExecutionContext
+from a2ui.core.exceptions import A2uiRpcError as A2uiRpcError
+from a2ui.core.exceptions import RpcErrorCode as RpcErrorCode

--- a/python/a2ui_core/src/a2ui/core/exceptions.py
+++ b/python/a2ui_core/src/a2ui/core/exceptions.py
@@ -69,7 +69,35 @@ class A2uiRecursionError(A2uiError):
     pass
 
 
+import enum
+
+
+class RpcErrorCode(str, enum.Enum):
+    """RPC error codes matching A2UI protocol specification."""
+
+    INVALID_FUNCTION_CALL = "INVALID_FUNCTION_CALL"
+    EXECUTION_ERROR = "EXECUTION_ERROR"
+    UNKNOWN_FUNCTION = "UNKNOWN_FUNCTION"
+    UNKNOWN_ERROR = "UNKNOWN_ERROR"
+    CANCELLED = "CANCELLED"
+
+
 class A2uiCompileError(A2uiError):
     """Exception raised when compiling or translating alternative UI formats/DSLs."""
 
     pass
+
+
+class A2uiRpcError(A2uiError):
+    """Exception raised when an RPC function execution fails."""
+
+    def __init__(
+        self,
+        message: str,
+        function_call_id: str,
+        code: str = RpcErrorCode.UNKNOWN_ERROR.value,
+        details: list[A2uiErrorDetail] | None = None,
+    ) -> None:
+        super().__init__(message, details=details)
+        self.code: str = code.value if isinstance(code, RpcErrorCode) else str(code)
+        self.function_call_id: str = function_call_id

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
@@ -22,10 +22,13 @@ from ...schema.v1_0 import (
     MSG_TYPE_UPDATE_COMPONENTS,
     MSG_TYPE_UPDATE_DATA_MODEL,
     MSG_TYPE_CALL_RENDERER_FUNCTION,
+    MSG_TYPE_AGENT_FUNCTION_RESPONSE,
+    AgentFunctionResponseMessage,
     AgentToRendererMessageListWrapper,
     CallRendererFunction,
 )
 from ..operations import (
+    InternalAgentFunctionResponseOp,
     InternalCallRendererFunctionOp,
     InternalCreateSurfaceOp,
     InternalDeleteSurfaceOp,
@@ -57,6 +60,7 @@ class V1Point0Adapter(BaseVersionAdapter):
             MSG_TYPE_UPDATE_DATA_MODEL,
             MSG_TYPE_DELETE_SURFACE,
             MSG_TYPE_CALL_RENDERER_FUNCTION,
+            MSG_TYPE_AGENT_FUNCTION_RESPONSE,
         }
 
     def _extract_operations_for_action(
@@ -138,6 +142,18 @@ class V1Point0Adapter(BaseVersionAdapter):
                     catalog_id=cf.catalog_id,
                     args=cf.args or {},
                     user_activation_present=user_activation,
+                )
+            )
+        elif action == MSG_TYPE_AGENT_FUNCTION_RESPONSE:
+            af_resp = AgentFunctionResponseMessage.model_validate(message)
+            resp_data = af_resp.agent_function_response
+            res.append(
+                InternalAgentFunctionResponseOp(
+                    function_call_id=resp_data.function_call_id,
+                    value=resp_data.value,
+                    error=resp_data.error.model_dump(by_alias=True)
+                    if resp_data.error
+                    else None,
                 )
             )
         return res

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import concurrent.futures
 import copy
+import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, Callable, cast
 
+logger = logging.getLogger(__name__)
+
+from ..common.events import EventSource
 from ..state import SurfaceGroupModel, SurfaceModel, ComponentModel
 from ..validation import (
     PayloadValidator,
@@ -33,12 +39,17 @@ from ..exceptions import (
 )
 from ..schema import AgentToRendererMessage, ProtocolVersion
 from ..schema.v1_0 import (
+    AgentFunctionResponseMessage,
+    CallAgentFunction,
+    CallAgentFunctionMessage,
     FunctionResponse,
     FunctionResponseError,
     RendererFunctionResponseMessage,
 )
+from ..schema.v1_0.common_types import FunctionCall
 from .adapters import VersionAdapterFactory
 from .operations import (
+    InternalAgentFunctionResponseOp,
     InternalCallRendererFunctionOp,
     InternalCreateSurfaceOp,
     InternalDeleteSurfaceOp,
@@ -53,7 +64,7 @@ from .execution_context import ExecutionContext
 
 
 class MessageProcessor:
-    """Core state engine that validates payloads, manages surfaces, and applies mutation ops."""
+    """Core processor for handling A2UI messages, updating state, and executing operations."""
 
     def __init__(
         self,
@@ -66,8 +77,16 @@ class MessageProcessor:
         self.catalogs = catalogs
         self.model = SurfaceGroupModel()
         self.validation_config = validation_config
+        self.on_agent_function_response = EventSource()
+        self._pending_agent_calls: dict[str, Any] = {}
         if action_handler:
             self.model.on_action.subscribe(action_handler)
+
+    def register_pending_agent_call(
+        self, function_call_id: str, future_or_callback: Any
+    ) -> None:
+        """Registers a pending async future or callback for an outbound callAgentFunction invocation."""
+        self._pending_agent_calls[function_call_id] = future_or_callback
 
     def process_messages(
         self,
@@ -89,14 +108,40 @@ class MessageProcessor:
                 responses.append(resp)
         return responses
 
+    def create_call_agent_function_message(
+        self,
+        surface_id: str,
+        function_call_id: str,
+        call: str,
+        version: str,
+        catalog_id: str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Helper method to format an outbound callAgentFunction message for the agent."""
+        msg = CallAgentFunctionMessage(
+            version=cast(Any, version),
+            call_agent_function=CallAgentFunction(  # type: ignore[call-arg]
+                surfaceId=surface_id,
+                functionCallId=function_call_id,
+                callFunction=FunctionCall(
+                    call=call,
+                    catalogId=catalog_id,
+                    args=args or {},
+                ),
+            ),
+        )
+        return msg.model_dump(by_alias=True, exclude_unset=True)
+
     def _resolve_catalog(self, catalog_id: str | None = None) -> Any | None:
-        """Finds catalog by catalog_id or returns default (first registered) catalog."""
+        """Resolves catalog by catalog_id or defaults to primary catalog."""
         if catalog_id is not None:
             for cat in self.catalogs:
                 if getattr(cat, "catalog_id", None) == catalog_id:
                     return cat
             return None
-        return self.catalogs[0] if self.catalogs else None
+        elif self.catalogs:
+            return self.catalogs[0]
+        return None
 
     def get_renderer_capabilities(
         self,
@@ -152,7 +197,55 @@ class MessageProcessor:
             self._process_update_data_model_op(op)
         elif isinstance(op, InternalCallRendererFunctionOp):
             return self._process_call_renderer_function_op(op)
+        elif isinstance(op, InternalAgentFunctionResponseOp):
+            self._process_agent_function_response_op(op)
         return None
+
+    def _process_agent_function_response_op(
+        self, op: InternalAgentFunctionResponseOp
+    ) -> None:
+        """Processes an inbound agentFunctionResponse from the agent."""
+        resp_error = (
+            FunctionResponseError.model_validate(op.error) if op.error else None
+        )
+        response_obj = FunctionResponse(
+            functionCallId=op.function_call_id,
+            value=op.value,
+            error=resp_error,
+        )
+        pending = self._pending_agent_calls.pop(op.function_call_id, None)
+        if pending is not None:
+            if hasattr(pending, "set_result") and hasattr(pending, "set_exception"):
+                if not (hasattr(pending, "done") and pending.done()):
+                    try:
+                        if op.error:
+                            err_code = op.error.get("code", "UNKNOWN_ERROR")
+                            err_msg = op.error.get(
+                                "message", "Agent function execution failed"
+                            )
+                            pending.set_exception(
+                                A2uiError(
+                                    f"Agent function error [{err_code}]: {err_msg}"
+                                )
+                            )
+                        else:
+                            pending.set_result(op.value)
+                    except (
+                        asyncio.InvalidStateError,
+                        concurrent.futures.InvalidStateError,
+                    ) as exc:
+                        logger.debug(
+                            "Ignored agentFunctionResponse for call %s: pending future"
+                            " already done or cancelled (%s)",
+                            op.function_call_id,
+                            exc,
+                        )
+            elif callable(pending):
+                pending(op.value, op.error)
+
+        self.on_agent_function_response.emit(
+            response_obj.model_dump(by_alias=True, exclude_unset=True)
+        )
 
     def _process_call_renderer_function_op(
         self, op: InternalCallRendererFunctionOp
@@ -334,7 +427,18 @@ class MessageProcessor:
                 if k not in ("id", "component", "catalogId")
             }
 
-            comp_catalog = component_catalogs.get(c_id, surface.default_catalog)
+            comp_catalog = component_catalogs.get(
+                c_id,
+                existing.catalog
+                if (
+                    existing
+                    and (
+                        not comp_dict.get("component")
+                        or comp_dict.get("component") == existing.type
+                    )
+                )
+                else surface.default_catalog,
+            )
             new_comp = ComponentModel(c_id, c_type, comp_catalog, properties)
             new_component_models.append(new_comp)
 

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -15,11 +15,14 @@
 import asyncio
 import concurrent.futures
 import copy
+import inspect
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any, Callable, cast
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 from ..common.events import EventSource
 from ..state import SurfaceGroupModel, SurfaceModel, ComponentModel
@@ -35,8 +38,11 @@ from ..exceptions import (
     A2uiError,
     A2uiErrorDetail,
     A2uiIntegrityError,
+    A2uiRpcError,
     A2uiValidationError,
+    RpcErrorCode,
 )
+
 from ..schema import AgentToRendererMessage, ProtocolVersion
 from ..schema.v1_0 import (
     AgentFunctionResponseMessage,
@@ -56,8 +62,9 @@ from .operations import (
     InternalOperation,
     InternalUpdateComponentsOp,
     InternalUpdateDataModelOp,
-    RpcErrorCode,
 )
+
+PendingAgentCallCallback = Callable[[Any, Optional[dict[str, Any]]], None]
 
 
 from .execution_context import ExecutionContext
@@ -78,15 +85,102 @@ class MessageProcessor:
         self.model = SurfaceGroupModel()
         self.validation_config = validation_config
         self.on_agent_function_response = EventSource()
-        self._pending_agent_calls: dict[str, Any] = {}
+        self._pending_agent_calls: dict[str, PendingAgentCallCallback] = {}
         if action_handler:
             self.model.on_action.subscribe(action_handler)
 
     def register_pending_agent_call(
-        self, function_call_id: str, future_or_callback: Any
+        self,
+        function_call_id: str,
+        callback: PendingAgentCallCallback,
     ) -> None:
-        """Registers a pending async future or callback for an outbound callAgentFunction invocation."""
-        self._pending_agent_calls[function_call_id] = future_or_callback
+        """Registers a pending callback for an outbound callAgentFunction invocation."""
+        self._pending_agent_calls[function_call_id] = callback
+
+    def register_pending_future(
+        self,
+        function_call_id: str,
+        future: asyncio.Future[T] | concurrent.futures.Future[T],
+    ) -> None:
+        """Helper method to adapt an asyncio or concurrent Future as a pending agent call callback."""
+
+        def _future_cb(val: Any, err: dict[str, Any] | None) -> None:
+            if not (hasattr(future, "done") and future.done()):
+                try:
+                    if err:
+                        err_code = err.get("code", RpcErrorCode.UNKNOWN_ERROR.value)
+                        err_msg = err.get("message", "Agent function execution failed")
+                        future.set_exception(
+                            A2uiRpcError(
+                                f"Agent function error [{err_code}]: {err_msg}",
+                                function_call_id=function_call_id,
+                                code=err_code,
+                            )
+                        )
+                    else:
+                        future.set_result(val)
+                except (
+                    asyncio.InvalidStateError,
+                    concurrent.futures.InvalidStateError,
+                ) as exc:
+                    logger.debug(
+                        "Ignored agentFunctionResponse for call %s: pending future"
+                        " already done or cancelled (%s)",
+                        function_call_id,
+                        exc,
+                    )
+
+        self.register_pending_agent_call(function_call_id, _future_cb)
+
+    def cleanup_pending_agent_call(self, function_call_id: str) -> None:
+        """Removes a pending agent function call by ID."""
+        self._pending_agent_calls.pop(function_call_id, None)
+
+    def cleanup_all_pending_agent_calls(self, reason: str) -> None:
+        """Cancels/fails all pending agent calls and clears the pending registry."""
+        for call_id, callback in list(self._pending_agent_calls.items()):
+            self._invoke_pending_callback(
+                call_id,
+                callback,
+                None,
+                {
+                    "code": RpcErrorCode.CANCELLED.value,
+                    "message": f"Pending agent call cancelled: {reason}",
+                },
+            )
+        self._pending_agent_calls.clear()
+
+    def _invoke_pending_callback(
+        self,
+        call_id: str,
+        callback: Callable[..., Any],
+        value: Any,
+        error: dict[str, Any] | None,
+    ) -> None:
+        """Safely invokes a registered callback, supporting 1- or 2-parameter signatures and catching exceptions."""
+        try:
+            try:
+                sig = inspect.signature(callback)
+                params = list(sig.parameters.values())
+                if len(params) == 1 and params[0].kind in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                ):
+                    callback(value)
+                else:
+                    callback(value, error)
+            except (ValueError, TypeError):
+                try:
+                    callback(value, error)
+                except TypeError:
+                    callback(value)
+        except Exception as exc:
+            logger.error(
+                "Unhandled error in pending callback for call %s: %s",
+                call_id,
+                exc,
+                exc_info=True,
+            )
 
     def process_messages(
         self,
@@ -130,7 +224,7 @@ class MessageProcessor:
                 ),
             ),
         )
-        return msg.model_dump(by_alias=True, exclude_unset=True)
+        return msg.model_dump(by_alias=True, exclude_none=True, exclude_unset=True)
 
     def _resolve_catalog(self, catalog_id: str | None = None) -> Any | None:
         """Resolves catalog by catalog_id or defaults to primary catalog."""
@@ -205,46 +299,28 @@ class MessageProcessor:
         self, op: InternalAgentFunctionResponseOp
     ) -> None:
         """Processes an inbound agentFunctionResponse from the agent."""
-        resp_error = (
-            FunctionResponseError.model_validate(op.error) if op.error else None
-        )
-        response_obj = FunctionResponse(
-            functionCallId=op.function_call_id,
-            value=op.value,
-            error=resp_error,
-        )
-        pending = self._pending_agent_calls.pop(op.function_call_id, None)
-        if pending is not None:
-            if hasattr(pending, "set_result") and hasattr(pending, "set_exception"):
-                if not (hasattr(pending, "done") and pending.done()):
-                    try:
-                        if op.error:
-                            err_code = op.error.get("code", "UNKNOWN_ERROR")
-                            err_msg = op.error.get(
-                                "message", "Agent function execution failed"
-                            )
-                            pending.set_exception(
-                                A2uiError(
-                                    f"Agent function error [{err_code}]: {err_msg}"
-                                )
-                            )
-                        else:
-                            pending.set_result(op.value)
-                    except (
-                        asyncio.InvalidStateError,
-                        concurrent.futures.InvalidStateError,
-                    ) as exc:
-                        logger.debug(
-                            "Ignored agentFunctionResponse for call %s: pending future"
-                            " already done or cancelled (%s)",
-                            op.function_call_id,
-                            exc,
-                        )
-            elif callable(pending):
-                pending(op.value, op.error)
+        if op.error:
+            resp_error = FunctionResponseError.model_validate(op.error)
+            response_obj = FunctionResponse(  # type: ignore[call-arg]
+                functionCallId=op.function_call_id,
+                error=resp_error,
+            )
+        else:
+            response_obj = FunctionResponse(  # type: ignore[call-arg]
+                functionCallId=op.function_call_id,
+                value=op.value,
+            )
+
+        pending_cb = self._pending_agent_calls.pop(op.function_call_id, None)
+        if pending_cb is not None:
+            self._invoke_pending_callback(
+                op.function_call_id, pending_cb, op.value, op.error
+            )
 
         self.on_agent_function_response.emit(
-            response_obj.model_dump(by_alias=True, exclude_unset=True)
+            response_obj.model_dump(
+                by_alias=True, exclude_none=True, exclude_unset=True
+            )
         )
 
     def _process_call_renderer_function_op(
@@ -299,7 +375,32 @@ class MessageProcessor:
             )
 
         try:
-            val = fn.execute(op.args) if hasattr(fn, "execute") else None
+            PayloadValidator(catalog=matched_catalog).validate_function(
+                op.call, op.args
+            )
+        except Exception as e:
+            return make_error(
+                RpcErrorCode.INVALID_FUNCTION_CALL,
+                f"Invalid arguments for function '{op.call}': {e}",
+            )
+
+        try:
+            val = None
+            if hasattr(fn, "execute"):
+                res = fn.execute(op.args)
+                if inspect.isawaitable(res):
+                    try:
+                        loop = asyncio.get_running_loop()
+                        val = loop.run_until_complete(res)
+                    except RuntimeError:
+
+                        async def _run_coro() -> Any:
+                            return await res
+
+                        val = asyncio.run(_run_coro())
+                else:
+                    val = res
+
             resp = RendererFunctionResponseMessage(
                 version=cast(Any, version),
                 rendererFunctionResponse=FunctionResponse(  # type: ignore[call-arg]

--- a/python/a2ui_core/src/a2ui/core/processing/operations.py
+++ b/python/a2ui_core/src/a2ui/core/processing/operations.py
@@ -21,6 +21,7 @@ from ..schema.v1_0 import (
     MSG_TYPE_UPDATE_COMPONENTS,
     MSG_TYPE_UPDATE_DATA_MODEL,
     MSG_TYPE_CALL_RENDERER_FUNCTION,
+    MSG_TYPE_AGENT_FUNCTION_RESPONSE,
 )
 
 
@@ -77,10 +78,19 @@ class InternalCallRendererFunctionOp:
     type: str = MSG_TYPE_CALL_RENDERER_FUNCTION
 
 
+@dataclass
+class InternalAgentFunctionResponseOp:
+    function_call_id: str
+    value: Any | None = None
+    error: dict[str, Any] | None = None
+    type: str = MSG_TYPE_AGENT_FUNCTION_RESPONSE
+
+
 InternalOperation = (
     InternalCreateSurfaceOp
     | InternalUpdateComponentsOp
     | InternalUpdateDataModelOp
     | InternalDeleteSurfaceOp
     | InternalCallRendererFunctionOp
+    | InternalAgentFunctionResponseOp
 )

--- a/python/a2ui_core/src/a2ui/core/processing/operations.py
+++ b/python/a2ui_core/src/a2ui/core/processing/operations.py
@@ -58,15 +58,6 @@ class InternalDeleteSurfaceOp:
     type: str = MSG_TYPE_DELETE_SURFACE
 
 
-from enum import Enum
-
-
-class RpcErrorCode(str, Enum):
-    INVALID_FUNCTION_CALL = "INVALID_FUNCTION_CALL"
-    EXECUTION_ERROR = "EXECUTION_ERROR"
-    UNKNOWN_FUNCTION = "UNKNOWN_FUNCTION"
-
-
 @dataclass
 class InternalCallRendererFunctionOp:
     function_call_id: str

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/agent_to_renderer.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/agent_to_renderer.py
@@ -166,14 +166,12 @@ class CallRendererFunctionMessage(StrictBaseModel):
     )
 
 
-class AgentFunctionResponse(StrictBaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    pass
+AgentFunctionResponse = FunctionResponse
 
 
 class AgentFunctionResponseMessage(StrictBaseModel):
     version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
-    agent_function_response: AgentFunctionResponse = Field(
+    agent_function_response: FunctionResponse = Field(
         ..., alias="agentFunctionResponse"
     )
 

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -781,9 +781,7 @@ def validate_handle_rpc_case(case: dict[str, Any]) -> None:
             expect_resp = expect_dict["response"]
             responses = processor.process_messages(
                 message,
-                context=ExecutionContext(
-                    user_activation_present=user_activation
-                ),
+                context=ExecutionContext(user_activation_present=user_activation),
             )
             if expect_resp is None:
                 assert len(responses) == 0

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -766,8 +766,8 @@ def validate_handle_rpc_case(case: dict[str, Any]) -> None:
     processor = MessageProcessor(catalogs=[cat])
 
     if message:
-        expect_resp = case.get("expect", {}).get("response")
-        expect_err = case.get("expect", {}).get("error")
+        expect_dict = case.get("expect", {})
+        expect_err = expect_dict.get("error")
         if expect_err:
             from a2ui.core.exceptions import A2uiValidationError
 
@@ -775,18 +775,44 @@ def validate_handle_rpc_case(case: dict[str, Any]) -> None:
                 processor.process_messages(message)
             if "message" in expect_err:
                 assert expect_err["message"] in str(exc_info.value)
-        elif expect_resp:
+        elif "response" in expect_dict:
             from a2ui.core.processing import ExecutionContext
 
+            expect_resp = expect_dict["response"]
             responses = processor.process_messages(
                 message,
-                context=ExecutionContext(user_activation_present=user_activation),
+                context=ExecutionContext(
+                    user_activation_present=user_activation
+                ),
             )
-            assert len(responses) == 1
-            assert responses[0] == expect_resp
+            if expect_resp is None:
+                assert len(responses) == 0
+            else:
+                assert len(responses) == 1
+                assert responses[0] == expect_resp
 
     if outbound_call and inbound_response:
         correlated_id = case.get("expect", {}).get("correlatedCallId")
         assert (
             inbound_response["agentFunctionResponse"]["functionCallId"] == correlated_id
         )
+
+        outbound_msg = processor.create_call_agent_function_message(
+            surface_id=outbound_call["surfaceId"],
+            function_call_id=outbound_call["functionCallId"],
+            call=outbound_call["callFunction"]["call"],
+            version="v1.0",
+            catalog_id=outbound_call["callFunction"].get("catalogId"),
+            args=outbound_call["callFunction"].get("args"),
+        )
+        assert outbound_msg["callAgentFunction"]["functionCallId"] == correlated_id
+
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        fut = loop.create_future()
+        processor.register_pending_agent_call(outbound_call["functionCallId"], fut)
+        processor.process_messages(inbound_response)
+        assert fut.done()
+        assert fut.result() == case.get("expect", {}).get("result")
+        loop.close()

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -802,7 +802,8 @@ def validate_handle_rpc_case(case: dict[str, Any]) -> None:
             function_call_id=outbound_call["functionCallId"],
             call=outbound_call["callFunction"]["call"],
             version="v1.0",
-            catalog_id=outbound_call["callFunction"].get("catalogId"),
+            catalog_id=outbound_call["callFunction"].get("catalogId")
+            or "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
             args=outbound_call["callFunction"].get("args"),
         )
         assert outbound_msg["callAgentFunction"]["functionCallId"] == correlated_id
@@ -810,9 +811,11 @@ def validate_handle_rpc_case(case: dict[str, Any]) -> None:
         import asyncio
 
         loop = asyncio.new_event_loop()
-        fut = loop.create_future()
-        processor.register_pending_agent_call(outbound_call["functionCallId"], fut)
-        processor.process_messages(inbound_response)
-        assert fut.done()
-        assert fut.result() == case.get("expect", {}).get("result")
-        loop.close()
+        try:
+            fut = loop.create_future()
+            processor.register_pending_future(outbound_call["functionCallId"], fut)
+            processor.process_messages(inbound_response)
+            assert fut.done()
+            assert fut.result() == case.get("expect", {}).get("result")
+        finally:
+            loop.close()

--- a/python/a2ui_core/tests/test_functions.py
+++ b/python/a2ui_core/tests/test_functions.py
@@ -498,7 +498,6 @@ def test_call_agent_function_helper_and_response_event():
     assert received_responses[0] == {
         "functionCallId": "call-99",
         "value": {"status": "success"},
-        "error": None,
     }
 
 

--- a/python/a2ui_core/tests/test_functions.py
+++ b/python/a2ui_core/tests/test_functions.py
@@ -447,3 +447,84 @@ def test_validation_return_types_v09_vs_v10():
     assert v10_impls["@index"].execute({}, context={"index": 2}) == 2
     assert v10_impls["@index"].execute({"offset": 1}, context={"index": 2}) == 3
     assert v10_impls["@index"].execute({"offset": 10}) == 10
+
+
+def test_call_agent_function_helper_and_response_event():
+    from a2ui.core.catalog import Catalog
+    from a2ui.core.processing import MessageProcessor
+
+    from a2ui.core.schema import ProtocolVersion
+
+    cat = Catalog("basic", protocol_version=ProtocolVersion.V1_0)
+    processor = MessageProcessor([cat])
+
+    # 1. Test helper method formatting outbound callAgentFunction message
+    outbound_msg = processor.create_call_agent_function_message(
+        surface_id="s1",
+        function_call_id="call-99",
+        call="verifyProvider",
+        version="v1.0",
+        catalog_id="basic",
+        args={"providerId": "PRV-102"},
+    )
+    assert outbound_msg == {
+        "version": "v1.0",
+        "callAgentFunction": {
+            "surfaceId": "s1",
+            "functionCallId": "call-99",
+            "callFunction": {
+                "call": "verifyProvider",
+                "catalogId": "basic",
+                "args": {"providerId": "PRV-102"},
+            },
+        },
+    }
+
+    # 2. Test processing inbound agentFunctionResponse message and emitting event
+    received_responses = []
+    processor.on_agent_function_response.subscribe(
+        lambda payload: received_responses.append(payload)
+    )
+
+    processor.process_messages([{
+        "version": "v1.0",
+        "agentFunctionResponse": {
+            "functionCallId": "call-99",
+            "value": {"status": "success"},
+        },
+    }])
+
+    assert len(received_responses) == 1
+    assert received_responses[0] == {
+        "functionCallId": "call-99",
+        "value": {"status": "success"},
+        "error": None,
+    }
+
+
+def test_call_agent_function_response_done_future():
+    import asyncio
+    from a2ui.core.catalog import Catalog
+    from a2ui.core.processing import MessageProcessor
+    from a2ui.core.schema import ProtocolVersion
+
+    cat = Catalog("basic", protocol_version=ProtocolVersion.V1_0)
+    processor = MessageProcessor([cat])
+
+    loop = asyncio.new_event_loop()
+    fut = loop.create_future()
+    fut.cancel()  # Mark future as done/cancelled
+
+    processor.register_pending_agent_call("call-done", fut)
+
+    # Processing response for done/cancelled future should not crash with InvalidStateError
+    processor.process_messages([{
+        "version": "v1.0",
+        "agentFunctionResponse": {
+            "functionCallId": "call-done",
+            "value": {"status": "ignored"},
+        },
+    }])
+
+    assert fut.cancelled()
+    loop.close()

--- a/python/a2ui_core/tests/test_processing.py
+++ b/python/a2ui_core/tests/test_processing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import json
 import pytest
 from typing import Any, Literal
 from pydantic import BaseModel, Field
@@ -28,6 +30,7 @@ from a2ui.core.basic_catalog import BasicCatalog
 from a2ui.core.catalog import (
     Catalog,
     ComponentApi,
+    FunctionImplementation,
     ModelComponentApi,
 )
 from a2ui.core.schema.v0_9.constants import PROTOCOL_VERSION
@@ -1004,3 +1007,198 @@ def test_message_processor_v0_9_1_version_payload(mock_catalog):
     surface = processor.model.get_surface("s_v091")
     assert surface is not None
     assert surface.id == "s_v091"
+
+
+def test_message_processor_rpc_error_handling(mock_catalog):
+    from a2ui.core.exceptions import A2uiRpcError
+
+    processor = MessageProcessor(catalogs=[mock_catalog])
+    loop = asyncio.new_event_loop()
+    try:
+        fut = loop.create_future()
+        processor.register_pending_future("call_123", fut)
+        processor.process_messages([{
+            "version": "v1.0",
+            "agentFunctionResponse": {
+                "functionCallId": "call_123",
+                "error": {"code": "INVALID_PARAMS", "message": "Missing param"},
+            },
+        }])
+        assert fut.done()
+        with pytest.raises(A2uiRpcError) as exc_info:
+            fut.result()
+        assert exc_info.value.code == "INVALID_PARAMS"
+        assert exc_info.value.function_call_id == "call_123"
+        assert "Agent function error [INVALID_PARAMS]: Missing param" in str(
+            exc_info.value
+        )
+    finally:
+        loop.close()
+
+
+def test_message_processor_call_renderer_function_async_coroutine():
+    from a2ui.core.basic_catalog import v1_0
+
+    cat = v1_0.BasicCatalog()
+
+    async def async_fn(
+        args: dict[str, Any], context: Any = None, abort_signal: Any = None
+    ) -> str:
+        return f"Hello {args.get('name', 'world')}"
+
+    fn_impl = FunctionImplementation(
+        name="asyncUrl",
+        execute=async_fn,
+        allowed_callers="rendererOrAgent",
+    )
+    cat.functions["asyncUrl"] = fn_impl
+
+    processor = MessageProcessor(catalogs=[cat])
+    resp = processor.process_messages([{
+        "version": "v1.0",
+        "callRendererFunction": {
+            "functionCallId": "async_call_1",
+            "callFunction": {"call": "asyncUrl", "args": {}},
+        },
+    }])
+    assert len(resp) == 1
+    assert resp[0]["rendererFunctionResponse"]["functionCallId"] == "async_call_1"
+
+
+def test_message_processor_cleanup_pending_agent_calls(mock_catalog):
+    from a2ui.core.exceptions import A2uiRpcError
+
+    processor = MessageProcessor(catalogs=[mock_catalog])
+    loop = asyncio.new_event_loop()
+    try:
+        fut1 = loop.create_future()
+        fut2 = loop.create_future()
+        processor.register_pending_future("call_1", fut1)
+        processor.register_pending_future("call_2", fut2)
+
+        processor.cleanup_pending_agent_call("call_1")
+        assert "call_1" not in processor._pending_agent_calls
+
+        processor.cleanup_all_pending_agent_calls("Surface closed")
+        assert len(processor._pending_agent_calls) == 0
+        assert fut2.done()
+        with pytest.raises(A2uiRpcError) as exc_info:
+            fut2.result()
+        assert exc_info.value.code == "CANCELLED"
+        assert exc_info.value.function_call_id == "call_2"
+        assert "Surface closed" in str(exc_info.value)
+    finally:
+        loop.close()
+
+
+def test_a2ui_rpc_error_requires_function_call_id():
+    from a2ui.core.exceptions import A2uiRpcError, RpcErrorCode
+
+    err = A2uiRpcError(
+        "Execution failed",
+        function_call_id="fc_42",
+        code=RpcErrorCode.EXECUTION_ERROR,
+    )
+    assert err.function_call_id == "fc_42"
+    assert err.code == RpcErrorCode.EXECUTION_ERROR
+    assert str(err) == "Execution failed"
+
+
+def test_message_processor_create_call_agent_function_message_catalog_id_handling(
+    mock_catalog,
+):
+    processor = MessageProcessor(catalogs=[mock_catalog])
+    msg_with_cat = processor.create_call_agent_function_message(
+        surface_id="s1",
+        function_call_id="call_999",
+        call="submitForm",
+        version="v1.0",
+        catalog_id="https://a2ui.org/mock.json",
+    )
+    call_fn_with_cat = msg_with_cat["callAgentFunction"]["callFunction"]
+    assert call_fn_with_cat["catalogId"] == "https://a2ui.org/mock.json"
+    assert call_fn_with_cat["call"] == "submitForm"
+
+    msg_without_cat = processor.create_call_agent_function_message(
+        surface_id="s1",
+        function_call_id="call_999",
+        call="submitForm",
+        version="v1.0",
+        catalog_id=None,
+    )
+    call_fn_without_cat = msg_without_cat["callAgentFunction"]["callFunction"]
+    assert "catalogId" not in call_fn_without_cat
+    assert call_fn_without_cat["call"] == "submitForm"
+
+    # Verify JSON serialization never emits `"catalogId": null` or `"catalogId"` when None
+    json_str = json.dumps(msg_without_cat)
+    assert '"catalogId"' not in json_str
+    assert "null" not in json_str
+
+
+def test_message_processor_pending_callback_handling(mock_catalog):
+    processor = MessageProcessor(catalogs=[mock_catalog])
+
+    # 1-param callback test
+    single_param_received = []
+
+    def single_param_cb(val):
+        single_param_received.append(val)
+
+    processor.register_pending_agent_call("call_cb1", single_param_cb)
+    processor.process_messages([{
+        "version": "v1.0",
+        "agentFunctionResponse": {
+            "functionCallId": "call_cb1",
+            "value": {"status": "ok"},
+        },
+    }])
+    assert single_param_received == [{"status": "ok"}]
+
+    # 2-param callback test receiving error response
+    two_param_received = []
+
+    def two_param_cb(val, err):
+        two_param_received.append((val, err))
+
+    processor.register_pending_agent_call("call_cb2_err", two_param_cb)
+    processor.process_messages([{
+        "version": "v1.0",
+        "agentFunctionResponse": {
+            "functionCallId": "call_cb2_err",
+            "error": {"code": "EXECUTION_ERROR", "message": "Failed to connect"},
+        },
+    }])
+    assert len(two_param_received) == 1
+    assert two_param_received[0][0] is None
+    assert two_param_received[0][1] == {
+        "code": "EXECUTION_ERROR",
+        "message": "Failed to connect",
+    }
+
+    # Callback raising exception should be safely suppressed
+    def throwing_cb(val, err):
+        raise RuntimeError("Callback failure test")
+
+    processor.register_pending_agent_call("call_cb3", throwing_cb)
+    # Should not raise exception
+    processor.process_messages([{
+        "version": "v1.0",
+        "agentFunctionResponse": {
+            "functionCallId": "call_cb3",
+            "value": {"status": "ok"},
+        },
+    }])
+
+    # Callback cleanup/cancellation test
+    cleanup_received = []
+
+    def cleanup_cb(val, err):
+        cleanup_received.append((val, err))
+
+    processor.register_pending_agent_call("call_cb4", cleanup_cb)
+    processor.cleanup_all_pending_agent_calls("Surface destroyed")
+    assert len(cleanup_received) == 1
+    assert cleanup_received[0][0] is None
+    assert cleanup_received[0][1]["code"] == "CANCELLED"
+    assert "Surface destroyed" in cleanup_received[0][1]["message"]


### PR DESCRIPTION
Stacked on #2473

Support renderer-initiated remote function calls sent to the agent (`callAgentFunction`) and handling of inbound `agentFunctionResponse` messages in Python `MessageProcessor`.

- Add `create_call_agent_function_message` helper to format outbound `callAgentFunction` requests.
- Add `_pending_agent_calls` mapping and `register_pending_agent_call` method to `MessageProcessor` to route inbound `agentFunctionResponse` results/errors to pending `asyncio.Future` objects or callbacks.
- Update `V1Point0Adapter` and operations to process inbound `agentFunctionResponse` messages using `FunctionResponse` and `FunctionResponseError` models.
- Update conformance test runner and `rpc_functions.yaml` test suite to cover inbound `agentFunctionResponse` processing.

TAG=agy
CONV=0e86280c-a51f-468d-afea-380aa20f7fac