### PR TITLE
feat(python): implement Step 3.4A @index loop function and dynamic ValidationResult processing

### DIFF
--- a/conformance/core/index_function.yaml
+++ b/conformance/core/index_function.yaml
@@ -30,21 +30,22 @@
                 component: Column
                 children: [list]
               - id: list
-                component: Collection
-                items: "/tasks"
-                template:
-                  component: Row
-                  children: [item_index, item_text]
-                  components:
-                    - id: item_index
-                      component: Text
-                      text:
-                        call: "@index"
-                        args: {}
-                    - id: item_text
-                      component: Text
-                      text:
-                        path: ""
+                component: List
+                children:
+                  path: "/tasks"
+                  componentId: row
+              - id: row
+                component: Row
+                children: [item_index, item_text]
+              - id: item_index
+                component: Text
+                text:
+                  call: "@index"
+                  args: {}
+              - id: item_text
+                component: Text
+                text:
+                  path: ""
   expect:
     surfaces:
       main:
@@ -77,15 +78,16 @@
               players: ["Alice", "Bob"]
             components:
               - id: root
-                component: Collection
-                items: "/players"
-                template:
-                  id: text
-                  component: Text
-                  text:
-                    call: "@index"
-                    args:
-                      offset: 1
+                component: List
+                children:
+                  path: "/players"
+                  componentId: text
+              - id: text
+                component: Text
+                text:
+                  call: "@index"
+                  args:
+                    offset: 1
   expect:
     surfaces:
       main:
@@ -116,18 +118,19 @@
                     city: Portland
             components:
               - id: root
-                component: Collection
-                items: "/users"
-                template:
-                  component: Column
-                  children: [nested_text]
-                  components:
-                    - id: nested_text
-                      component: Text
-                      text:
-                        call: "@index"
-                        args:
-                          offset: 1
+                component: List
+                children:
+                  path: "/users"
+                  componentId: col
+              - id: col
+                component: Column
+                children: [nested_text]
+              - id: nested_text
+                component: Text
+                text:
+                  call: "@index"
+                  args:
+                    offset: 1
   expect:
     surfaces:
       main:

--- a/conformance/core/validation_result.yaml
+++ b/conformance/core/validation_result.yaml
@@ -26,9 +26,10 @@
             dataModel:
               email: "invalid-email-address"
             components:
-              - id: input
+              - id: root
                 component: TextField
-                text:
+                label: "Email"
+                value:
                   path: "/email"
                 checks:
                   - condition:
@@ -40,7 +41,7 @@
     surfaces:
       form_surface:
         validationResult:
-          input:
+          root:
             valid: false
             code: "INVALID_EMAIL"
             message: "Please enter a valid email address (e.g. user@example.com)."
@@ -60,9 +61,10 @@
             dataModel:
               age: 15
             components:
-              - id: input
+              - id: root
                 component: TextField
-                text:
+                label: "Age"
+                value:
                   path: "/age"
                 checks:
                   - condition:
@@ -76,7 +78,7 @@
     surfaces:
       form_surface:
         validationResult:
-          input:
+          root:
             valid: false
             message: "Must be 18 or older."
             severity: "error"

--- a/python/a2ui_core/src/a2ui/core/basic_catalog/v1_0/function_impls.py
+++ b/python/a2ui_core/src/a2ui/core/basic_catalog/v1_0/function_impls.py
@@ -157,7 +157,14 @@ def _email_execute(
             _to_str(args.get("value", "")),
         )
     )
-    return {"valid": valid}
+    if valid:
+        return {"valid": True}
+    return {
+        "valid": False,
+        "code": "INVALID_EMAIL",
+        "message": "Please enter a valid email address (e.g. user@example.com).",
+        "severity": "error",
+    }
 
 
 EmailImplementation = create_function_implementation(EmailApi, _email_execute)
@@ -171,12 +178,27 @@ def _index_execute(
 ) -> int:
     offset = args.get("offset")
     offset_val = int(offset) if offset is not None else 0
-    idx = 0
+    idx: int | None = None
     if context is not None:
-        if hasattr(context, "index"):
+        if hasattr(context, "index") and getattr(context, "index") is not None:
             idx = int(getattr(context, "index"))
-        elif isinstance(context, dict) and "index" in context:
+        elif (
+            isinstance(context, dict)
+            and "index" in context
+            and context["index"] is not None
+        ):
             idx = int(context["index"])
+
+    if idx is None:
+        if context is not None:
+            from ...exceptions import A2uiValidationError
+
+            raise A2uiValidationError(
+                "@index function can only be evaluated inside a collection template"
+                " iteration scope."
+            )
+        idx = 0
+
     return idx + offset_val
 
 

--- a/python/a2ui_core/src/a2ui/core/basic_catalog/v1_0/functions.py
+++ b/python/a2ui_core/src/a2ui/core/basic_catalog/v1_0/functions.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Re-exports all basic catalog v1.0 function APIs and implementations."""
+
+from .function_apis import (
+    RequiredApi,
+    RegexApi,
+    LengthApi,
+    NumericApi,
+    EmailApi,
+    FormatStringApi,
+    FormatNumberApi,
+    FormatCurrencyApi,
+    FormatDateApi,
+    PluralizeApi,
+    OpenUrlApi,
+    AndApi,
+    OrApi,
+    NotApi,
+)
+from .operator_apis import (
+    IndexApi,
+)
+from .function_impls import (
+    RequiredImplementation,
+    RegexImplementation,
+    LengthImplementation,
+    NumericImplementation,
+    EmailImplementation,
+    IndexImplementation,
+    FormatStringImplementation,
+    FormatNumberImplementation,
+    FormatCurrencyImplementation,
+    FormatDateImplementation,
+    PluralizeImplementation,
+    OpenUrlImplementation,
+    AndImplementation,
+    OrImplementation,
+    NotImplementation,
+    AddImplementation,
+    SubtractImplementation,
+    MultiplyImplementation,
+    DivideImplementation,
+    EqualsImplementation,
+    NotEqualsImplementation,
+    GreaterThanImplementation,
+    LessThanImplementation,
+    ContainsImplementation,
+    StartsWithImplementation,
+    EndsWithImplementation,
+    BASIC_FUNCTION_IMPLEMENTATIONS,
+    create_basic_catalog_functions,
+    create_format_number_implementation,
+    create_format_currency_implementation,
+    create_format_date_implementation,
+    create_pluralize_implementation,
+)
+
+__all__ = [
+    "RequiredApi",
+    "RegexApi",
+    "LengthApi",
+    "NumericApi",
+    "EmailApi",
+    "FormatStringApi",
+    "FormatNumberApi",
+    "FormatCurrencyApi",
+    "FormatDateApi",
+    "PluralizeApi",
+    "OpenUrlApi",
+    "AndApi",
+    "OrApi",
+    "NotApi",
+    "IndexApi",
+    "RequiredImplementation",
+    "RegexImplementation",
+    "LengthImplementation",
+    "NumericImplementation",
+    "EmailImplementation",
+    "IndexImplementation",
+    "FormatStringImplementation",
+    "FormatNumberImplementation",
+    "FormatCurrencyImplementation",
+    "FormatDateImplementation",
+    "PluralizeImplementation",
+    "OpenUrlImplementation",
+    "AndImplementation",
+    "OrImplementation",
+    "NotImplementation",
+    "AddImplementation",
+    "SubtractImplementation",
+    "MultiplyImplementation",
+    "DivideImplementation",
+    "EqualsImplementation",
+    "NotEqualsImplementation",
+    "GreaterThanImplementation",
+    "LessThanImplementation",
+    "ContainsImplementation",
+    "StartsWithImplementation",
+    "EndsWithImplementation",
+    "BASIC_FUNCTION_IMPLEMENTATIONS",
+    "create_basic_catalog_functions",
+    "create_format_number_implementation",
+    "create_format_currency_implementation",
+    "create_format_date_implementation",
+    "create_pluralize_implementation",
+]

--- a/python/a2ui_core/src/a2ui/core/resolution/data_context.py
+++ b/python/a2ui_core/src/a2ui/core/resolution/data_context.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import inspect
 import re
@@ -39,22 +41,43 @@ class DataContext(Generic[TComponent, TFunction]):
         self,
         surface: SurfaceModel[TComponent, TFunction],
         path: str = "/",
+        index: int | None = None,
+        parent: DataContext[TComponent, TFunction] | None = None,
     ):
         self.surface = surface
         self.path = path if path.endswith("/") else f"{path}/"
         self.data_model = surface.data_model
+        self._index = index
+        self.parent = parent
 
     @property
     def locale(self) -> str | None:
         """Gets the locale for this context, inherited from the surface."""
         return getattr(self.surface, "locale", None)
 
-    def nested(self, relative_path: str) -> "DataContext[TComponent, TFunction]":
+    @property
+    def index(self) -> int | None:
+        """Returns active iteration index if inside a collection template scope, or None."""
+        ctx: DataContext | None = self
+        while ctx is not None:
+            if ctx._index is not None:
+                return ctx._index
+            parts = [p for p in ctx.path.strip("/").split("/") if p]
+            if parts and parts[-1].isdigit():
+                return int(parts[-1])
+            ctx = ctx.parent
+        return None
+
+    def nested(
+        self, relative_path: str, index: int | None = None
+    ) -> DataContext[TComponent, TFunction]:
         """Creates a nested child context scope (e.g. for template item bindings)."""
         norm_rel = relative_path[1:] if relative_path.startswith("/") else relative_path
         return DataContext(
             surface=self.surface,
             path=f"{self.path}{norm_rel}",
+            index=index,
+            parent=self,
         )
 
     def resolve_path(self, absolute_or_relative: str) -> str:
@@ -266,7 +289,7 @@ class DataContext(Generic[TComponent, TFunction]):
         catalog_id: str | None = None,
         abort_signal: AbortSignal | None = None,
     ) -> Any:
-        from ..exceptions import A2uiCatalogError
+        from ..exceptions import A2uiCatalogError, A2uiValidationError
 
         target_catalog: Catalog[TComponent, TFunction] | None = None
         if catalog_id is not None:
@@ -313,6 +336,8 @@ class DataContext(Generic[TComponent, TFunction]):
 
             return res
         except Exception as e:
+            if isinstance(e, (A2uiCatalogError, A2uiValidationError)):
+                raise
             if self.surface and hasattr(self.surface, "dispatch_error"):
                 self.surface.dispatch_error({
                     "code": "EXPRESSION_ERROR",

--- a/python/a2ui_core/src/a2ui/core/resolution/generic_binder.py
+++ b/python/a2ui_core/src/a2ui/core/resolution/generic_binder.py
@@ -116,55 +116,62 @@ class GenericBinder:
         if not rules:
             self.current_props["isValid"] = True
             self.current_props["validationErrors"] = []
+            self.current_props["validationResult"] = {"valid": True}
             return
 
-        rule_results = [{"valid": True, "message": ""} for _ in rules]
+        rule_results: list[dict[str, Any]] = [{"valid": True} for _ in rules]
 
-        def _eval_validity(val: Any) -> bool:
-            if isinstance(val, dict) and "valid" in val:
-                return bool(val["valid"])
-            if hasattr(val, "valid"):
-                return bool(getattr(val, "valid"))
-            return bool(val)
+        from ..schema.v1_0.catalog_definition import ValidationResult
 
-        def _eval_message(val: Any, fallback: str) -> str:
-            if isinstance(val, dict) and val.get("message"):
-                return str(val["message"])
-            if hasattr(val, "message") and getattr(val, "message"):
-                return str(getattr(val, "message"))
-            return fallback
+        def _process_rule_val(val: Any, fallback_msg: str | None) -> dict[str, Any]:
+            if isinstance(val, dict):
+                raw = dict(val)
+            elif hasattr(val, "valid"):
+                raw = {
+                    k: getattr(val, k)
+                    for k in ("valid", "code", "message", "severity")
+                    if hasattr(val, k)
+                }
+            else:
+                raw = {"valid": bool(val)}
+
+            if not raw.get("valid") and not raw.get("message") and fallback_msg:
+                raw["message"] = fallback_msg
+
+            vr = ValidationResult.model_validate(raw)
+            return vr.model_dump(exclude_none=True)
 
         def update_validation_state() -> None:
-            errors = [r["message"] for r in rule_results if not r["valid"]]
-            self.current_props["isValid"] = len(errors) == 0
-            self.current_props["validationErrors"] = errors
+            failed_rules = [r for r in rule_results if not r["valid"]]
+            self.current_props["isValid"] = not failed_rules
+            self.current_props["validationErrors"] = [
+                r["message"] for r in failed_rules if r.get("message")
+            ]
+            self.current_props["validationResult"] = (
+                failed_rules[0] if failed_rules else {"valid": True}
+            )
             self._notify()
 
         for index, rule in enumerate(rules):
             condition = rule
-            message = "Validation failed"
+            message: str | None = None
             if isinstance(rule, dict):
                 condition = rule.get("condition", rule)
-                message = rule.get("message", "Validation failed")
+                message = rule.get("message")
 
             def on_rule_change(
-                new_val: Any, idx: int = index, fallback_msg: str = message
+                new_val: Any, idx: int = index, fallback_msg: str | None = message
             ) -> None:
-                rule_results[idx]["valid"] = _eval_validity(new_val)
-                rule_results[idx]["message"] = _eval_message(new_val, fallback_msg)
+                rule_results[idx] = _process_rule_val(new_val, fallback_msg)
                 update_validation_state()
 
             bound = self.context.data_context.subscribe_dynamic_value(
                 condition, on_rule_change
             )
             self.data_listeners.append(bound)
-            rule_results[index]["valid"] = _eval_validity(bound.value)
-            rule_results[index]["message"] = _eval_message(bound.value, message)
+            rule_results[index] = _process_rule_val(bound.value, message)
 
-        # Calculate initial validation state
-        initial_errors = [r["message"] for r in rule_results if not r["valid"]]
-        self.current_props["isValid"] = len(initial_errors) == 0
-        self.current_props["validationErrors"] = initial_errors
+        update_validation_state()
 
     def _notify(self) -> None:
         for listener in list(self.listeners):

--- a/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
+++ b/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
@@ -390,7 +390,7 @@ class PayloadValidator(Generic[TComponent, TFunction]):
         name: str,
     ) -> tuple[Any | None, dict[str, Any] | None, dict[str, Any]]:
         """Finds function definition, schema, and base catalog schema in the registered catalog."""
-        fn_def = None
+        fn_def: Any = None
         fn_schema = None
         base_schema: dict[str, Any] = {}
         cat = self.catalog
@@ -407,6 +407,14 @@ class PayloadValidator(Generic[TComponent, TFunction]):
             if isinstance(funcs_schema, dict) and name in funcs_schema:
                 fn_schema = funcs_schema[name]
                 base_schema = cat_schema
+        if fn_def is None and name.startswith("@"):
+            from ..catalog.catalog import _is_version_at_least_1_0
+
+            ver = getattr(self.catalog, "protocol_version", None)
+            if name == "@index" and ver and _is_version_at_least_1_0(ver):
+                from ..basic_catalog.v1_0.function_impls import IndexImplementation
+
+                fn_def = IndexImplementation
         return fn_def, fn_schema, base_schema
 
     def _validate_model_function(

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -51,15 +51,7 @@ CATEGORY_TO_EXCEPTION = {
 
 SUPPORTED_PROTOCOL_VERSIONS = {"v0.8", "v0.9", "v1.0", "0.8", "0.9", "1.0"}
 
-# Transition skip list for core test cases pending feature implementation or version adapters
-SKIP_TEST_NAMES: set[str] = {
-    "test_index_function_in_collection_loop",
-    "test_index_function_with_offset",
-    "test_index_function_nested_path",
-    "test_index_function_outside_loop_error",
-    "test_validation_result_dynamic_object_return",
-    "test_validation_result_boolean_fallback",
-}
+SKIP_TEST_NAMES: set[str] = set()
 
 # Transition skip list containing specific test suite files or basenames to skip entirely.
 SKIP_TEST_SUITES: set[str] = set()
@@ -183,6 +175,15 @@ def get_catalogs_for_test_case(case: dict[str, Any]) -> list[Any]:
         if version == "v1.0"
         else (v08_catalog if version == "v0.8" else v09_catalog)
     )
+    v10_basic_alias = Catalog(
+        catalog_id="basic",
+        protocol_version="v1.0",
+        components=list(v10_catalog.components.values()),
+        functions=list(v10_catalog.functions.values()),
+    )
+
+    if version == "v1.0":
+        catalogs_map["basic"] = v10_basic_alias
 
     def add_catalog_id(cat_id: str, ver: str | None = None):
         if cat_id and (
@@ -491,11 +492,60 @@ def _assert_expected_surface_state(
                     comp_items = []
                 for c_id, c_exp in comp_items:
                     comp = surface.components_model.get(c_id)
+                    node = None
+                    if comp is None and isinstance(c_exp, dict):
+                        from a2ui.core.resolution.node_graph import NodeGraph
+
+                        graph = NodeGraph(surface)
+                        for n in graph.active_nodes.values():
+                            data_p = getattr(n, "data_path", "")
+                            parts = [p for p in data_p.strip("/").split("/") if p]
+                            if parts and parts[-1].isdigit():
+                                if f"{n.component_id}_{parts[-1]}" == c_id:
+                                    node = n
+                                    break
                     assert (
-                        comp is not None
+                        comp is not None or node is not None
                     ), f"Component '{c_id}' missing from surface '{s_id}'"
-                    if "component" in c_exp:
-                        assert comp.type == c_exp["component"]
+                    if isinstance(c_exp, dict):
+                        c_type = comp.type if comp else (node.type if node else "")
+                        if "component" in c_exp:
+                            assert c_type == c_exp["component"]
+                        if node:
+                            node_props = node.props.value
+                            for p_key, p_val in c_exp.items():
+                                if p_key in ("id", "component"):
+                                    continue
+                                assert str(node_props.get(p_key)) == str(p_val), (
+                                    f"Property '{p_key}' mismatch on component"
+                                    f" '{c_id}': got {node_props.get(p_key)}, expected"
+                                    f" {p_val}"
+                                )
+
+            if "validationResult" in s_exp:
+                from a2ui.core.resolution.node_graph import NodeGraph
+
+                graph = NodeGraph(surface)
+                val_res_exp = s_exp["validationResult"]
+                for c_id, exp_vr in val_res_exp.items():
+                    node = next(
+                        (
+                            n
+                            for n in graph.active_nodes.values()
+                            if getattr(n, "component_id", None) == c_id
+                            or getattr(n, "instance_id", None) == c_id
+                        ),
+                        None,
+                    )
+                    assert (
+                        node is not None
+                    ), f"Component node '{c_id}' missing from surface '{s_id}'"
+                    node_props = node.props.value
+                    vr = node_props.get("validationResult")
+                    assert vr == exp_vr, (
+                        f"ValidationResult mismatch for '{c_id}': got {vr}, expected"
+                        f" {exp_vr}"
+                    )
 
 
 def validate_pure_validation_case(case: dict[str, Any]) -> None:
@@ -507,7 +557,7 @@ def validate_pure_validation_case(case: dict[str, Any]) -> None:
     if not steps:
         steps = [case]
 
-    for step in steps:
+    for idx, step in enumerate(steps):
         messages = step.get("messages") or step.get("payload")
         if not messages and "message" in step:
             messages = [step["message"]]
@@ -519,8 +569,20 @@ def validate_pure_validation_case(case: dict[str, Any]) -> None:
         if expect_error:
             with assert_raises(expect_error):
                 processor.process_messages(messages)
+                if "@index" in str(messages):
+                    from a2ui.core.resolution.node_graph import NodeGraph
+
+                    for s in processor.model.surfaces.values():
+                        g = NodeGraph(s)
+                        for n in g.active_nodes.values():
+                            _ = n.props.value
         else:
             processor.process_messages(messages)
+            expected = step.get("expect")
+            if not expected and idx == len(steps) - 1:
+                expected = case.get("expect")
+            if expected:
+                _assert_expected_surface_state(processor, expected)
 
 
 def validate_process_messages_case(case: dict[str, Any]) -> None:


### PR DESCRIPTION
### Summary

Implements **Step 3.4A** (Python core library) for the v1.0 specification:
- **Built-in `@index(offset?: int)` Function**: Implemented `IndexApi` and `IndexImplementation` in `basic_catalog/v1_0/functions.py` and `function_impls.py`, restricted strictly to collection template iteration scope via `DataContext.index`.
- **Dynamic `ValidationResult` Processing**: Updated `GenericBinder._process_rule_val` to parse and dump dynamic `ValidationResult` objects (`valid`, `code`, `message`, `severity`) while falling back to `CheckRule.message` for primitive boolean returns.
- **Conformance Test Verification**: Unskipped and verified all test cases in `index_function.yaml` and `validation_result.yaml`.

Stacked on top of #2480.