### PR TITLE
Refactor prompt generator to expose modular prompt information

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/prompt_generator.py
@@ -55,9 +55,9 @@ class DirectJsonPromptGenerator(PromptGenerator):
             return self.selected_catalog.render_as_llm_instructions() or ""
         if self._format and self._format._supported_catalogs:
             instructions = [
-                c.render_as_llm_instructions()
+                inst
                 for c in self._format._supported_catalogs
-                if c.render_as_llm_instructions()
+                if (inst := c.render_as_llm_instructions())
             ]
             return "\n\n".join(instructions)
         return ""

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/prompt_generator.py
@@ -130,7 +130,7 @@ class DirectJsonPromptGenerator(PromptGenerator):
             parts.append(f"## UI Description:\n{ui_description}")
 
         if include_schema:
-            instructions = self.catalog_description(include_schema=True)
+            instructions = self._catalog_description(include_schema=True)
             if instructions:
                 parts.append(instructions)
 
@@ -139,7 +139,7 @@ class DirectJsonPromptGenerator(PromptGenerator):
 
         return "\n\n".join(parts)
 
-    def catalog_description(self, include_schema: bool = True) -> str:
+    def _catalog_description(self, include_schema: bool = True) -> str:
         """Assembles the system prompt component catalog signatures block.
 
         Args:
@@ -150,11 +150,11 @@ class DirectJsonPromptGenerator(PromptGenerator):
         """
         if not include_schema:
             return ""
-        catalog = self.selected_catalog
+        catalog = getattr(self, "selected_catalog", None)
         if not catalog:
             catalog = (
                 self._format._supported_catalogs[0]
-                if self._format._supported_catalogs
+                if self._format and self._format._supported_catalogs
                 else None
             )
         if not catalog:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/prompt_generator.py
@@ -35,6 +35,50 @@ class DirectJsonPromptGenerator(PromptGenerator):
         self._format = format_inst
         self.selected_catalog: Optional["A2uiCatalog"] = None
 
+    def generate_base_rules(self) -> str:
+        """Returns default JSON workflow rules."""
+        from a2ui.schema.constants import DEFAULT_WORKFLOW_RULES
+
+        return DEFAULT_WORKFLOW_RULES
+
+    def generate_catalog_instructions(
+        self,
+        include_schema: bool = True,
+        catalog: Optional[Any] = None,
+    ) -> str:
+        """Returns LLM instructions for a catalog or all supported catalogs."""
+        if not include_schema:
+            return ""
+        if catalog:
+            return catalog.render_as_llm_instructions() or ""
+        if self.selected_catalog:
+            return self.selected_catalog.render_as_llm_instructions() or ""
+        if self._format and self._format._supported_catalogs:
+            instructions = [
+                c.render_as_llm_instructions()
+                for c in self._format._supported_catalogs
+                if c.render_as_llm_instructions()
+            ]
+            return "\n\n".join(instructions)
+        return ""
+
+    def generate_examples(
+        self,
+        catalog: Optional[Any] = None,
+        validate: bool = False,
+    ) -> str:
+        """Loads and formats few-shot examples for a catalog."""
+        target_catalog = catalog or self.selected_catalog
+        if not target_catalog:
+            target_catalog = (
+                self._format._supported_catalogs[0]
+                if self._format._supported_catalogs
+                else None
+            )
+        if not target_catalog:
+            return ""
+        return self._format.load_examples(target_catalog, validate=validate) or ""
+
     def generate(
         self,
         role_description: str,

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/atom/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/atom/prompt_generator.py
@@ -113,6 +113,7 @@ class AtomPromptGenerator(PromptGenerator):
         Args:
             format_inst: The AtomFormat strategy instance.
         """
+        self._format = format_inst
         self.format = format_inst
         try:
             from a2ui.schema.schema_helper import CatalogSchemaHelper
@@ -125,6 +126,52 @@ class AtomPromptGenerator(PromptGenerator):
             self.schema_helper = CatalogSchemaHelper(format_inst.catalog)
         except Exception:
             self.schema_helper = None
+
+    def generate_base_rules(self) -> str:
+        """Returns core syntax rules for A2UI Atom."""
+        return ATOM_RULES
+
+    def generate_catalog_instructions(
+        self,
+        include_schema: bool = True,
+        catalog: Optional[Any] = None,
+    ) -> str:
+        """Assembles Atom component and function signatures."""
+        if not include_schema:
+            return ""
+        if catalog:
+            try:
+                from a2ui.schema.schema_helper import CatalogSchemaHelper
+            except ImportError:
+                from a2ui.inference_formats.experimental.express.schema_helper import (
+                    CatalogSchemaHelper,
+                )
+            old_helper = self.schema_helper
+            self.schema_helper = CatalogSchemaHelper(catalog)
+            comps = self.generate_component_signatures()
+            funcs = self.generate_function_signatures()
+            res = (comps + ("\n\n" if funcs else "") + funcs).strip()
+            self.schema_helper = old_helper
+            return res
+        comps = self.generate_component_signatures()
+        funcs = self.generate_function_signatures()
+        return (comps + ("\n\n" if funcs else "") + funcs).strip()
+
+    def generate_examples(
+        self,
+        catalog: Optional[Any] = None,
+        validate: bool = False,
+    ) -> str:
+        """Loads and formats few-shot Atom examples."""
+        target_catalog = catalog or self.format.catalog
+        if not target_catalog or not self.format or not self.format.examples_path:
+            return ""
+        raw_examples = target_catalog.load_examples(
+            self.format.examples_path, validate=validate
+        )
+        if not raw_examples:
+            return ""
+        return self.transform_examples(raw_examples)
 
     def generate(
         self,

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/atom/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/atom/prompt_generator.py
@@ -146,15 +146,11 @@ class AtomPromptGenerator(PromptGenerator):
                 from a2ui.inference_formats.experimental.express.schema_helper import (
                     CatalogSchemaHelper,
                 )
-            old_helper = self.schema_helper
-            self.schema_helper = CatalogSchemaHelper(catalog)
-            comps = self.generate_component_signatures()
-            funcs = self.generate_function_signatures()
-            res = (comps + ("\n\n" if funcs else "") + funcs).strip()
-            self.schema_helper = old_helper
-            return res
-        comps = self.generate_component_signatures()
-        funcs = self.generate_function_signatures()
+            helper = CatalogSchemaHelper(catalog)
+        else:
+            helper = self.schema_helper
+        comps = self.generate_component_signatures(helper=helper)
+        funcs = self.generate_function_signatures(helper=helper)
         return (comps + ("\n\n" if funcs else "") + funcs).strip()
 
     def generate_examples(
@@ -220,15 +216,16 @@ class AtomPromptGenerator(PromptGenerator):
 
         return "\n\n".join(parts)
 
-    def generate_component_signatures(self) -> str:
+    def generate_component_signatures(self, helper: Optional[Any] = None) -> str:
         """Compiles component definitions into S-expression signatures."""
-        if not self.schema_helper:
+        h = helper or self.schema_helper
+        if not h:
             return ""
         signatures = []
-        for name in sorted(self.schema_helper.component_properties.keys()):
-            props = self.schema_helper.get_component_properties(name)
-            reqs = self.schema_helper.get_component_required(name)
-            comp_desc = self.schema_helper.get_component_description(name)
+        for name in sorted(h.component_properties.keys()):
+            props = h.get_component_properties(name)
+            reqs = h.get_component_required(name)
+            comp_desc = h.get_component_description(name)
 
             ordered_args = []
             prop_details = []
@@ -237,7 +234,7 @@ class AtomPromptGenerator(PromptGenerator):
                     continue
                 is_req = p in reqs
                 opt_suffix = "" if is_req else "?"
-                p_schema = self.schema_helper.get_property_schema(name, p)
+                p_schema = h.get_property_schema(name, p)
 
                 arg_label = f":{p}{opt_suffix}"
                 ordered_args.append(arg_label)
@@ -264,22 +261,23 @@ class AtomPromptGenerator(PromptGenerator):
             signatures.append(sig)
         return "\n".join(signatures)
 
-    def generate_function_signatures(self) -> str:
+    def generate_function_signatures(self, helper: Optional[Any] = None) -> str:
         """Compiles function definitions into S-expression signatures."""
-        if not self.schema_helper:
+        h = helper or self.schema_helper
+        if not h:
             return ""
         signatures = []
-        for name in sorted(self.schema_helper.function_properties.keys()):
-            props = self.schema_helper.get_function_properties(name)
-            reqs = self.schema_helper.get_function_required(name)
-            f_desc = self.schema_helper.get_function_description(name)
+        for name in sorted(h.function_properties.keys()):
+            props = h.get_function_properties(name)
+            reqs = h.get_function_required(name)
+            f_desc = h.get_function_description(name)
 
             ordered_args = []
             prop_details = []
             for p in props:
                 is_req = p in reqs
                 opt_suffix = "" if is_req else "?"
-                p_schema = self.schema_helper.get_property_schema(name, p)
+                p_schema = h.get_property_schema(name, p)
 
                 arg_label = f":{p}{opt_suffix}"
                 ordered_args.append(arg_label)

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/atom/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/atom/prompt_generator.py
@@ -149,8 +149,8 @@ class AtomPromptGenerator(PromptGenerator):
             helper = CatalogSchemaHelper(catalog)
         else:
             helper = self.schema_helper
-        comps = self.generate_component_signatures(helper=helper)
-        funcs = self.generate_function_signatures(helper=helper)
+        comps = self._generate_component_signatures(helper=helper)
+        funcs = self._generate_function_signatures(helper=helper)
         return (comps + ("\n\n" if funcs else "") + funcs).strip()
 
     def generate_examples(
@@ -207,8 +207,8 @@ class AtomPromptGenerator(PromptGenerator):
         parts.append(f"## Instructions:\n{rules}")
 
         if include_schema and self.schema_helper:
-            comp_sigs = self.generate_component_signatures()
-            func_sigs = self.generate_function_signatures()
+            comp_sigs = self._generate_component_signatures()
+            func_sigs = self._generate_function_signatures()
             if comp_sigs:
                 parts.append(f"## Component Catalog Signatures:\n{comp_sigs}")
             if func_sigs:
@@ -216,7 +216,7 @@ class AtomPromptGenerator(PromptGenerator):
 
         return "\n\n".join(parts)
 
-    def generate_component_signatures(self, helper: Optional[Any] = None) -> str:
+    def _generate_component_signatures(self, helper: Optional[Any] = None) -> str:
         """Compiles component definitions into S-expression signatures."""
         h = helper or self.schema_helper
         if not h:
@@ -261,7 +261,7 @@ class AtomPromptGenerator(PromptGenerator):
             signatures.append(sig)
         return "\n".join(signatures)
 
-    def generate_function_signatures(self, helper: Optional[Any] = None) -> str:
+    def _generate_function_signatures(self, helper: Optional[Any] = None) -> str:
         """Compiles function definitions into S-expression signatures."""
         h = helper or self.schema_helper
         if not h:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
@@ -123,6 +123,45 @@ class ElementalPromptGenerator(PromptGenerator):
         self.catalog_id: str = format_inst.catalog.catalog_id
         self.parser: Optional[ElementalParser] = None
 
+    def generate_base_rules(self) -> str:
+        """Returns core syntax rules for A2UI Elemental."""
+        return ELEMENTAL_RULES
+
+    def generate_catalog_instructions(
+        self,
+        include_schema: bool = True,
+        catalog: Optional[Any] = None,
+    ) -> str:
+        """Assembles TypeScript interfaces and catalog instructions."""
+        if not include_schema:
+            return ""
+        if catalog:
+            old_catalog = self.catalog
+            old_helper = self.helper
+            self.catalog = catalog
+            self.helper = CatalogSchemaHelper(catalog)
+            res = self.catalog_description(include_schema=True)
+            self.catalog = old_catalog
+            self.helper = old_helper
+            return res
+        return self.catalog_description(include_schema=True)
+
+    def generate_examples(
+        self,
+        catalog: Optional[Any] = None,
+        validate: bool = False,
+    ) -> str:
+        """Loads and formats few-shot Elemental examples."""
+        target_catalog = catalog or self.catalog
+        if not target_catalog or not self._format or not self._format.examples_path:
+            return ""
+        raw_examples = target_catalog.load_examples(
+            self._format.examples_path, validate=validate
+        )
+        if not raw_examples:
+            return ""
+        return self.transform_examples(raw_examples)
+
     def _map_schema_to_ts_type(
         self, component_name: str, prop_name: str, prop_schema: Any
     ) -> str:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
@@ -135,16 +135,7 @@ class ElementalPromptGenerator(PromptGenerator):
         """Assembles TypeScript interfaces and catalog instructions."""
         if not include_schema:
             return ""
-        if catalog:
-            old_catalog = self.catalog
-            old_helper = self.helper
-            self.catalog = catalog
-            self.helper = CatalogSchemaHelper(catalog)
-            res = self.catalog_description(include_schema=True)
-            self.catalog = old_catalog
-            self.helper = old_helper
-            return res
-        return self.catalog_description(include_schema=True)
+        return self.catalog_description(include_schema=True, catalog=catalog)
 
     def generate_examples(
         self,
@@ -158,6 +149,9 @@ class ElementalPromptGenerator(PromptGenerator):
         raw_examples = target_catalog.load_examples(
             self._format.examples_path, validate=validate
         )
+        if not raw_examples:
+            return ""
+        return self.transform_examples(raw_examples)
         if not raw_examples:
             return ""
         return self.transform_examples(raw_examples)
@@ -296,25 +290,30 @@ class ElementalPromptGenerator(PromptGenerator):
             lines.append(f"{indent}// {line}")
         return lines
 
-    def generate_component_declarations(self) -> str:
+    def generate_component_declarations(
+        self, helper: Optional[CatalogSchemaHelper] = None
+    ) -> str:
         """Compiles component definitions into TypeScript element interfaces.
 
         Returns:
             A string containing TypeScript interface declarations.
         """
+        h = helper or self.helper
+        if not h:
+            return ""
         declarations = []
-        for name in sorted(self.helper.component_properties.keys()):
-            props = self.helper.get_component_properties(name)
-            reqs = self.helper.get_component_required(name)
+        for name in sorted(h.component_properties.keys()):
+            props = h.get_component_properties(name)
+            reqs = h.get_component_required(name)
 
             # Find all action properties to handle renaming
             action_props = []
             for p in props:
-                p_schema = self.helper.get_property_schema(name, p)
+                p_schema = h.get_property_schema(name, p)
                 if _is_action(p_schema):
                     action_props.append(p)
 
-            comp_desc = self.helper.get_component_description(name)
+            comp_desc = h.get_component_description(name)
             interface_lines = []
             interface_lines.extend(self._to_comments(comp_desc))
             interface_lines.extend([
@@ -324,7 +323,7 @@ class ElementalPromptGenerator(PromptGenerator):
             ])
 
             for p in props:
-                p_schema = self.helper.get_property_schema(name, p)
+                p_schema = h.get_property_schema(name, p)
                 is_req = p in reqs
 
                 ts_prop_name = p
@@ -348,18 +347,23 @@ class ElementalPromptGenerator(PromptGenerator):
 
         return "\n\n".join(declarations)
 
-    def generate_function_declarations(self) -> str:
+    def generate_function_declarations(
+        self, helper: Optional[CatalogSchemaHelper] = None
+    ) -> str:
         """Compiles function definitions into TypeScript function declarations.
 
         Returns:
             A string containing TypeScript function declarations.
         """
+        h = helper or self.helper
+        if not h:
+            return ""
         declarations = []
-        for name in sorted(self.helper.function_properties.keys()):
-            props = self.helper.get_function_properties(name)
-            reqs = self.helper.get_function_required(name)
+        for name in sorted(h.function_properties.keys()):
+            props = h.get_function_properties(name)
+            reqs = h.get_function_required(name)
 
-            func_schema = self.helper.functions.get(name, {})
+            func_schema = h.functions.get(name, {})
             return_type = func_schema.get("returnType", "any")
             func_desc = func_schema.get("description")
 
@@ -502,11 +506,14 @@ class ElementalPromptGenerator(PromptGenerator):
 
         return "\n\n".join(parts)
 
-    def catalog_description(self, include_schema: bool = True) -> str:
+    def catalog_description(
+        self, include_schema: bool = True, catalog: Optional[Any] = None
+    ) -> str:
         """Assembles the system prompt component catalog signatures block.
 
         Args:
             include_schema: Whether to include the schema description.
+            catalog: Optional catalog override to render signatures for.
 
         Returns:
             The rendered LLM instructions string block containing TypeScript element declarations.
@@ -514,12 +521,11 @@ class ElementalPromptGenerator(PromptGenerator):
         if not include_schema:
             return ""
 
-        comp_decls = self.generate_component_declarations()
-        func_decls = self.generate_function_declarations()
+        h = CatalogSchemaHelper(catalog) if catalog else self.helper
+        comp_decls = self.generate_component_declarations(helper=h)
+        func_decls = self.generate_function_declarations(helper=h)
 
-        catalog_instructions = (
-            self.helper.catalog.get("instructions", "") if self.helper else ""
-        )
+        catalog_instructions = h.catalog.get("instructions", "") if h else ""
         if catalog_instructions:
             catalog_instructions = catalog_instructions.replace(
                 "specify any custom error messages directly in the check's 'message'"

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
@@ -135,7 +135,7 @@ class ElementalPromptGenerator(PromptGenerator):
         """Assembles TypeScript interfaces and catalog instructions."""
         if not include_schema:
             return ""
-        return self.catalog_description(include_schema=True, catalog=catalog)
+        return self._catalog_description(include_schema=True, catalog=catalog)
 
     def generate_examples(
         self,
@@ -290,7 +290,7 @@ class ElementalPromptGenerator(PromptGenerator):
             lines.append(f"{indent}// {line}")
         return lines
 
-    def generate_component_declarations(
+    def _generate_component_declarations(
         self, helper: Optional[CatalogSchemaHelper] = None
     ) -> str:
         """Compiles component definitions into TypeScript element interfaces.
@@ -347,7 +347,7 @@ class ElementalPromptGenerator(PromptGenerator):
 
         return "\n\n".join(declarations)
 
-    def generate_function_declarations(
+    def _generate_function_declarations(
         self, helper: Optional[CatalogSchemaHelper] = None
     ) -> str:
         """Compiles function definitions into TypeScript function declarations.
@@ -481,7 +481,7 @@ class ElementalPromptGenerator(PromptGenerator):
             self.catalog_id = catalog.catalog_id
             self.parser = ElementalParser(catalog)
 
-        prompt = self.catalog_description(include_schema=True)
+        prompt = self._catalog_description(include_schema=True)
 
         parts = [role_description]
 
@@ -506,7 +506,7 @@ class ElementalPromptGenerator(PromptGenerator):
 
         return "\n\n".join(parts)
 
-    def catalog_description(
+    def _catalog_description(
         self, include_schema: bool = True, catalog: Optional[Any] = None
     ) -> str:
         """Assembles the system prompt component catalog signatures block.
@@ -522,8 +522,8 @@ class ElementalPromptGenerator(PromptGenerator):
             return ""
 
         h = CatalogSchemaHelper(catalog) if catalog else self.helper
-        comp_decls = self.generate_component_declarations(helper=h)
-        func_decls = self.generate_function_declarations(helper=h)
+        comp_decls = self._generate_component_declarations(helper=h)
+        func_decls = self._generate_function_declarations(helper=h)
 
         catalog_instructions = h.catalog.get("instructions", "") if h else ""
         if catalog_instructions:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/elemental/prompt_generator.py
@@ -152,9 +152,6 @@ class ElementalPromptGenerator(PromptGenerator):
         if not raw_examples:
             return ""
         return self.transform_examples(raw_examples)
-        if not raw_examples:
-            return ""
-        return self.transform_examples(raw_examples)
 
     def _map_schema_to_ts_type(
         self, component_name: str, prop_name: str, prop_schema: Any

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/prompt_generator.py
@@ -158,7 +158,7 @@ class ExpressPromptGenerator(PromptGenerator):
         """Assembles positional signatures and instructions for a catalog."""
         if not include_schema:
             return ""
-        return self.catalog_description(include_schema=True, catalog=catalog)
+        return self._catalog_description(include_schema=True, catalog=catalog)
 
     def generate_examples(
         self,
@@ -176,7 +176,7 @@ class ExpressPromptGenerator(PromptGenerator):
             return ""
         return self.transform_examples(raw_examples)
 
-    def generate_component_signatures(
+    def _generate_component_signatures(
         self, helper: Optional[CatalogSchemaHelper] = None
     ) -> str:
         """Compiles component definitions into clean function-like signatures.
@@ -285,7 +285,7 @@ class ExpressPromptGenerator(PromptGenerator):
             signatures.append(sig)
         return "\n".join(signatures)
 
-    def generate_function_signatures(
+    def _generate_function_signatures(
         self, helper: Optional[CatalogSchemaHelper] = None
     ) -> str:
         """Compiles function definitions into clean signatures.
@@ -334,9 +334,9 @@ class ExpressPromptGenerator(PromptGenerator):
         return "\n".join(signatures)
 
     def _build_schema_prompt(self) -> str:
-        return self.catalog_description(include_schema=True)
+        return self._catalog_description(include_schema=True)
 
-    def catalog_description(
+    def _catalog_description(
         self, include_schema: bool = True, catalog: Optional[Any] = None
     ) -> str:
         """Assembles the system prompt component catalog signatures block.
@@ -352,8 +352,8 @@ class ExpressPromptGenerator(PromptGenerator):
             return ""
 
         h = CatalogSchemaHelper(catalog) if catalog else self.helper
-        comp_sigs = self.generate_component_signatures(helper=h)
-        func_sigs = self.generate_function_signatures(helper=h)
+        comp_sigs = self._generate_component_signatures(helper=h)
+        func_sigs = self._generate_function_signatures(helper=h)
         catalog_instructions = h.catalog.get("instructions", "") if h else ""
 
         # Translate json examples in catalog instructions into A2UI Express DSL

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/prompt_generator.py
@@ -158,13 +158,7 @@ class ExpressPromptGenerator(PromptGenerator):
         """Assembles positional signatures and instructions for a catalog."""
         if not include_schema:
             return ""
-        if catalog:
-            old_helper = self.helper
-            self.helper = CatalogSchemaHelper(catalog)
-            res = self.catalog_description(include_schema=True)
-            self.helper = old_helper
-            return res
-        return self.catalog_description(include_schema=True)
+        return self.catalog_description(include_schema=True, catalog=catalog)
 
     def generate_examples(
         self,
@@ -182,19 +176,24 @@ class ExpressPromptGenerator(PromptGenerator):
             return ""
         return self.transform_examples(raw_examples)
 
-    def generate_component_signatures(self) -> str:
+    def generate_component_signatures(
+        self, helper: Optional[CatalogSchemaHelper] = None
+    ) -> str:
         """Compiles component definitions into clean function-like signatures.
 
         Returns:
             A plain-text multi-line list of component signatures.
         """
+        h = helper or self.helper
+        if not h:
+            return ""
         signatures = []
-        for name in sorted(self.helper.component_properties.keys()):
-            props = self.helper.get_component_properties(name)
-            reqs = self.helper.get_component_required(name)
+        for name in sorted(h.component_properties.keys()):
+            props = h.get_component_properties(name)
+            reqs = h.get_component_required(name)
 
             # Retrieve component-level description
-            comp_desc = self.helper.get_component_description(name)
+            comp_desc = h.get_component_description(name)
 
             ordered_args = []
             prop_details = []
@@ -202,7 +201,7 @@ class ExpressPromptGenerator(PromptGenerator):
                 is_req = p in reqs
                 opt_suffix = "" if is_req else "?"
 
-                p_schema = self.helper.get_property_schema(name, p)
+                p_schema = h.get_property_schema(name, p)
 
                 # Determine signature argument label
                 arg_label = f"{p}{opt_suffix}"
@@ -286,24 +285,29 @@ class ExpressPromptGenerator(PromptGenerator):
             signatures.append(sig)
         return "\n".join(signatures)
 
-    def generate_function_signatures(self) -> str:
+    def generate_function_signatures(
+        self, helper: Optional[CatalogSchemaHelper] = None
+    ) -> str:
         """Compiles function definitions into clean signatures.
 
         Returns:
             A plain-text multi-line list of function signatures.
         """
+        h = helper or self.helper
+        if not h:
+            return ""
         signatures = []
-        for name in sorted(self.helper.function_properties.keys()):
-            props = self.helper.get_function_properties(name)
-            reqs = self.helper.get_function_required(name)
+        for name in sorted(h.function_properties.keys()):
+            props = h.get_function_properties(name)
+            reqs = h.get_function_required(name)
 
             # Retrieve function-level description
-            f_desc = self.helper.get_function_description(name)
+            f_desc = h.get_function_description(name)
 
             ordered_args = []
             prop_details = []
 
-            func_schema = self.helper.functions.get(name, {})
+            func_schema = h.functions.get(name, {})
             args_properties = (
                 func_schema.get("properties", {}).get("args", {}).get("properties", {})
             )
@@ -332,11 +336,14 @@ class ExpressPromptGenerator(PromptGenerator):
     def _build_schema_prompt(self) -> str:
         return self.catalog_description(include_schema=True)
 
-    def catalog_description(self, include_schema: bool = True) -> str:
+    def catalog_description(
+        self, include_schema: bool = True, catalog: Optional[Any] = None
+    ) -> str:
         """Assembles the system prompt component catalog signatures block.
 
         Args:
             include_schema: Whether to include the schema description.
+            catalog: Optional catalog override to render signatures for.
 
         Returns:
             The rendered LLM instructions string block containing positional signatures.
@@ -344,11 +351,10 @@ class ExpressPromptGenerator(PromptGenerator):
         if not include_schema:
             return ""
 
-        comp_sigs = self.generate_component_signatures()
-        func_sigs = self.generate_function_signatures()
-        catalog_instructions = (
-            self.helper.catalog.get("instructions", "") if self.helper else ""
-        )
+        h = CatalogSchemaHelper(catalog) if catalog else self.helper
+        comp_sigs = self.generate_component_signatures(helper=h)
+        func_sigs = self.generate_function_signatures(helper=h)
+        catalog_instructions = h.catalog.get("instructions", "") if h else ""
 
         # Translate json examples in catalog instructions into A2UI Express DSL
         if catalog_instructions:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/prompt_generator.py
@@ -146,6 +146,42 @@ class ExpressPromptGenerator(PromptGenerator):
         self.helper = CatalogSchemaHelper(format_inst.catalog)
         self.parser: Optional[ExpressParser] = None
 
+    def generate_base_rules(self) -> str:
+        """Returns the core syntax contract and grammar rules for A2UI Express."""
+        return EXPRESS_RULES
+
+    def generate_catalog_instructions(
+        self,
+        include_schema: bool = True,
+        catalog: Optional[Any] = None,
+    ) -> str:
+        """Assembles positional signatures and instructions for a catalog."""
+        if not include_schema:
+            return ""
+        if catalog:
+            old_helper = self.helper
+            self.helper = CatalogSchemaHelper(catalog)
+            res = self.catalog_description(include_schema=True)
+            self.helper = old_helper
+            return res
+        return self.catalog_description(include_schema=True)
+
+    def generate_examples(
+        self,
+        catalog: Optional[Any] = None,
+        validate: bool = False,
+    ) -> str:
+        """Loads and formats few-shot Express DSL examples."""
+        target_catalog = catalog or self.catalog
+        if not target_catalog or not self._format or not self._format.examples_path:
+            return ""
+        raw_examples = target_catalog.load_examples(
+            self._format.examples_path, validate=validate
+        )
+        if not raw_examples:
+            return ""
+        return self.transform_examples(raw_examples)
+
     def generate_component_signatures(self) -> str:
         """Compiles component definitions into clean function-like signatures.
 
@@ -486,26 +522,14 @@ class ExpressPromptGenerator(PromptGenerator):
             self.helper = CatalogSchemaHelper(catalog) if catalog else None
             self.parser = ExpressParser(catalog) if catalog else None
 
-        parts = [role_description]
-
-        rules = EXPRESS_RULES
-        if workflow_description:
-            rules += f"\n\n{workflow_description}"
-        parts.append(f"## Workflow Description:\n{rules}")
-
-        if ui_description:
-            parts.append(f"## UI Description:\n{ui_description}")
-
-        if include_schema and self.helper:
-            prompt = self._build_schema_prompt()
-            parts.append(prompt)
-
-        if include_examples and self._format and self._format.examples_path and catalog:
-            raw_examples = catalog.load_examples(
-                self._format.examples_path, validate=validate_examples
-            )
-            if raw_examples:
-                formatted_examples = self.transform_examples(raw_examples)
-                parts.append(f"### Examples:\n{formatted_examples}")
-
-        return "\n\n".join(parts)
+        return super().generate(
+            role_description=role_description,
+            workflow_description=workflow_description,
+            ui_description=ui_description,
+            client_ui_capabilities=client_ui_capabilities,
+            allowed_components=allowed_components,
+            allowed_messages=allowed_messages,
+            include_schema=include_schema,
+            include_examples=include_examples,
+            validate_examples=validate_examples,
+        )

--- a/agent_sdks/python/a2ui_agent/src/a2ui/prompt/generator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/prompt/generator.py
@@ -22,7 +22,46 @@ from a2ui.core.schema.client_capabilities import V09Capabilities
 class PromptGenerator(ABC):
     """Abstract base class for inference format prompt generators."""
 
-    @abstractmethod
+    def generate_base_rules(self) -> str:
+        """Returns the core syntax contract and grammar rules for the inference format.
+
+        Returns:
+            The core syntax rules string.
+        """
+        return ""
+
+    def generate_catalog_instructions(
+        self,
+        include_schema: bool = True,
+        catalog: Optional[Any] = None,
+    ) -> str:
+        """Returns component and function signatures or JSON schemas for a catalog.
+
+        Args:
+            include_schema: Whether to include schema details.
+            catalog: Optional target catalog instance.
+
+        Returns:
+            The catalog instructions string.
+        """
+        return ""
+
+    def generate_examples(
+        self,
+        catalog: Optional[Any] = None,
+        validate: bool = False,
+    ) -> str:
+        """Returns formatted few-shot examples for a catalog.
+
+        Args:
+            catalog: Optional target catalog instance.
+            validate: Whether to validate examples.
+
+        Returns:
+            The formatted few-shot examples string.
+        """
+        return ""
+
     def generate(
         self,
         role_description: str,
@@ -31,11 +70,11 @@ class PromptGenerator(ABC):
         client_ui_capabilities: Optional[Union[dict[str, Any], V09Capabilities]] = None,
         allowed_components: Optional[list[str]] = None,
         allowed_messages: Optional[list[str]] = None,
-        include_schema: bool = False,
+        include_schema: bool = True,
         include_examples: bool = False,
         validate_examples: bool = False,
     ) -> str:
-        """Assembles prompt instructions contract for standard JSON.
+        """Template Method: Assembles prompt instructions using sub-methods.
 
         Args:
             role_description: Description of the agent's role.
@@ -51,4 +90,30 @@ class PromptGenerator(ABC):
         Returns:
             The complete generated prompt system instruction.
         """
-        pass
+        parts = []
+
+        if role_description:
+            parts.append(role_description)
+
+        rules = self.generate_base_rules()
+        if workflow_description:
+            rules = (
+                f"{rules}\n\n{workflow_description}" if rules else workflow_description
+            )
+        if rules:
+            parts.append(f"## Workflow Description:\n{rules}")
+
+        if ui_description:
+            parts.append(f"## UI Description:\n{ui_description}")
+
+        if include_schema:
+            catalog_inst = self.generate_catalog_instructions(include_schema=True)
+            if catalog_inst:
+                parts.append(catalog_inst)
+
+        if include_examples:
+            examples = self.generate_examples(validate=validate_examples)
+            if examples:
+                parts.append(f"### Examples:\n{examples}")
+
+        return "\n\n".join(parts)

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -170,7 +170,7 @@ class A2uiCatalog:
     def from_config(cls, config: CatalogConfig, version: str = "1.0") -> A2uiCatalog:
         """Constructs an A2uiCatalog from a loaded CatalogConfig."""
         from a2ui.schema.constants import SPEC_VERSION_MAP, SERVER_TO_CLIENT_SCHEMA_KEY, COMMON_TYPES_SCHEMA_KEY
-        from a2ui.inference_formats.direct_json.format import load_from_bundled_resource
+        from a2ui.schema.utils import load_from_bundled_resource
 
         s2c_schema = load_from_bundled_resource(
             version, SERVER_TO_CLIENT_SCHEMA_KEY, SPEC_VERSION_MAP

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -166,6 +166,35 @@ class A2uiCatalog:
     custom_cuttable_keys: Optional[frozenset[str]] = None
     experiments: Optional[frozenset[str]] = None
 
+    @classmethod
+    def from_config(cls, config: CatalogConfig, version: str = "1.0") -> A2uiCatalog:
+        """Constructs an A2uiCatalog from a loaded CatalogConfig."""
+        from a2ui.schema.constants import SPEC_VERSION_MAP, SERVER_TO_CLIENT_SCHEMA_KEY, COMMON_TYPES_SCHEMA_KEY
+        from a2ui.inference_formats.direct_json.format import load_from_bundled_resource
+
+        s2c_schema = load_from_bundled_resource(
+            version, SERVER_TO_CLIENT_SCHEMA_KEY, SPEC_VERSION_MAP
+        )
+        common_types_schema = load_from_bundled_resource(
+            version, COMMON_TYPES_SCHEMA_KEY, SPEC_VERSION_MAP
+        )
+        catalog_schema = config.provider.load()
+        return cls(
+            version=version,
+            name=config.name,
+            catalog_schema=catalog_schema,
+            s2c_schema=s2c_schema,
+            common_types_schema=common_types_schema,
+            custom_cuttable_keys=config.custom_cuttable_keys,
+        )
+
+    @classmethod
+    def from_json_file(cls, path: str, name: Optional[str] = None) -> A2uiCatalog:
+        """Constructs an A2uiCatalog from a JSON file path."""
+        cat_name = name or os.path.basename(path).replace(".json", "")
+        config = CatalogConfig.from_path(cat_name, path)
+        return cls.from_config(config)
+
     @property
     def cuttable_keys(self) -> frozenset[str]:
         if self.custom_cuttable_keys is not None:

--- a/agent_sdks/python/a2ui_agent/tests/elemental/test_prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/tests/elemental/test_prompt_generator.py
@@ -145,14 +145,14 @@ class TestElementalPromptGenerator(unittest.TestCase):
     def test_catalog_description_before_generate(self):
         elemental_format = ElementalFormat(catalog=self.catalog)
         generator = elemental_format.prompt_generator
-        desc = generator.catalog_description(include_schema=True)
+        desc = generator.generate_catalog_instructions(include_schema=True)
         self.assertIn("interface Text {", desc)
 
     def test_catalog_description_no_schema(self):
         """Verifies catalog_description returns an empty string when include_schema is False."""
         fmt = ElementalFormat(catalog=self.catalog)
         generator = fmt.prompt_generator
-        desc = generator.catalog_description(include_schema=False)
+        desc = generator.generate_catalog_instructions(include_schema=False)
         self.assertEqual(desc, "")
 
     def test_catalog_description_initializes_helper_and_decompiles_instructions(self):
@@ -190,7 +190,7 @@ class TestElementalPromptGenerator(unittest.TestCase):
         fmt = ElementalFormat(catalog=custom_catalog)
         generator = fmt.prompt_generator
 
-        desc = generator.catalog_description(include_schema=True)
+        desc = generator.generate_catalog_instructions(include_schema=True)
 
         # Verify JSON block in catalog instructions is decompiled to HTML block
         self.assertIn("## Catalog Instructions", desc)
@@ -237,7 +237,7 @@ class TestElementalPromptGenerator(unittest.TestCase):
         fmt = ElementalFormat(catalog=custom_catalog)
         generator = fmt.prompt_generator
 
-        desc = generator.catalog_description(include_schema=True)
+        desc = generator.generate_catalog_instructions(include_schema=True)
 
         self.assertIn("## Catalog Instructions", desc)
         self.assertIn("```html", desc)

--- a/agent_sdks/python/a2ui_agent/tests/express/test_prompt_generator.py
+++ b/agent_sdks/python/a2ui_agent/tests/express/test_prompt_generator.py
@@ -74,7 +74,7 @@ class TestExpressPromptGenerator(unittest.TestCase):
     def test_catalog_description_before_generate(self):
         express_format = ExpressFormat(catalog=self.catalog)
         generator = express_format.prompt_generator
-        desc = generator.catalog_description(include_schema=True)
+        desc = generator.generate_catalog_instructions(include_schema=True)
         self.assertIn("Text(", desc)
 
     def test_express_allowed_components_pruning(self):
@@ -210,7 +210,7 @@ class TestExpressPromptGenerator(unittest.TestCase):
             },
         )
         fmt = ExpressFormat(catalog=cat_map_obj)
-        sigs = fmt.prompt_generator.generate_component_signatures()
+        sigs = fmt.prompt_generator._generate_component_signatures()
         self.assertIn("MapComp", sigs)
         self.assertIn("Map with keys:", sigs)
 

--- a/agent_sdks/python/a2ui_agent/tests/test_atom_format.py
+++ b/agent_sdks/python/a2ui_agent/tests/test_atom_format.py
@@ -389,7 +389,7 @@ class TestAtomFormat(unittest.TestCase):
         cat = direct_json_format.get_selected_catalog()
 
         fmt = AtomFormat(catalog=cat)
-        func_sigs = fmt.prompt_generator.generate_function_signatures()
+        func_sigs = fmt.prompt_generator._generate_function_signatures()
         self.assertIsInstance(func_sigs, str)
 
         # Test _get_schema_enum helper
@@ -818,7 +818,7 @@ class TestAtomFormat(unittest.TestCase):
 
         fmt = AtomFormat(catalog=cat)
         prompt_gen = fmt.prompt_generator
-        func_sigs = prompt_gen.generate_function_signatures()
+        func_sigs = prompt_gen._generate_function_signatures()
         self.assertIsInstance(func_sigs, str)
         prompt_full = prompt_gen.generate(include_schema=True, include_examples=True)
         self.assertIn("Instructions", prompt_full)
@@ -877,11 +877,11 @@ class TestAtomFormat(unittest.TestCase):
         pg = AtomPromptGenerator(mock_fmt)
         pg.schema_helper = mock_helper
 
-        comp_sigs = pg.generate_component_signatures()
+        comp_sigs = pg._generate_component_signatures()
         self.assertIn("- (CompA :prop1)", comp_sigs)
         self.assertIn("Must be one of: 'val1', 'val2'", comp_sigs)
 
-        func_sigs = pg.generate_function_signatures()
+        func_sigs = pg._generate_function_signatures()
         self.assertIn("- (FuncA :arg1?)", func_sigs)
         self.assertIn("Must be one of: 'val1', 'val2'", func_sigs)
 

--- a/agent_sdks/python/a2ui_agent/tests/test_formats.py
+++ b/agent_sdks/python/a2ui_agent/tests/test_formats.py
@@ -221,7 +221,7 @@ def test_decompiler_delegation(test_catalog):
         def generate(self, *args, **kwargs):
             return super().generate(*args, **kwargs)
 
-    assert DummyPromptGenerator().generate("role") is None
+    assert DummyPromptGenerator().generate("role") == "role"
 
     # Verify invalid catalog_id check
     bad_catalog = A2uiCatalog(


### PR DESCRIPTION
## Summary

Refactors the `PromptGenerator` abstraction in the Python Agent SDK (`agent_sdks/python/a2ui_agent`) to establish the Template Method pattern for prompt assembly and decompose prompt generation into clean, granular sub-methods (`generate_base_rules`, `generate_catalog_instructions`, `generate_examples`).

This refactoring allows callers (such as skill strategies, multi-catalog formats, or custom agent orchestrators) to extract granular prompt components (e.g., catalog signatures or syntax rules for a specific catalog) on demand without having to parse a monolithic prompt string.

## Key Changes

1. **Granular Sub-Method Decomposition & Template Method**:
   - Refactors `PromptGenerator.generate()` to compose role descriptions, workflow rules, catalog signatures, and few-shot examples using modular sub-methods:
     - `generate_base_rules()`: Returns format syntax/grammar rules.
     - `generate_catalog_instructions(include_schema=..., catalog=...)`: Returns component/function signatures or JSON schemas for a catalog.
     - `generate_examples(catalog=..., validate=...)`: Returns formatted few-shot examples.

2. **Stateless Catalog Instruction Generation**:
   - Eliminates instance variable overrides across `ExpressPromptGenerator`, `AtomPromptGenerator`, `ElementalPromptGenerator`, and `DirectJsonPromptGenerator`.
   - `generate_catalog_instructions(catalog=...)` accepts an optional `catalog` argument and derives a local `CatalogSchemaHelper(catalog)` without mutating `self.helper` or `self.catalog`.

3. **Multi-Catalog Support & Deduplication**:
   - `DirectJsonPromptGenerator.generate_catalog_instructions()` iterates over all configured catalogs using a single walrus assignment (`[inst for c in ... if (inst := c.render_as_llm_instructions())]`) to deduplicate calls while supporting multi-catalog rendering.

4. **Encapsulation & Format Attribute Initialization**:
   - Prefixes internal helper methods (`_generate_component_signatures`, `_generate_function_signatures`, `_generate_component_declarations`, `_generate_function_declarations`, `_catalog_description`) with a leading underscore to keep the public API clean.
   - Ensures `self._format = format_inst` is initialized across all prompt generators.

## Test Strategy & Verification

- `uv run pyink --check .`: Passed 100%.
- `uv run mypy agent_sdks/python/a2ui_agent/src/a2ui/`: Passed with 0 errors.
- `uv run pytest agent_sdks/python/a2ui_agent/tests/`: Passed 100% (589 / 589 passed).
