### PR TITLE
refactor(web_core, lit): address review feedback from PR #2190

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Replace wildcard re-exports in `@a2ui/lit/v0_9` with explicit named exports.
 - (v0_9) Move universal basic catalog component implementations (`A2uiText`, `A2uiButton`, `A2uiCard`, etc.) to `@a2ui/web_core/v0_9/basic_catalog` and re-export them from `@a2ui/lit/v0_9` and `@a2ui/lit/v0_9/catalogs/basic` for backwards compatibility. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - **BREAKING CHANGE**: (v0_9) Align Basic Catalog component DOM structures, behaviors, and styling contracts with the Angular reference implementation: [#2205](https://github.com/a2ui-project/a2ui/pull/2205)
   - `DateTimeInput`: Migrate from a single dynamic HTML5 input (`datetime-local`) to dual side-by-side date and time inputs (`.a2ui-date-time-inputs`), support overridable `--a2ui-datetimeinput-width`, and ensure time-only mode preserves time-only strings without invalid date concatenation.

--- a/renderers/lit/README.md
+++ b/renderers/lit/README.md
@@ -168,7 +168,7 @@ You can find the full specification of the basic catalog in the [GitHub reposito
 - **Content**: `Text`, `Image`, `Icon`, `Video`
 - **Input**: `Button`, `TextField`, `CheckBox`, `ChoicePicker`, `Slider`, `DateTimeInput`
 
-You can find the source code for these components in the [GitHub repository](../web_core/src/v0_9/basic_catalog/components).
+The standard basic catalog components are implemented as framework-agnostic universal Custom Elements in `@a2ui/web_core` ([source code on GitHub](https://github.com/a2ui-project/a2ui/tree/main/renderers/web_core/src/v0_9/basic_catalog/components)) and re-exported from `@a2ui/lit/v0_9` for backwards compatibility.
 
 ## Migration from v0.8
 

--- a/renderers/lit/src/v0_9/context/markdown.ts
+++ b/renderers/lit/src/v0_9/context/markdown.ts
@@ -15,11 +15,7 @@
  */
 
 import {createContext} from '@lit/context';
-
-export type MarkdownRenderer = (
-  text: string,
-  options?: {tagClassMap?: Record<string, string[]>},
-) => Promise<string> | string;
+import type {MarkdownRenderer} from '@a2ui/web_core/v0_9';
 
 /**
  * The markdown renderer context.

--- a/renderers/lit/src/v0_9/index.ts
+++ b/renderers/lit/src/v0_9/index.ts
@@ -18,6 +18,5 @@ export type {LitComponentApi} from './types.js';
 export {A2uiSurface} from './surface/a2ui-surface.js';
 export {A2uiLitElement} from './a2ui-lit-element.js';
 export {A2uiController} from './a2ui-controller.js';
-export {BasicCatalogA2uiLitElement} from './catalogs/basic/index.js';
 export {Context} from './context/context.js';
-export * from './catalogs/basic/index.js';
+export {basicCatalog, BasicCatalogA2uiLitElement} from './catalogs/basic/index.js';

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - (v0_9) Add unit test coverage for all basic catalog Web Component implementations. [#2357](https://github.com/a2ui-project/a2ui/pull/2357)
+- (v0_9) Replace `A2uiLitElement.controller` property with a read-only getter to disallow external reassignment, simplify style root target resolution, and replace basic catalog barrel wildcard exports with explicit exports.
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) The child-reference marker on `ComponentIdSchema` and `ChildListSchema` now lives in the schema's metadata, so `.describe()` and other schema-rebuilding methods no longer drop it. Hand-authored `REF:` descriptions are still recognized ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).

--- a/renderers/web_core/src/v0_9/basic_catalog/basic-catalog-a2ui-lit-element.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/basic-catalog-a2ui-lit-element.test.ts
@@ -34,7 +34,6 @@ describe('BasicCatalogA2uiLitElement', () => {
     setupTestDom();
 
     const {BasicCatalogA2uiLitElement} = await import('./basic-catalog-a2ui-lit-element.js');
-    const {A2uiController} = await import('../catalog/a2ui-controller.js');
     const {css, html} = await import('lit');
 
     const TestComponentSchema = z.object({
@@ -58,9 +57,7 @@ describe('BasicCatalogA2uiLitElement', () => {
         }
       `;
 
-      protected createController() {
-        return new A2uiController(this, TestComponentApi);
-      }
+      protected override readonly api = TestComponentApi;
 
       override render() {
         return html`<div class="inner">${this.controller?.props?.text ?? ''}</div>`;

--- a/renderers/web_core/src/v0_9/basic_catalog/index.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/index.ts
@@ -41,7 +41,7 @@ export * from './components/ChoicePicker.js';
 export * from './components/Tabs.js';
 export * from './components/Modal.js';
 
-export * from './catalog.js';
+export {basicCatalog} from './catalog.js';
 export {Context} from './context/context.js';
 export type {
   MarkdownRenderer,

--- a/renderers/web_core/src/v0_9/catalog/a2ui-lit-element.ts
+++ b/renderers/web_core/src/v0_9/catalog/a2ui-lit-element.ts
@@ -56,16 +56,21 @@ export abstract class A2uiLitElement<Api extends ComponentApi = ComponentApi> ex
    */
   protected readonly api?: Api;
 
+  private _controller?: A2uiController<Api>;
+
   /**
    * The reactive controller instance managing property bindings and state subscriptions.
    */
-  public controller!: A2uiController<Api>;
+  public get controller(): A2uiController<Api> {
+    return this._controller!;
+  }
 
   /**
-   * Adopts and scopes component CSS rules into the containing document or shadow root.
+   * Adopts and scopes component CSS rules into the containing document or host shadow root.
    *
-   * When rendering in Light DOM, this method dynamically scopes `:host` selectors to the
-   * element's custom tag name and prefixes descendant rules to prevent stylesheet leakage.
+   * In Light DOM (the default for A2uiLitElement), the element has no shadow root of its own,
+   * so this method locates the nearest enclosing Document or ShadowRoot and adopts the
+   * stylesheet once per root, scoping `:host` and descendant selectors to the element's tagName.
    */
   protected adoptLightDomStyles() {
     if (typeof document === 'undefined') return;
@@ -147,11 +152,7 @@ export abstract class A2uiLitElement<Api extends ComponentApi = ComponentApi> ex
     }
 
     const target =
-      typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot
-        ? root
-        : typeof document !== 'undefined'
-          ? document
-          : undefined;
+      typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot ? root : document;
 
     if (target) {
       if (!constructor._adoptedRoots) {
@@ -249,16 +250,16 @@ export abstract class A2uiLitElement<Api extends ComponentApi = ComponentApi> ex
   override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
     if (changedProperties.has('context') && this.context) {
-      if (this.controller) {
-        this.removeController(this.controller);
-        this.controller.dispose();
+      if (this._controller) {
+        this.removeController(this._controller);
+        this._controller.dispose();
       }
-      this.controller = this.createController();
+      this._controller = this.createController();
     }
   }
 
   protected override update(changedProperties: PropertyValues) {
-    if (!this.controller) {
+    if (!this._controller) {
       return;
     }
     super.update(changedProperties);


### PR DESCRIPTION
## Overview

Addresses code and documentation review feedback from merged PR #2190.

## Details

- **Controller Access**: Replaces `A2uiLitElement.controller` property with a read-only getter `public get controller(): A2uiController<Api>` backed by private `_controller` to prevent external reassignment while supporting internal lifecycle management during `willUpdate` and external read access for subclasses/tests.
- **Export Hygiene**: Replaces wildcard `export *` in `@a2ui/lit/v0_9` and `@a2ui/web_core/v0_9/basic_catalog` with explicit named exports.
- **Markdown Context**: Re-exports markdown context and types in `@a2ui/lit/v0_9` directly from `@a2ui/web_core/v0_9` to eliminate duplicate context definitions.
- **Style Adoption**: Simplifies root target ternary in `adoptLightDomStyles` and clarifies JSDoc regarding Light DOM style resolution.
- **Unit Tests**: Replaces redundant `createController()` override in basic catalog element tests with declarative `protected override readonly api`.

## Verification

- `yarn workspace @a2ui/web_core test` (417 passing tests)
- `yarn workspace @a2ui/lit test` (unit and integration tests passing)
- `yarn workspace @a2ui/web_core lint` and `yarn workspace @a2ui/lit lint` (0 errors)
- `./scripts/fix_format.sh`