### PR TITLE
refactor(swift): migrate DataModel and SurfaceComponentsModel to MainActor (#2124)

### DIFF
--- a/swift/core/Sources/A2UICore/Catalogs/FunctionImplementation.swift
+++ b/swift/core/Sources/A2UICore/Catalogs/FunctionImplementation.swift
@@ -30,5 +30,6 @@ public protocol FunctionImplementation: Sendable {
   /// - Parameter context: The data context.
   /// - Returns: The result of the function evaluation.
   /// - Throws: ``FunctionError`` if evaluation fails.
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue
 }

--- a/swift/core/Sources/A2UICore/Models/DataBinding.swift
+++ b/swift/core/Sources/A2UICore/Models/DataBinding.swift
@@ -32,14 +32,14 @@ public struct DataBinding<Value: Sendable>: Sendable {
 
   /// The resolved value at the time the Node was resolved.
   public let value: Value?
-  private let setter: @Sendable (Value) -> Void
+  private let setter: @Sendable @MainActor (Value) -> Void
 
   /// Creates a new data binding with the specified identity, resolved value,
   /// and setter.
   public init(
     identity: Identity,
     value: Value? = nil,
-    set: @escaping @Sendable (Value) -> Void = { _ in }
+    set: @escaping @Sendable @MainActor (Value) -> Void = { _ in }
   ) {
     self.identity = identity
     self.value = value
@@ -47,6 +47,7 @@ public struct DataBinding<Value: Sendable>: Sendable {
   }
 
   /// Updates the bound value.
+  @MainActor
   public func set(_ value: Value) {
     setter(value)
   }

--- a/swift/core/Sources/A2UICore/Models/ResolvedAction.swift
+++ b/swift/core/Sources/A2UICore/Models/ResolvedAction.swift
@@ -25,19 +25,20 @@ public struct ResolvedAction: Sendable {
   /// The identity of this resolved action.
   public let identity: Identity
 
-  private let triggerClosure: @Sendable () -> Void
+  private let triggerClosure: @Sendable @MainActor () -> Void
 
   /// Creates a new resolved action with the specified identity and
   /// trigger closure.
   public init(
     identity: Identity,
-    trigger: @escaping @Sendable () -> Void
+    trigger: @escaping @Sendable @MainActor () -> Void
   ) {
     self.identity = identity
     self.triggerClosure = trigger
   }
 
   /// Triggers the action using function-call syntax.
+  @MainActor
   public func callAsFunction() {
     triggerClosure()
   }

--- a/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
+++ b/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
@@ -28,7 +28,8 @@ import OrderedJSON
 /// `SurfaceViewModel` also hosts the tree resolution logic (dynamic value
 /// evaluation, action resolution, child list expansion) that will
 /// eventually move to a dedicated Binder/Context layer (Phase 4).
-public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
+@MainActor
+public final class SurfaceViewModel: ObservableObject {
 
   // MARK: - Properties
 
@@ -142,11 +143,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
   /// Rebuilds the node tree and publishes the new root.
   private func rebuildTree(components: [String: ComponentModel], data: JSONValue) {
     let newRoot = resolveNode(id: "root", components: components, data: data)
-
-    // Hopping to Main Thread to update the @Published property safely
-    DispatchQueue.main.async { [weak self] in
-      self?.rootNode = newRoot
-    }
+    self.rootNode = newRoot
   }
 
   // MARK: - Property Classification

--- a/swift/core/Sources/A2UICore/State/DataContext.swift
+++ b/swift/core/Sources/A2UICore/State/DataContext.swift
@@ -17,7 +17,8 @@ import OrderedJSON
 
 /// Transient object created on-demand during rendering to solve "scope"
 /// and binding resolution.
-public final class DataContext: @unchecked Sendable {
+@MainActor
+public final class DataContext {
   public let path: String
   public let dataModel: DataModel
 

--- a/swift/core/Sources/A2UICore/State/DataModel.swift
+++ b/swift/core/Sources/A2UICore/State/DataModel.swift
@@ -23,14 +23,14 @@ import OrderedJSON
 /// Mirrors `DataModel` in the core blueprint and `web_core`. The path
 /// subscripting logic delegates to `JSONValue`'s existing path utilities
 /// in ``JSONValue+Path``.
-public final class DataModel: @unchecked Sendable, ObservableObject {
+@MainActor
+public final class DataModel: ObservableObject {
 
-  private let lock = NSRecursiveLock()
   private let dataSubject: CurrentValueSubject<JSONValue, Never>
 
   /// The current data tree.
   public var data: JSONValue {
-    lock.withLock { dataSubject.value }
+    dataSubject.value
   }
 
   /// Emits the data tree after each update is stored, and replays the
@@ -54,12 +54,10 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
   /// - Parameter path: The path (e.g., `/user/name`).
   /// - Returns: The value at the path, or `nil` if not found.
   public func get(_ path: String) -> JSONValue? {
-    lock.withLock {
-      if path.isEmpty || path == "/" {
-        return dataSubject.value
-      }
-      return dataSubject.value[path]
+    if path.isEmpty || path == "/" {
+      return dataSubject.value
     }
+    return dataSubject.value[path]
   }
 
   /// Sets a value at the given JSON Pointer path.
@@ -70,15 +68,13 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
   ///   - path: The path (e.g., `/user/name`).
   ///   - value: The value to set, or `nil` to remove.
   public func set(_ path: String, value: JSONValue?) {
-    lock.withLock {
-      objectWillChange.send()
-      var current = dataSubject.value
-      if path.isEmpty || path == "/" {
-        current = value ?? .object([:])
-      } else {
-        current[path] = value
-      }
-      dataSubject.send(current)
+    objectWillChange.send()
+    var current = dataSubject.value
+    if path.isEmpty || path == "/" {
+      current = value ?? .object([:])
+    } else {
+      current[path] = value
     }
+    dataSubject.send(current)
   }
 }

--- a/swift/core/Sources/A2UICore/State/FunctionHandler.swift
+++ b/swift/core/Sources/A2UICore/State/FunctionHandler.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@MainActor
 public protocol FunctionHandler: AnyObject, Sendable {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)?
 }

--- a/swift/core/Sources/A2UICore/State/SurfaceComponentsModel.swift
+++ b/swift/core/Sources/A2UICore/State/SurfaceComponentsModel.swift
@@ -20,14 +20,14 @@ import OrderedJSON
 ///
 /// Mirrors `SurfaceComponentsModel` in the core blueprint and
 /// `web_core`.
-public final class SurfaceComponentsModel: @unchecked Sendable, ObservableObject {
+@MainActor
+public final class SurfaceComponentsModel: ObservableObject {
 
-  private let lock = NSRecursiveLock()
   private let componentsSubject: CurrentValueSubject<[String: ComponentModel], Never>
 
   /// The current components map.
   public var components: [String: ComponentModel] {
-    lock.withLock { componentsSubject.value }
+    componentsSubject.value
   }
 
   /// Emits the components map after each update is stored, and replays the
@@ -46,31 +46,27 @@ public final class SurfaceComponentsModel: @unchecked Sendable, ObservableObject
   /// - Parameter id: The component ID to look up.
   /// - Returns: The `ComponentModel` if found, otherwise `nil`.
   public func get(_ id: String) -> ComponentModel? {
-    lock.withLock { componentsSubject.value[id] }
+    componentsSubject.value[id]
   }
 
   /// Adds or replaces a component in the collection.
   ///
   /// - Parameter component: The component model to add.
   public func addComponent(_ component: ComponentModel) {
-    lock.withLock {
-      objectWillChange.send()
-      var current = componentsSubject.value
-      current[component.id] = component
-      componentsSubject.send(current)
-    }
+    objectWillChange.send()
+    var current = componentsSubject.value
+    current[component.id] = component
+    componentsSubject.send(current)
   }
 
   /// Removes the component with the given ID.
   ///
   /// - Parameter id: The component ID to remove.
   public func removeComponent(_ id: String) {
-    lock.withLock {
-      objectWillChange.send()
-      var current = componentsSubject.value
-      current.removeValue(forKey: id)
-      componentsSubject.send(current)
-    }
+    objectWillChange.send()
+    var current = componentsSubject.value
+    current.removeValue(forKey: id)
+    componentsSubject.send(current)
   }
 
   /// Validates references across the component graph
@@ -79,17 +75,15 @@ public final class SurfaceComponentsModel: @unchecked Sendable, ObservableObject
   /// - Parameter config: The validation configuration.
   /// - Throws: `A2UIIntegrityError` if graph topology validation fails.
   public func validateReferences(config: ValidationConfig = .strict) throws {
-    let rawComponents: [[String: JSONValue]] = lock.withLock {
-      componentsSubject.value.values.map { component in
-        var dictionary: [String: JSONValue] = [
-          "id": .string(component.id),
-          "component": .string(component.type),
-        ]
-        for (key, value) in component.properties {
-          dictionary[key] = value
-        }
-        return dictionary
+    let rawComponents: [[String: JSONValue]] = componentsSubject.value.values.map { component in
+      var dictionary: [String: JSONValue] = [
+        "id": .string(component.id),
+        "component": .string(component.type),
+      ]
+      for (key, value) in component.properties {
+        dictionary[key] = value
       }
+      return dictionary
     }
     try GraphTopologyValidator.validate(
       components: rawComponents,

--- a/swift/core/Tests/A2UIConformanceTests/BasicCatalogConformanceTests.swift
+++ b/swift/core/Tests/A2UIConformanceTests/BasicCatalogConformanceTests.swift
@@ -18,12 +18,14 @@ import Foundation
 import OrderedJSON
 import Testing
 
-private final class ConformanceMockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class ConformanceMockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     nil
   }
 }
 
+@MainActor
 struct BasicCatalogConformanceTests {
   private let functionHandler = ConformanceMockFunctionHandler()
 

--- a/swift/core/Tests/A2UIConformanceTests/DataModelPointerConformanceTests.swift
+++ b/swift/core/Tests/A2UIConformanceTests/DataModelPointerConformanceTests.swift
@@ -19,6 +19,7 @@ import OrderedCollections
 import OrderedJSON
 import Testing
 
+@MainActor
 struct DataModelPointerConformanceTests {
   @Test func numericAutoVivification() {
     let dataModel = DataModel()

--- a/swift/core/Tests/A2UICoreTests/CatalogTests.swift
+++ b/swift/core/Tests/A2UICoreTests/CatalogTests.swift
@@ -36,6 +36,7 @@ struct ConcatFunction: FunctionImplementation {
     )
   )
 
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     let first = arguments["a"]?.stringValue ?? ""
     let second = arguments["b"]?.stringValue ?? ""
@@ -61,6 +62,7 @@ struct IsEmptyFunction: FunctionImplementation {
     )
   )
 
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     let value = arguments["value"]?.stringValue ?? ""
     return .boolean(value.isEmpty)

--- a/swift/core/Tests/A2UICoreTests/DataContextTests.swift
+++ b/swift/core/Tests/A2UICoreTests/DataContextTests.swift
@@ -16,7 +16,7 @@ import A2UICore
 import OrderedJSON
 import Testing
 
-@Suite
+@MainActor
 struct DataContextTests {
 
   @Test func setUpdatesDataModelWithAbsolutePath() {
@@ -38,10 +38,11 @@ struct DataContextTests {
 
   @Test func nestedReturnsNilIfFunctionHandlerIsDeallocated() {
     let dataModel = DataModel()
-    var handler: MockFunctionHandler? = MockFunctionHandler()
-    let context = DataContext(dataModel: dataModel, path: "/foo", functionHandler: handler!)
-
-    handler = nil
+    let context: DataContext
+    do {
+      let handler = MockFunctionHandler()
+      context = DataContext(dataModel: dataModel, path: "/foo", functionHandler: handler)
+    }
     let nested = context.nested(relativePath: "baz")
     #expect(nested == nil)
   }
@@ -108,7 +109,8 @@ struct DataContextTests {
   }
 }
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   var functionToReturn: (any FunctionImplementation)? = nil
   var lastRequestedName: String? = nil
   var lastRequestedCatalogID: String? = nil

--- a/swift/core/Tests/A2UICoreTests/ModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/ModelTests.swift
@@ -294,6 +294,7 @@ final class Box<T>: @unchecked Sendable {
   init(_ value: T) { self.value = value }
 }
 
+@MainActor
 struct DataBindingTests {
 
   // MARK: - Path-based Binding

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -39,6 +39,7 @@ struct TestConcatFunction: FunctionImplementation {
     )
   )
 
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     let a = arguments["a"]?.stringValue ?? ""
     let b = arguments["b"]?.stringValue ?? ""
@@ -55,6 +56,7 @@ struct TestRequiredFunction: FunctionImplementation {
     schema: try! Schema(instance: "{\"type\": \"object\"}")
   )
 
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let value = arguments["value"] else { return .boolean(false) }
     switch value {
@@ -72,6 +74,7 @@ struct TestEmailFunction: FunctionImplementation {
     schema: try! Schema(instance: "{\"type\": \"object\"}")
   )
 
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let s = arguments["value"]?.stringValue else { return .boolean(false) }
     return .boolean(s.contains("@") && s.contains("."))
@@ -1055,6 +1058,7 @@ struct ComponentModelTests {
 
 // MARK: - SurfaceComponentsModel Tests
 
+@MainActor
 struct SurfaceComponentsModelTests {
 
   @Test func startsEmpty() {
@@ -1113,6 +1117,7 @@ struct SurfaceComponentsModelTests {
 
 // MARK: - DataModel Tests
 
+@MainActor
 struct DataModelTests {
 
   @Test func startsEmpty() {

--- a/swift/core/Tests/BasicCatalogTests/AndFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/AndFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct AndFunctionTests {
 
   let function = AndFunction()

--- a/swift/core/Tests/BasicCatalogTests/EmailFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/EmailFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct EmailFunctionTests {
 
   let function = EmailFunction()

--- a/swift/core/Tests/BasicCatalogTests/FormatCurrencyFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatCurrencyFunctionTests.swift
@@ -18,12 +18,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct FormatCurrencyFunctionTests {
 
   let function = FormatCurrencyFunction()

--- a/swift/core/Tests/BasicCatalogTests/FormatDateFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatDateFunctionTests.swift
@@ -18,12 +18,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct FormatDateFunctionTests {
 
   let function = FormatDateFunction()

--- a/swift/core/Tests/BasicCatalogTests/FormatNumberFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatNumberFunctionTests.swift
@@ -18,12 +18,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct FormatNumberFunctionTests {
 
   let function = FormatNumberFunction()

--- a/swift/core/Tests/BasicCatalogTests/FormatStringFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatStringFunctionTests.swift
@@ -19,7 +19,8 @@ import JSONSchema
 import OrderedJSON
 import Testing
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     if named == "upper" {
       return UpperFunction()
@@ -32,11 +33,13 @@ private struct UpperFunction: FunctionImplementation, Sendable {
   let api = FunctionAPI(
     name: "upper", returnType: .string, schema: try! JSONSchema.Schema(instance: "{}"))
 
+  @MainActor
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     return .string(arguments["text"]?.stringValue?.uppercased() ?? "")
   }
 }
 
+@MainActor
 struct FormatStringFunctionTests {
 
   let function = FormatStringFunction()

--- a/swift/core/Tests/BasicCatalogTests/LengthFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/LengthFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct LengthFunctionTests {
 
   let function = LengthFunction()

--- a/swift/core/Tests/BasicCatalogTests/NotFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/NotFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct NotFunctionTests {
 
   let function = NotFunction()

--- a/swift/core/Tests/BasicCatalogTests/NumericFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/NumericFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct NumericFunctionTests {
 
   let function = NumericFunction()

--- a/swift/core/Tests/BasicCatalogTests/OpenURLFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/OpenURLFunctionTests.swift
@@ -18,7 +18,8 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
@@ -32,6 +33,7 @@ private final class MockOpenURLHandler: OpenURLHandler, @unchecked Sendable {
   }
 }
 
+@MainActor
 struct OpenURLFunctionTests {
 
   let context = DataContext(

--- a/swift/core/Tests/BasicCatalogTests/OrFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/OrFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct OrFunctionTests {
 
   let function = OrFunction()

--- a/swift/core/Tests/BasicCatalogTests/PluralizeFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/PluralizeFunctionTests.swift
@@ -18,7 +18,8 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
@@ -37,6 +38,7 @@ private final class MockPluralResolver: PluralResolver, @unchecked Sendable {
   }
 }
 
+@MainActor
 struct PluralizeFunctionTests {
 
   let function = PluralizeFunction()

--- a/swift/core/Tests/BasicCatalogTests/RegexFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/RegexFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct RegexFunctionTests {
 
   let function = RegexFunction()

--- a/swift/core/Tests/BasicCatalogTests/RequiredFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/RequiredFunctionTests.swift
@@ -17,12 +17,14 @@ import Testing
 
 @testable import BasicCatalog
 
-private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
+@MainActor
+private final class MockFunctionHandler: FunctionHandler {
   func function(named: String, catalogID: String?) -> (any FunctionImplementation)? {
     return nil
   }
 }
 
+@MainActor
 struct RequiredFunctionTests {
 
   let function = RequiredFunction()

--- a/swift/swiftui/Sources/A2UISwiftUI/DataBinding+SwiftUI.swift
+++ b/swift/swiftui/Sources/A2UISwiftUI/DataBinding+SwiftUI.swift
@@ -20,6 +20,7 @@ import SwiftUI
 /// This extension bridges A2UI's thread-safe `DataBinding` to
 /// SwiftUI's `Binding` for use in form controls and other two-way
 /// bound views.
+@MainActor
 extension DataBinding {
   /// A SwiftUI `Binding` backed by this `DataBinding`.
   public var swiftUIBinding: Binding<Value?> {
@@ -48,6 +49,7 @@ extension DataBinding {
   }
 }
 
+@MainActor
 extension DataBinding where Value == String {
   /// A non-optional SwiftUI `Binding<String>` defaulting to empty string if `value` is nil.
   public var stringBinding: Binding<String> {
@@ -55,6 +57,7 @@ extension DataBinding where Value == String {
   }
 }
 
+@MainActor
 extension DataBinding where Value == Bool {
   /// A non-optional SwiftUI `Binding<Bool>` defaulting to false if `value` is nil.
   public var boolBinding: Binding<Bool> {
@@ -62,6 +65,7 @@ extension DataBinding where Value == Bool {
   }
 }
 
+@MainActor
 extension DataBinding where Value == Double {
   /// A non-optional SwiftUI `Binding<Double>` defaulting to 0.0 if `value` is nil.
   public var doubleBinding: Binding<Double> {
@@ -71,6 +75,7 @@ extension DataBinding where Value == Double {
 
 // MARK: - Node SwiftUI Binding Accessors
 
+@MainActor
 extension Node {
   /// Returns a two-way SwiftUI `Binding<Value>` for the given property key,
   /// falling back to `defaultValue` if the binding is unset or missing.

--- a/swift/swiftui/Tests/A2UISwiftUITests/DataBindingSwiftUITests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/DataBindingSwiftUITests.swift
@@ -22,6 +22,7 @@ private final class TestBox<T>: @unchecked Sendable {
   init(_ value: T) { self.value = value }
 }
 
+@MainActor
 struct DataBindingSwiftUITests {
 
   @Test func swiftUIBindingGetsValue() {

--- a/swift/swiftui/Tests/A2UISwiftUITests/StressTests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/StressTests.swift
@@ -104,7 +104,7 @@ struct StressTests {
 
   // MARK: - Concurrent Updates
 
-  @Test nonisolated func concurrentDataModelUpdates() async throws {
+  @Test func concurrentDataModelUpdates() async throws {
     let dataModel = DataModel()
 
     // 10 tasks × 200 updates each
@@ -117,7 +117,7 @@ struct StressTests {
           for updateIndex in 0..<updatesPerTask {
             let path = "/task\(taskIndex)/val\(updateIndex)"
             let value: JSONValue = .integer(updateIndex)
-            dataModel.set(path, value: value)
+            await dataModel.set(path, value: value)
           }
         }
       }
@@ -136,7 +136,7 @@ struct StressTests {
     }
   }
 
-  @Test nonisolated func concurrentComponentUpdates() async throws {
+  @Test func concurrentComponentUpdates() async throws {
     let componentsModel = SurfaceComponentsModel()
 
     // Multiple tasks updating different components concurrently
@@ -149,7 +149,7 @@ struct StressTests {
               type: "text",
               properties: ["text": .string("Task \(taskIndex) Component \(i)")]
             )
-            componentsModel.addComponent(comp)
+            await componentsModel.addComponent(comp)
           }
         }
       }


### PR DESCRIPTION
# Description

Replaces manual locking (`NSRecursiveLock`) with `@MainActor` isolation in `DataModel` and `SurfaceComponentsModel`, addressing issue #2124.

### Motivation & Context
Previously, `DataModel` and `SurfaceComponentsModel` used `NSRecursiveLock` while marked `@unchecked Sendable`. Because background queues could mutate state, `SurfaceViewModel.rebuildTree` had to dispatch asynchronously to `DispatchQueue.main.async` before assigning `@Published var rootNode`.

Because `MessageProcessor`, `SurfaceGroupModel`, and all SwiftUI rendering components are already isolated to `@MainActor`, isolating state models to `@MainActor`:
- Eliminates manual locks and `@unchecked Sendable` annotations.
- Removes the asynchronous hop in `SurfaceViewModel.rebuildTree`, updating the root node synchronously on `@MainActor`.
- Preserves full compatibility with `ObservableObject` and SwiftUI synchronous bindings (`Binding(get:set:)`).

### Key Changes
- **`DataModel` & `SurfaceComponentsModel`**: Removed `NSRecursiveLock` and `@unchecked Sendable`. Marked both classes with `@MainActor`.
- **`SurfaceViewModel`**: Removed `DispatchQueue.main.async` in `rebuildTree`. The root node updates synchronously upon state changes.
- **`DataContext` & `FunctionHandler`**: Marked with `@MainActor` to maintain consistency across the evaluation pipeline.
- **`DataBinding` & `ResolvedAction`**: Isolated setters and trigger closures to `@Sendable @MainActor`.
- **Test Suites**: Updated test suites across core, Basic Catalog, conformance, and SwiftUI to execute with `@MainActor` isolation or `await` background mutations in stress tests.

Fixes #2124.