### PR TITLE
feat(macros): add programmatic macro runtime and type coercion engine

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/README.md
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/README.md
@@ -1,0 +1,105 @@
+# A2UI Macros
+
+Macros allow developers to expose high-level, domain-specific UI components to Large Language Models while compiling them into standard A2UI primitives on the server.
+
+## Overview
+
+When models generate raw A2UI component trees, complex or recurring UI patterns require verbose syntax. For example, rendering a product card with images, badges, pricing, and buy buttons requires authoring dozens of lines of nested JSON or DSL tokens.
+
+Macros solve this by allowing agents to output concise, high-level tags:
+
+```xml
+<ProductCard productId="sku_482" title="Trail Runner Shoes" price="$120" onBuy="checkout" />
+```
+
+Before transmitting messages to the client renderer, the `MacroParser` expands `<ProductCard ...>` into standard A2UI components (`Card`, `Column`, `Row`, `Text`, `Button`, `Action`) using a Python function registered with the `@macro` decorator. The client renderer receives standard protocol messages without needing custom client-side widget code.
+
+## The `@macro` annotation contract
+
+The `@macro` decorator inspects a Python function's type annotations and docstring to synthesize a catalog component JSON schema and an execution wrapper.
+
+```python
+from a2ui.inference_formats.experimental.macros import macro
+from a2ui.builder.catalogs.basic import Card, Column, Text, Button, Action
+
+@macro
+def product_card(
+    title: str,
+    price: str,
+    on_buy: Action,
+    in_stock: bool = True,
+) -> Card:
+    """Renders a product showcase card.
+
+    Args:
+        title: Display name of the product.
+        price: Formatted price string.
+        on_buy: Action triggered when the user clicks buy.
+        in_stock: Whether the item is available for purchase.
+    """
+    return Card(
+        child=Column(
+            children=[
+                Text(text=title, variant="h3"),
+                Text(text=price, variant="body"),
+                Button(
+                    child=Text(text="Buy Now" if in_stock else "Out of Stock"),
+                    action=on_buy,
+                    variant="primary",
+                ),
+            ]
+        )
+    )
+```
+
+### Parameter type mapping
+
+The decorator maps Python type hints to A2UI JSON schema definitions:
+
+- **Primitives**: `str`, `int`, `float`, and `bool` map to standard JSON schema types.
+- **Enums**: `Enum` subclasses or `Literal["a", "b"]` map to enum string schemas.
+- **Slots (Single Child)**: Parameters typed as `ComponentBuilderNode`, `Slot`, or concrete component classes (like `Text`) map to `#/$defs/ComponentId`. When the model passes a component ID or nested tag, `MacroProcessor` coerces the input into a `ComponentRef(id=...)`.
+- **Slot lists (Children)**: Parameters typed as `Sequence[ComponentBuilderNode]` or `SlotList` map to `#/$defs/ChildList`. Incoming ID arrays are coerced to lists of `ComponentRef`.
+- **Actions**: Parameters typed as `Action` map to `#/$defs/Action`.
+- **Data bindings**: Values passed as `{"path": "/..."}` are coerced into `DataBinding` objects.
+
+### Docstring contract
+
+`@macro` uses docstring inspection to generate LLM descriptions:
+
+- The summary line of the docstring becomes the `description` of the generated component in the catalog schema.
+- Parameter descriptions under `Args:`, `Arguments:`, or `Parameters:` are parsed and assigned as `description` attributes on each property schema.
+
+### Return type contract
+
+A macro function must return a `ComponentBuilderNode` (such as `Card`, `Column`, `Row`, or a custom subclass).
+
+During expansion:
+
+1. `MacroProcessor` calls the function with coerced arguments.
+2. The returned node hierarchy is flattened into component dictionaries via `tree.to_components()`.
+3. The root component of the returned tree inherits the macro's instance ID. Any parent components that referenced the macro now reference this root component seamlessly.
+
+## Integrating macros with inference formats
+
+Use `MacroInferenceFormat` to bind macros to an underlying syntax format (such as `ExpressFormat` or `ElementalFormat`):
+
+```python
+from a2ui.inference_formats.experimental.express import ExpressFormat
+from a2ui.inference_formats.experimental.macros import MacroInferenceFormat
+from a2ui.schema.catalog import A2uiCatalog
+
+# 1. Base format with base catalog
+base_format = ExpressFormat(catalog=catalog, surface_id="main")
+
+# 2. Wrap with MacroInferenceFormat
+format_with_macros = MacroInferenceFormat(
+    base_format=base_format,
+    macros=[product_card],
+)
+```
+
+`MacroInferenceFormat` handles two tasks:
+
+1. **Schema synthesis**: Automatically combines base catalog components with the macro schemas into a unified catalog, updating `#/$defs/anyComponent/oneOf`.
+2. **Parsing decoration**: Wraps the base parser with `MacroParser`, which intercepts parsed messages and expands macro instances before returning wire messages.

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/README.md
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/README.md
@@ -20,7 +20,7 @@ The `@macro` decorator inspects a Python function's type annotations and docstri
 
 ```python
 from a2ui.inference_formats.experimental.macros import macro
-from a2ui.builder.catalogs.basic import Card, Column, Text, Button, Action
+from a2ui.builder.v0_9.catalogs.basic_catalog import Card, Column, Text, Button, Action
 
 @macro
 def product_card(

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/__init__.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/__init__.py
@@ -1,0 +1,91 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A2UI Macros (Programmatic Components and Typesafe Builders)."""
+
+from a2ui.builder import (
+    AccessibilityAttributes,
+    Action,
+    CheckRule,
+    Child,
+    ChildList,
+    ComponentBuilderNode,
+    ComponentRef,
+    DataBinding,
+    DynamicBoolean,
+    DynamicChildList,
+    DynamicNumber,
+    DynamicString,
+    DynamicStringList,
+    DynamicValue,
+    ExternalComponentBuilderNode,
+    FunctionCall,
+    ComponentTree,
+    IdAllocator,
+    bind,
+    flatten_component_tree,
+)
+from a2ui.inference_formats.experimental.macros.format import (
+    MacroInferenceFormat,
+)
+from a2ui.inference_formats.experimental.macros.parser import (
+    MacroParser,
+)
+from a2ui.inference_formats.experimental.macros.macro import (
+    MacroMetadata,
+    MacroParameter,
+    clear_macros,
+    dynamic_template,
+    get_macro,
+    list_macros,
+    macro,
+    macro_component,
+    register_macro,
+)
+from a2ui.inference_formats.experimental.macros.processor import MacroProcessor
+
+__all__ = [
+    "macro",
+    "macro_component",
+    "dynamic_template",
+    "register_macro",
+    "get_macro",
+    "list_macros",
+    "clear_macros",
+    "MacroMetadata",
+    "MacroParameter",
+    "MacroProcessor",
+    "MacroInferenceFormat",
+    "MacroParser",
+    "AccessibilityAttributes",
+    "ComponentBuilderNode",
+    "ExternalComponentBuilderNode",
+    "ComponentRef",
+    "DataBinding",
+    "DynamicBoolean",
+    "DynamicChildList",
+    "DynamicNumber",
+    "DynamicString",
+    "DynamicStringList",
+    "DynamicValue",
+    "Child",
+    "ChildList",
+    "bind",
+    "FunctionCall",
+    "Action",
+    "CheckRule",
+    "IdAllocator",
+    "ComponentTree",
+    "flatten_component_tree",
+]

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/__init__.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/__init__.py
@@ -14,7 +14,7 @@
 
 """A2UI Macros (Programmatic Components and Typesafe Builders)."""
 
-from a2ui.builder import (
+from a2ui.builder.v0_9 import (
     AccessibilityAttributes,
     Action,
     CheckRule,

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/format.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/format.py
@@ -1,0 +1,167 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Macro inference format coordinating prompt generation and macro catalog synthesis."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Sequence, Union
+
+from a2ui.inference_format import InferenceFormat
+from a2ui.parser.parser import Parser
+from a2ui.prompt import PromptGenerator
+from a2ui.schema.catalog import A2uiCatalog
+from a2ui.schema.constants import (
+    COMMON_TYPES_SCHEMA_KEY,
+    SERVER_TO_CLIENT_SCHEMA_KEY,
+    SPEC_VERSION_MAP,
+)
+from a2ui.schema.utils import load_from_bundled_resource
+from google.adk.utils.feature_decorator import experimental
+
+from a2ui.inference_formats.experimental.macros.macro import (
+    MacroMetadata,
+    get_macro,
+    list_macros,
+)
+from a2ui.inference_formats.experimental.macros.parser import MacroParser
+from a2ui.inference_formats.experimental.macros.processor import MacroProcessor
+
+
+def _clean_version(version: str) -> str:
+    """Normalizes version string by removing leading 'v' if present."""
+    return version.lstrip("v")
+
+
+@experimental
+class MacroInferenceFormat(InferenceFormat):
+    """Inference format coordinating prompt generation and expansion of macros.
+
+    Wraps a base inference format (e.g. ExpressFormat, ElementalFormat),
+    synthesizes a unified catalog that combines base catalog components with
+    registered macro definitions, and returns a MacroParser that expands
+    macro component tags into standard A2UI wire messages.
+    """
+
+    def __init__(
+        self,
+        base_format: Optional[InferenceFormat] = None,
+        *,
+        catalog: Optional[Union[A2uiCatalog, dict[str, Any]]] = None,
+        macros: Optional[Sequence[Union[Callable[..., Any], MacroMetadata]]] = None,
+        surface_id: Optional[str] = None,
+        version: Optional[str] = None,
+    ):
+        """Initializes the macro inference format.
+
+        Args:
+            base_format: The underlying syntax format to wrap (e.g., ExpressFormat).
+            catalog: Optional override catalog. If omitted, uses base_format.catalog.
+            macros: Explicit sequence of macro functions or MacroMetadata objects.
+                If None, defaults to all globally registered macros.
+            surface_id: Target surface identifier for emitted envelopes.
+            version: A2UI protocol version (defaults to '0.9.1').
+
+        Raises:
+            ValueError: If base_format or a valid catalog is not provided.
+        """
+        if base_format is None:
+            raise ValueError(
+                "MacroInferenceFormat requires a base_format to be passed (e.g."
+                " MacroInferenceFormat(base_format=ExpressFormat(catalog=catalog,"
+                " surface_id='main')))."
+            )
+
+        self.surface_id = surface_id or getattr(base_format, "surface_id", "main")
+        raw_version = version or getattr(base_format, "version", "v0.9.1")
+        clean_v = _clean_version(raw_version)
+        if clean_v not in ("0.9", "0.9.1", "0.8", "1.0"):
+            clean_v = "0.9.1"
+        self.version = raw_version
+        self.processor = MacroProcessor()
+
+        # Ingest macros
+        if macros is not None:
+            self.macros: list[MacroMetadata] = []
+            for m in macros:
+                if isinstance(m, MacroMetadata):
+                    self.macros.append(m)
+                elif hasattr(m, "__a2ui_macro__"):
+                    self.macros.append(getattr(m, "__a2ui_macro__"))
+                elif callable(m):
+                    meta = get_macro(m.__name__) or get_macro(m.__name__.title())
+                    if meta:
+                        self.macros.append(meta)
+        else:
+            self.macros = list_macros()
+
+        # 1. Resolve base catalog from base_format or catalog parameter
+        extracted_catalog = catalog or getattr(base_format, "catalog", None)
+        if extracted_catalog is None:
+            raise ValueError(
+                "A catalog must be provided to MacroInferenceFormat (either via"
+                " base_format or as catalog=...). Inference formats must remain"
+                " catalog-agnostic."
+            )
+        elif isinstance(extracted_catalog, A2uiCatalog):
+            self.base_catalog = extracted_catalog
+        else:
+            s2c = load_from_bundled_resource(
+                clean_v, SERVER_TO_CLIENT_SCHEMA_KEY, SPEC_VERSION_MAP
+            )
+            common_types = load_from_bundled_resource(
+                clean_v, COMMON_TYPES_SCHEMA_KEY, SPEC_VERSION_MAP
+            )
+            self.base_catalog = A2uiCatalog(
+                version=self.version,
+                name="custom",
+                catalog_schema=extracted_catalog
+                if isinstance(extracted_catalog, dict)
+                else {},
+                s2c_schema=s2c,
+                common_types_schema=common_types,
+            )
+
+        # 2. Programmatically combine base catalog with macro component schemas
+        macro_components = {m.name: m.to_json_schema() for m in self.macros}
+        self.combined_catalog = self.base_catalog.with_components(macro_components)
+
+        # 3. Instantiate underlying inference format with the combined catalog
+        fmt_cls = base_format.__class__
+        try:
+            self.underlying_format = fmt_cls(
+                catalog=self.combined_catalog,
+                surface_id=self.surface_id,
+                version=self.version,
+                examples_path=getattr(base_format, "examples_path", None),
+            )
+        except Exception:
+            self.underlying_format = fmt_cls(
+                catalog=self.combined_catalog,
+                surface_id=self.surface_id,
+                version=self.version,
+            )
+
+    @property
+    def prompt_generator(self) -> PromptGenerator:
+        """Returns the prompt generator configured with combined catalog components."""
+        return self.underlying_format.prompt_generator
+
+    @property
+    def parser(self) -> Parser:
+        """Returns the MacroParser wrapping the underlying syntax parser."""
+        return MacroParser(self.underlying_format.parser, processor=self.processor)
+
+
+__all__ = ["MacroInferenceFormat", "MacroParser"]

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/macro.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/macro.py
@@ -1,0 +1,497 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections.abc
+from collections.abc import Iterable as AbcIterable, Sequence as AbcSequence
+from enum import Enum
+import inspect
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    Optional,
+    Sequence,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+from a2ui.builder import (
+    AccessibilityAttributes,
+    Action,
+    CheckRule,
+    ComponentBuilderNode,
+    ComponentRef,
+    DataBinding,
+    DynamicChildList,
+    ExternalComponentBuilderNode,
+    FunctionCall,
+)
+
+
+def _to_pascal_case(s: str) -> str:
+    """Converts a snake_case or identifier string to PascalCase."""
+    if not s:
+        return s
+    if s[0].isupper() and "_" not in s:
+        return s
+    return "".join(word.capitalize() for word in s.split("_") if word)
+
+
+def _parse_docstring(doc: Optional[str]) -> tuple[Optional[str], dict[str, str]]:
+    """Extracts top description and per-argument descriptions from Google/Sphinx style docstrings."""
+    if not doc:
+        return None, {}
+
+    cleaned = inspect.cleandoc(doc)
+    lines = cleaned.splitlines()
+
+    main_lines: list[str] = []
+    param_descriptions: dict[str, str] = {}
+
+    in_args = False
+    current_param: Optional[str] = None
+    current_desc: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        lowered = stripped.lower()
+        if lowered in ("args:", "arguments:", "parameters:"):
+            in_args = True
+            continue
+
+        if in_args:
+            # A non-indented section header ends the Args section
+            if stripped and not line.startswith(" ") and not line.startswith("\t"):
+                if current_param:
+                    param_descriptions[current_param] = " ".join(current_desc).strip()
+                    current_param = None
+                    current_desc = []
+                in_args = False
+                continue
+
+            # Match "param_name: description" or "param_name (type): description"
+            if ":" in stripped:
+                prefix, desc = stripped.split(":", 1)
+                name_part = prefix.split("(")[0].strip()
+                if name_part.isidentifier():
+                    if current_param:
+                        param_descriptions[current_param] = " ".join(
+                            current_desc
+                        ).strip()
+                    current_param = name_part
+                    current_desc = [desc.strip()]
+                    continue
+
+            if current_param:
+                current_desc.append(stripped)
+        else:
+            main_lines.append(line)
+
+    if current_param:
+        param_descriptions[current_param] = " ".join(current_desc).strip()
+
+    main_desc = "\n".join(main_lines).strip() or None
+    return main_desc, param_descriptions
+
+
+def _map_type_hint_to_schema(
+    t: Any, param_desc: Optional[str] = None
+) -> dict[str, Any]:
+    """Maps a Python type hint to a canonical A2UI JSON schema property."""
+    COMMON_REF_PREFIX = "https://a2ui.org/specification/v0_9/common_types.json#/$defs/"
+
+    origin = get_origin(t)
+    args = get_args(t)
+
+    # Handle Optional[T] / Union[T, None] / Dynamic Unions
+    if origin is Union:
+        non_none_args = [a for a in args if a is not type(None)]
+        if len(non_none_args) == 1:
+            return _map_type_hint_to_schema(non_none_args[0], param_desc)
+
+        has_binding = any(
+            a is DataBinding or (isinstance(a, type) and issubclass(a, DataBinding))
+            for a in non_none_args
+        )
+        has_func = any(
+            a is FunctionCall or (isinstance(a, type) and issubclass(a, FunctionCall))
+            for a in non_none_args
+        )
+        types_set = set(non_none_args)
+
+        if has_binding or has_func:
+            if (
+                str in types_set
+                and len(types_set - {str, DataBinding, FunctionCall}) == 0
+            ):
+                schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicString"}
+                if param_desc:
+                    schema["description"] = param_desc
+                return schema
+            elif (int in types_set or float in types_set) and len(
+                types_set - {int, float, DataBinding, FunctionCall}
+            ) == 0:
+                schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicNumber"}
+                if param_desc:
+                    schema["description"] = param_desc
+                return schema
+            elif (
+                bool in types_set
+                and len(types_set - {bool, DataBinding, FunctionCall}) == 0
+            ):
+                schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicBoolean"}
+                if param_desc:
+                    schema["description"] = param_desc
+                return schema
+            elif any(
+                get_origin(a) in (list, Sequence, AbcSequence, tuple, set)
+                for a in types_set
+            ):
+                schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicStringList"}
+                if param_desc:
+                    schema["description"] = param_desc
+                return schema
+            elif any(
+                a
+                in (
+                    ComponentBuilderNode,
+                    ComponentRef,
+                    ExternalComponentBuilderNode,
+                )
+                or (isinstance(a, type) and issubclass(a, ComponentBuilderNode))
+                for a in types_set
+            ):
+                if any(
+                    get_origin(a) in (list, Sequence, AbcSequence, tuple, set)
+                    or a is DynamicChildList
+                    for a in types_set
+                ):
+                    schema = {"$ref": f"{COMMON_REF_PREFIX}ChildList"}
+                    if param_desc:
+                        schema["description"] = param_desc
+                    return schema
+                else:
+                    schema = {"$ref": f"{COMMON_REF_PREFIX}ComponentId"}
+                    if param_desc:
+                        schema["description"] = param_desc
+                    return schema
+            else:
+                schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicValue"}
+                if param_desc:
+                    schema["description"] = param_desc
+                return schema
+
+        if any(
+            a
+            in (
+                ComponentBuilderNode,
+                ComponentRef,
+                ExternalComponentBuilderNode,
+            )
+            or (isinstance(a, type) and issubclass(a, ComponentBuilderNode))
+            for a in types_set
+        ) and any(
+            get_origin(a) in (list, Sequence, AbcSequence, tuple, set)
+            or a is DynamicChildList
+            for a in types_set
+        ):
+            schema = {"$ref": f"{COMMON_REF_PREFIX}ChildList"}
+            if param_desc:
+                schema["description"] = param_desc
+            return schema
+
+    # Literal strings or numbers
+    if origin is Literal:
+        literal_vals = list(args)
+        if all(isinstance(v, str) for v in literal_vals):
+            schema = {"type": "string", "enum": literal_vals}
+            if param_desc:
+                schema["description"] = param_desc
+            return schema
+        elif all(isinstance(v, (int, float)) for v in literal_vals):
+            schema = {"type": "number", "enum": literal_vals}
+            if param_desc:
+                schema["description"] = param_desc
+            return schema
+        else:
+            schema = {"enum": literal_vals}
+            if param_desc:
+                schema["description"] = param_desc
+            return schema
+
+    # Enum subclasses
+    if isinstance(t, type) and issubclass(t, Enum):
+        schema = {"type": "string", "enum": [e.value for e in t]}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+
+    # Direct Protocol References
+    if t is DataBinding:
+        schema = {"$ref": f"{COMMON_REF_PREFIX}DataBinding"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is Action:
+        schema = {"$ref": f"{COMMON_REF_PREFIX}Action"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is CheckRule:
+        schema = {"$ref": f"{COMMON_REF_PREFIX}CheckRule"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is AccessibilityAttributes:
+        schema = {"$ref": f"{COMMON_REF_PREFIX}AccessibilityAttributes"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is FunctionCall:
+        schema = {"$ref": f"{COMMON_REF_PREFIX}FunctionCall"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is DynamicChildList:
+        schema = {"$ref": f"{COMMON_REF_PREFIX}ChildList"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+
+    # Single Child Slots
+    if t in (
+        ComponentBuilderNode,
+        ExternalComponentBuilderNode,
+        ComponentRef,
+    ) or (isinstance(t, type) and issubclass(t, ComponentBuilderNode)):
+        schema = {
+            "$ref": f"{COMMON_REF_PREFIX}ComponentId",
+            "description": (
+                param_desc or "ID of the child component to place in this slot."
+            ),
+        }
+        return schema
+
+    # Child List Slots
+    if (
+        origin in (list, Sequence, AbcSequence, tuple, set)
+        and args
+        and (
+            args[0]
+            in (ComponentBuilderNode, ExternalComponentBuilderNode, ComponentRef)
+            or (isinstance(args[0], type) and issubclass(args[0], ComponentBuilderNode))
+        )
+    ):
+        schema = {"$ref": f"{COMMON_REF_PREFIX}ChildList"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+
+    # Primitives
+    if t is str:
+        schema = {"type": "string"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is int:
+        schema = {"type": "integer"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is float:
+        schema = {"type": "number"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+    if t is bool:
+        schema = {"type": "boolean"}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+
+    # Arrays
+    if origin in (list, Sequence, AbcSequence, tuple, set):
+        item_schema = _map_type_hint_to_schema(args[0]) if args else {"type": "string"}
+        schema = {"type": "array", "items": item_schema}
+        if param_desc:
+            schema["description"] = param_desc
+        return schema
+
+    schema = {"type": "string"}
+    if param_desc:
+        schema["description"] = param_desc
+    return schema
+
+
+@dataclass(frozen=True)
+class MacroParameter:
+    """Describes a parameter accepted by a macro."""
+
+    name: str
+    type_hint: Any
+    required: bool
+    default: Any = inspect.Parameter.empty
+    description: Optional[str] = None
+
+
+@dataclass
+class MacroMetadata:
+    """Metadata for a registered macro."""
+
+    name: str
+    description: Optional[str]
+    func: Callable[..., Any]
+    parameters: dict[str, MacroParameter]
+    return_type: Any
+
+    def to_json_schema(self) -> dict[str, Any]:
+        """Generates a JSON Schema tool definition for this macro."""
+        props: dict[str, Any] = {}
+        required: list[str] = []
+
+        for p_name, param in self.parameters.items():
+            prop_schema = _map_type_hint_to_schema(param.type_hint, param.description)
+            props[p_name] = prop_schema
+            if param.required:
+                required.append(p_name)
+
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": props,
+        }
+        if required:
+            schema["required"] = required
+        if self.description:
+            schema["description"] = self.description
+        return schema
+
+
+_MACRO_REGISTRY: dict[str, MacroMetadata] = {}
+
+
+def register_macro(
+    func: Callable[..., Any],
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Registers a Python function as an A2UI macro."""
+    macro_name = name or _to_pascal_case(func.__name__)
+    raw_doc = inspect.getdoc(func)
+    parsed_main_desc, param_docs = _parse_docstring(raw_doc)
+    doc = description or parsed_main_desc
+
+    sig = inspect.signature(func)
+    try:
+        hints = get_type_hints(func)
+    except Exception:
+        hints = {}
+
+    params: dict[str, MacroParameter] = {}
+    for p_name, param in sig.parameters.items():
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        type_hint = hints.get(p_name, Any)
+        is_req = param.default is inspect.Parameter.empty
+        param_desc = (
+            param_docs.get(p_name)
+            or param_docs.get(p_name.lower())
+            or p_name.replace("_", " ").capitalize()
+        )
+        params[p_name] = MacroParameter(
+            name=p_name,
+            type_hint=type_hint,
+            required=is_req,
+            default=param.default,
+            description=param_desc,
+        )
+
+    ret_type = hints.get("return", sig.return_annotation)
+
+    meta = MacroMetadata(
+        name=macro_name,
+        description=doc,
+        func=func,
+        parameters=params,
+        return_type=ret_type,
+    )
+    _MACRO_REGISTRY[macro_name] = meta
+    _MACRO_REGISTRY[func.__name__] = meta
+    func.__a2ui_macro__ = meta  # type: ignore[attr-defined]
+    return func
+
+
+def macro(
+    name: Optional[Union[str, Callable[..., Any]]] = None,
+    description: Optional[str] = None,
+) -> Any:
+    """Decorator to define an A2UI macro.
+
+    Can be used bare (@macro), with an explicit name (@macro("SalaryCard")),
+    or with keyword arguments (@macro(name="SalaryCard", description="...")).
+
+    Example:
+        @macro
+        def UserProfile(name: str, role: str) -> Card:
+            '''User summary card.
+
+            Args:
+                name: User's display name.
+                role: User's job title.
+            '''
+            return Card(child=Column(children=[Text(text=name), Text(text=role)]))
+    """
+    if callable(name):
+        return register_macro(name)
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        return register_macro(func, name=name, description=description)
+
+    return decorator
+
+
+# Backward-compatible aliases
+macro_component = macro
+dynamic_template = macro
+
+
+def get_macro(name: str) -> Optional[MacroMetadata]:
+    """Retrieves a registered macro by name."""
+    return _MACRO_REGISTRY.get(name)
+
+
+def list_macros() -> list[MacroMetadata]:
+    """Returns all currently registered unique macros."""
+    seen: set[str] = set()
+    res: list[MacroMetadata] = []
+    for m in _MACRO_REGISTRY.values():
+        if m.name not in seen:
+            seen.add(m.name)
+            res.append(m)
+    return res
+
+
+def get_all_macros() -> list[MacroMetadata]:
+    """Alias for list_macros()."""
+    return list_macros()
+
+
+def clear_macros() -> None:
+    """Clears the global macro registry."""
+    _MACRO_REGISTRY.clear()

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/macro.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/macro.py
@@ -29,7 +29,8 @@ from typing import (
     get_type_hints,
 )
 
-from a2ui.builder import (
+from a2ui.builder.v0_9 import (
+    A2uiExpression,
     AccessibilityAttributes,
     Action,
     CheckRule,
@@ -124,7 +125,8 @@ def _map_type_hint_to_schema(
             return _map_type_hint_to_schema(non_none_args[0], param_desc)
 
         has_binding = any(
-            a is DataBinding or (isinstance(a, type) and issubclass(a, DataBinding))
+            a in (A2uiExpression, DataBinding)
+            or (isinstance(a, type) and issubclass(a, (A2uiExpression, DataBinding)))
             for a in non_none_args
         )
         has_func = any(
@@ -132,18 +134,19 @@ def _map_type_hint_to_schema(
             for a in non_none_args
         )
         types_set = set(non_none_args)
+        expr_types = {A2uiExpression, DataBinding, FunctionCall}
 
         if has_binding or has_func:
             if (
                 str in types_set
-                and len(types_set - {str, DataBinding, FunctionCall}) == 0
+                and len(types_set - (expr_types | {str})) == 0
             ):
                 schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicString"}
                 if param_desc:
                     schema["description"] = param_desc
                 return schema
             elif (int in types_set or float in types_set) and len(
-                types_set - {int, float, DataBinding, FunctionCall}
+                types_set - (expr_types | {int, float})
             ) == 0:
                 schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicNumber"}
                 if param_desc:
@@ -151,7 +154,7 @@ def _map_type_hint_to_schema(
                 return schema
             elif (
                 bool in types_set
-                and len(types_set - {bool, DataBinding, FunctionCall}) == 0
+                and len(types_set - (expr_types | {bool})) == 0
             ):
                 schema = {"$ref": f"{COMMON_REF_PREFIX}DynamicBoolean"}
                 if param_desc:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/parser.py
@@ -1,0 +1,188 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parser decorator expanding macro components into standard A2UI wire messages."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from a2ui.parser.parser import Parser
+from a2ui.parser.response_part import ResponsePart
+
+from a2ui.inference_formats.experimental.macros.processor import MacroProcessor
+
+
+class MacroParser(Parser):
+    """Parser decorator that intercepts parsed A2UI messages and expands macros.
+
+    Wraps an underlying inference format parser (such as ExpressParser or
+    ElementalParser). When the underlying parser produces A2UI wire messages
+    containing macro components, MacroParser detects registered macro names,
+    executes their expansion functions via MacroProcessor, and splices the
+    resulting standard A2UI components into the message envelope.
+    """
+
+    def __init__(
+        self,
+        underlying_parser: Parser,
+        processor: Optional[MacroProcessor] = None,
+    ):
+        """Initializes the macro parser.
+
+        Args:
+            underlying_parser: The base syntax parser producing raw A2UI messages.
+            processor: The macro execution processor. If None, a new
+                MacroProcessor is instantiated.
+        """
+        self.underlying_parser = underlying_parser
+        self.processor = processor or MacroProcessor()
+
+    def has_format_content(self, content: str, *, complete: bool = False) -> bool:
+        """Checks whether the input text contains recognizable format markup.
+
+        Delegates directly to the underlying syntax parser.
+
+        Args:
+            content: Raw model output text.
+            complete: Whether the content represents a completed response stream.
+
+        Returns:
+            True if the underlying parser detects format content.
+        """
+        return self.underlying_parser.has_format_content(content, complete=complete)
+
+    def unwrap(self, content: str) -> List[ResponsePart]:
+        """Unwraps model response text into conversational and UI parts.
+
+        Delegates to the underlying parser to separate format markup from
+        natural language commentary.
+
+        Args:
+            content: Full or partial text from the model.
+
+        Returns:
+            List of ResponsePart objects.
+        """
+        return self.underlying_parser.unwrap(content)
+
+    @property
+    def supports_streaming(self) -> bool:
+        """Indicates whether the underlying parser supports streaming chunks."""
+        return self.underlying_parser.supports_streaming
+
+    def decompile(self, val: Any) -> str:
+        """Decompiles an A2UI component or value back into format syntax.
+
+        Args:
+            val: A component dictionary or value.
+
+        Returns:
+            String representation in the underlying format's DSL.
+        """
+        return self.underlying_parser.decompile(val)
+
+    def _expand_component_list(self, components: List[Any]) -> List[Dict[str, Any]]:
+        """Recursively expands any macro components found in a component list.
+
+        Args:
+            components: List of component dictionaries from an A2UI message.
+
+        Returns:
+            A new list of component dictionaries with macros expanded and
+            spliced in place.
+        """
+        expanded: List[Dict[str, Any]] = []
+        for comp in components:
+            if not isinstance(comp, dict):
+                expanded.append(comp)
+                continue
+
+            c_name = comp.get("component")
+            c_id = comp.get("id")
+
+            if c_name and self.processor.has_macro(c_name):
+                params = {k: v for k, v in comp.items() if k not in ("component", "id")}
+                try:
+                    expanded_macro = self.processor.expand(
+                        c_name, params, instance_id=c_id
+                    )
+                    # Spliced components may themselves contain macros
+                    expanded.extend(self._expand_component_list(expanded_macro))
+                except Exception:
+                    expanded.append(comp)
+            else:
+                expanded.append(comp)
+        return expanded
+
+    def compile(
+        self, format_content: str, *, is_final: bool = True
+    ) -> List[Dict[str, Any]]:
+        """Compiles format content into A2UI wire messages with macros expanded.
+
+        Invokes the underlying parser to compile syntax into initial A2UI
+        envelopes, then traverses each message to expand any macro components.
+
+        Args:
+            format_content: DSL markup extracted from the model response.
+            is_final: Whether this represents the final chunk of a stream.
+
+        Returns:
+            List of valid A2UI message dictionaries ready for transport.
+        """
+        raw_msgs = self.underlying_parser.compile(format_content, is_final=is_final)
+        expanded_msgs: List[Dict[str, Any]] = []
+
+        for msg in raw_msgs:
+            if not isinstance(msg, dict):
+                expanded_msgs.append(msg)
+                continue
+
+            if "surfaceUpdate" in msg and isinstance(msg["surfaceUpdate"], dict):
+                surf = msg["surfaceUpdate"]
+                comps = surf.get("components", [])
+                new_msg = dict(msg)
+                new_surf = dict(surf)
+                new_surf["components"] = self._expand_component_list(comps)
+                new_msg["surfaceUpdate"] = new_surf
+                expanded_msgs.append(new_msg)
+
+            elif "updateComponents" in msg and isinstance(
+                msg["updateComponents"], dict
+            ):
+                upd = msg["updateComponents"]
+                comps = upd.get("components", [])
+                new_msg = dict(msg)
+                new_upd = dict(upd)
+                new_upd["components"] = self._expand_component_list(comps)
+                new_msg["updateComponents"] = new_upd
+                expanded_msgs.append(new_msg)
+
+            elif (
+                "createSurface" in msg
+                and isinstance(msg["createSurface"], dict)
+                and "components" in msg["createSurface"]
+            ):
+                cs = msg["createSurface"]
+                comps = cs.get("components", [])
+                new_msg = dict(msg)
+                new_cs = dict(cs)
+                new_cs["components"] = self._expand_component_list(comps)
+                new_msg["createSurface"] = new_cs
+                expanded_msgs.append(new_msg)
+
+            else:
+                expanded_msgs.append(msg)
+
+        return expanded_msgs

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/processor.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/processor.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime expansion processor for A2UI macros."""
+
+from typing import Any, Optional, Sequence, Union
+
+from a2ui.builder import (
+    AccessibilityAttributes,
+    Action,
+    ComponentBuilderNode,
+    ComponentRef,
+    DataBinding,
+    ExternalComponentBuilderNode,
+    flatten_component_tree,
+)
+from a2ui.inference_formats.experimental.macros.macro import get_macro
+
+
+class MacroProcessor:
+    """Executes registered macros and flattens them into standard A2UI components."""
+
+    def has_macro(self, macro_name: str) -> bool:
+        """Checks if a macro is registered by name."""
+        return get_macro(macro_name) is not None
+
+    def expand(
+        self,
+        macro_name: str,
+        args: dict[str, Any],
+        instance_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """Executes a macro by name with provided arguments and returns flat component dicts.
+
+        Args:
+            macro_name: The registered macro function name.
+            args: Keyword arguments for the macro invocation.
+            instance_id: The ID assigned to this macro component instance (becomes root component ID).
+
+        Returns:
+            List of standard A2UI component dictionaries ready for surfaceUpdate.
+        """
+        root_id = instance_id
+        meta = get_macro(macro_name)
+        if meta is None:
+            raise KeyError(f"Macro '{macro_name}' is not registered.")
+
+        # Coerce parameters from incoming JSON values to rich builder AST types
+        coerced_args: dict[str, Any] = {}
+        for p_name, p_val in args.items():
+            if p_name in meta.parameters:
+                p_meta = meta.parameters[p_name]
+                t = p_meta.type_hint
+
+                # 1. Coerce single child slot from string ID to ComponentRef
+                if isinstance(p_val, str) and (
+                    t
+                    in (
+                        ComponentBuilderNode,
+                        ExternalComponentBuilderNode,
+                        ComponentRef,
+                        Optional[ComponentBuilderNode],
+                        Optional[ComponentRef],
+                    )
+                    or (isinstance(t, type) and issubclass(t, ComponentBuilderNode))
+                ):
+                    coerced_args[p_name] = ComponentRef(id=p_val)
+
+                # 2. Coerce child slot list from sequence of IDs to ComponentRefs
+                elif isinstance(p_val, (list, tuple)) and (
+                    t
+                    in (
+                        Sequence[ComponentBuilderNode],
+                        list[ComponentBuilderNode],
+                        Optional[Sequence[ComponentBuilderNode]],
+                    )
+                ):
+                    coerced_args[p_name] = [
+                        ComponentRef(id=x) if isinstance(x, str) else x for x in p_val
+                    ]
+
+                # 3. Coerce DataBinding dictionary: {"path": "/..."}
+                elif (
+                    isinstance(p_val, dict)
+                    and "path" in p_val
+                    and len(p_val) == 1
+                    and not isinstance(p_val, DataBinding)
+                ):
+                    coerced_args[p_name] = DataBinding(path=p_val["path"])
+
+                # 4. Coerce Action string or dict
+                elif isinstance(p_val, str) and t in (Action, Optional[Action]):
+                    coerced_args[p_name] = Action(event=p_val)
+                elif (
+                    isinstance(p_val, dict)
+                    and t in (Action, Optional[Action])
+                    and not isinstance(p_val, Action)
+                ):
+                    if "event" in p_val:
+                        coerced_args[p_name] = Action(event=p_val["event"])
+                    elif "name" in p_val:
+                        coerced_args[p_name] = Action(event=p_val)
+                    else:
+                        coerced_args[p_name] = Action(event=p_val)
+
+                # 5. Coerce AccessibilityAttributes
+                elif (
+                    isinstance(p_val, dict)
+                    and t
+                    in (AccessibilityAttributes, Optional[AccessibilityAttributes])
+                    and not isinstance(p_val, AccessibilityAttributes)
+                ):
+                    coerced_args[p_name] = AccessibilityAttributes(**p_val)
+
+                else:
+                    coerced_args[p_name] = p_val
+            else:
+                coerced_args[p_name] = p_val
+
+        # Execute macro layout function
+        result = meta.func(**coerced_args)
+
+        if not isinstance(result, (ComponentBuilderNode, Sequence)):
+            raise TypeError(
+                f"Macro '{macro_name}' must return a ComponentBuilderNode or Sequence"
+                f" of nodes, got {type(result)}."
+            )
+
+        # Flatten into primitive components with ID namespacing and root stitching
+        return flatten_component_tree(result, root_id=root_id)

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/processor.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/processor.py
@@ -16,7 +16,7 @@
 
 from typing import Any, Optional, Sequence, Union
 
-from a2ui.builder import (
+from a2ui.builder.v0_9 import (
     AccessibilityAttributes,
     Action,
     ComponentBuilderNode,

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -246,6 +246,43 @@ class A2uiCatalog:
 
         return replace(self, catalog_schema=schema_copy)
 
+    def with_components(
+        self,
+        additional_components: Dict[str, Dict[str, Any]],
+        *,
+        catalog_name: Optional[str] = None,
+    ) -> A2uiCatalog:
+        """Returns a new catalog that incorporates additional component schemas.
+
+        Combines the current catalog's components with the supplied components,
+        automatically registering them in components and #/$defs/anyComponent/oneOf
+        without requiring manual JSON schema mutation.
+
+        Args:
+          additional_components: Mapping of component name to JSON schema dict.
+          catalog_name: Optional new catalog name. Defaults to existing name.
+
+        Returns:
+          A new A2uiCatalog instance containing both sets of components.
+        """
+        schema_copy = copy.deepcopy(self.catalog_schema)
+        comps_map = dict(schema_copy.get(CATALOG_COMPONENTS_KEY, {}))
+        defs_map = schema_copy.setdefault("$defs", {})
+        any_comp_refs = defs_map.setdefault("anyComponent", {}).setdefault("oneOf", [])
+
+        for name, comp_schema in additional_components.items():
+            comps_map[name] = comp_schema
+            ref_entry = {"$ref": f"#/{CATALOG_COMPONENTS_KEY}/{name}"}
+            if ref_entry not in any_comp_refs:
+                any_comp_refs.append(ref_entry)
+
+        schema_copy[CATALOG_COMPONENTS_KEY] = comps_map
+        return replace(
+            self,
+            name=catalog_name or self.name,
+            catalog_schema=schema_copy,
+        )
+
     def _with_pruned_messages(self, allowed_messages: List[str]) -> A2uiCatalog:
         """Returns a new catalog with only allowed messages.
 

--- a/agent_sdks/python/a2ui_agent/tests/test_macros.py
+++ b/agent_sdks/python/a2ui_agent/tests/test_macros.py
@@ -1,0 +1,637 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exhaustive unit tests for A2UI Macros and Typesafe Builders."""
+
+import pytest
+from enum import Enum
+from typing import Any, Literal, Optional, Sequence, Union
+
+from a2ui.inference_formats.experimental.macros import (
+    AccessibilityAttributes,
+    Action,
+    CheckRule,
+    Child,
+    ChildList,
+    ComponentBuilderNode,
+    ComponentRef,
+    DataBinding,
+    DynamicBoolean,
+    DynamicChildList,
+    DynamicNumber,
+    DynamicString,
+    DynamicStringList,
+    DynamicValue,
+    ExternalComponentBuilderNode,
+    FunctionCall,
+    MacroInferenceFormat,
+    MacroProcessor,
+    ComponentTree,
+    bind,
+    clear_macros,
+    flatten_component_tree,
+    get_macro,
+    list_macros,
+    macro,
+)
+from a2ui.schema.catalog import A2uiCatalog
+from a2ui.builder.catalogs.basic import (
+    Button,
+    Card,
+    Column,
+    Row,
+    Text,
+)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_macros():
+    clear_macros()
+    yield
+    clear_macros()
+
+
+def test_data_binding():
+    b1 = bind("user/name")
+    assert b1.to_dict() == {"path": "/user/name"}
+
+    b2 = bind("/user/name")
+    assert b2.to_dict() == {"path": "/user/name"}
+
+
+def test_function_call_and_action():
+    fn = FunctionCall(call="formatString", args={"value": "Hello ${/user/name}"})
+    assert fn.to_dict() == {
+        "call": "formatString",
+        "args": {"value": "Hello ${/user/name}"},
+    }
+
+    action_fn = Action(function=fn)
+    assert action_fn.to_dict() == {
+        "function": {
+            "call": "formatString",
+            "args": {"value": "Hello ${/user/name}"},
+        }
+    }
+
+    action_ev = Action(event={"name": "submit_form", "data": {"id": 123}})
+    assert action_ev.to_dict() == {
+        "event": {"name": "submit_form", "data": {"id": 123}}
+    }
+
+
+def test_check_rule():
+    cond = FunctionCall(call="regex", args={"pattern": "^[A-Z]"})
+    rule = CheckRule(condition=cond, message="Must start with uppercase letter")
+    assert rule.to_dict() == {
+        "condition": {"call": "regex", "args": {"pattern": "^[A-Z]"}},
+        "message": "Must start with uppercase letter",
+    }
+
+
+def test_dynamic_child_list():
+    template = Card(child=Text(text=bind("item/title")))
+    dyn = DynamicChildList(data_model_path="items", template=template)
+    d = dyn.to_dict()
+    assert d["dataModelPath"] == "/items"
+    assert "template" in d
+    assert d["template"]["component"] == "Card"
+
+
+def test_flatten_single_node():
+    txt = Text(text="Hello World", variant="h1")
+    flat = flatten_component_tree(txt, root_id="header")
+    assert len(flat) == 1
+    assert flat[0]["component"] == "Text"
+    assert flat[0]["id"] == "header"
+    assert flat[0]["text"] == "Hello World"
+    assert flat[0]["variant"] == "h1"
+
+
+def test_flatten_nested_tree_with_root_anchor_and_namespacing():
+    tree = Card(
+        child=Column(
+            children=[
+                Text(text="Profile", variant="h2"),
+                Text(text="Software Engineer", variant="caption"),
+            ]
+        )
+    )
+
+    flat = flatten_component_tree(tree, root_id="user_card_1")
+    assert len(flat) == 4
+
+    by_id = {c["id"]: c for c in flat}
+    assert "user_card_1" in by_id
+    root_comp = by_id["user_card_1"]
+    assert root_comp["component"] == "Card"
+
+    # Column child of Card
+    col_id = root_comp["child"]
+    assert col_id.startswith("user_card_1__")
+    assert col_id in by_id
+    col_comp = by_id[col_id]
+    assert col_comp["component"] == "Column"
+
+    # Children of Column
+    children_ids = col_comp["children"]
+    assert len(children_ids) == 2
+    for cid in children_ids:
+        assert cid.startswith("user_card_1__")
+        assert cid in by_id
+        assert by_id[cid]["component"] == "Text"
+
+
+def test_slot_boundary_preservation_with_component_ref():
+    external_slot = ComponentRef("caller_provided_child_42")
+
+    macro_root = Card(
+        child=Column(
+            children=[
+                Text(text="Card Header", variant="h3"),
+                external_slot,
+            ]
+        )
+    )
+
+    flat = flatten_component_tree(macro_root, root_id="modal_dialog")
+
+    by_id = {c["id"]: c for c in flat}
+    # The external component itself MUST NOT be in the flattened output list
+    assert "caller_provided_child_42" not in by_id
+
+    # The column must reference the verbatim external ID without namespacing it
+    col_comp = [c for c in flat if c["component"] == "Column"][0]
+    assert "caller_provided_child_42" in col_comp["children"]
+    # But internal Text must be namespaced
+    assert col_comp["children"][0].startswith("modal_dialog__")
+
+
+def test_flatten_sequence_of_roots():
+    rows = [
+        Row(children=[Text(text="Row 1")]),
+        Row(children=[Text(text="Row 2")]),
+    ]
+    flat = flatten_component_tree(rows, root_id="table_row")
+    assert len(flat) == 4
+    # All rows and texts are flattened
+    comps = [c["component"] for c in flat]
+    assert comps.count("Row") == 2
+    assert comps.count("Text") == 2
+
+
+def test_component_tree_serialization_and_messages():
+    tree = ComponentTree(
+        surface_id="home",
+        root=Card(child=Text(text="Welcome")),
+    )
+    comps = tree.to_components()
+    assert len(comps) == 2
+    assert tree.to_json() is not None
+
+    messages = tree.to_surface(data_model={"user": {"name": "Alice"}})
+    assert len(messages) == 3
+    assert "createSurface" in messages[0]
+    assert messages[0]["createSurface"]["surfaceId"] == "home"
+    assert "updateComponents" in messages[1]
+    assert messages[1]["updateComponents"]["surfaceId"] == "home"
+    assert "updateDataModel" in messages[2]
+    assert messages[2]["updateDataModel"]["path"] == "/user"
+    assert messages[2]["updateDataModel"]["value"] == {"name": "Alice"}
+
+
+def test_macro_decorator_and_schema_synthesis():
+    @macro(description="A user summary card.")
+    def profile_card(name: str, age: int, is_admin: bool = False) -> Card:
+        """User profile card."""
+        return Card(
+            child=Column(
+                children=[
+                    Text(text=name, variant="h2"),
+                    Text(text=f"Age: {age}", variant="caption"),
+                ]
+            )
+        )
+
+    meta = get_macro("profile_card")
+    assert meta is not None
+    assert meta.name == "ProfileCard"
+    assert meta.description == "A user summary card."
+
+    schema = meta.to_json_schema()
+    assert schema["type"] == "object"
+    assert "name" in schema["properties"]
+    assert schema["properties"]["name"]["type"] == "string"
+    assert "age" in schema["properties"]
+    assert schema["properties"]["age"]["type"] == "integer"
+    assert "is_admin" in schema["properties"]
+    assert schema["properties"]["is_admin"]["type"] == "boolean"
+    assert schema["required"] == ["name", "age"]
+
+
+def test_macro_processor_expansion():
+    @macro(description="Status badge")
+    def status_badge(status: str, title: str) -> Card:
+        return Card(
+            child=Row(
+                children=[
+                    Text(text=status.upper(), variant="caption"),
+                    Text(text=title, variant="h3"),
+                ]
+            )
+        )
+
+    processor = MacroProcessor()
+    flat = processor.expand(
+        "status_badge",
+        args={"status": "active", "title": "Server 1"},
+        instance_id="badge_main",
+    )
+
+    by_id = {c["id"]: c for c in flat}
+    assert "badge_main" in by_id
+    assert by_id["badge_main"]["component"] == "Card"
+    row_id = by_id["badge_main"]["child"]
+    assert row_id in by_id
+    row_comp = by_id[row_id]
+    assert row_comp["component"] == "Row"
+
+    texts = [c for c in flat if c["component"] == "Text"]
+    assert len(texts) == 2
+    assert any(t["text"] == "ACTIVE" for t in texts)
+    assert any(t["text"] == "Server 1" for t in texts)
+
+
+def test_macro_processor_slot_coercion():
+    @macro(description="Container with slot")
+    def slot_container(title: str, content: ComponentBuilderNode) -> Card:
+        return Card(
+            child=Column(
+                children=[
+                    Text(text=title),
+                    content,
+                ]
+            )
+        )
+
+    processor = MacroProcessor()
+    # Pass a string ID into the ComponentBuilderNode slot parameter
+    flat = processor.expand(
+        "slot_container",
+        args={"title": "My Title", "content": "external_child_id"},
+        instance_id="container_1",
+    )
+
+    by_id = {c["id"]: c for c in flat}
+    assert "external_child_id" not in by_id
+    col_comp = [c for c in flat if c["component"] == "Column"][0]
+    assert "external_child_id" in col_comp["children"]
+
+
+def test_macro_docstring_parameter_parsing():
+    @macro
+    def MetricCard(
+        title: str,
+        value: int,
+        unit: str = "items",
+    ) -> Card:
+        """Dashboard metric counter.
+
+        Args:
+            title: Title label of the metric.
+            value: Numerical counter value.
+            unit: Optional unit label.
+        """
+        return Card(child=Column(children=[Text(text=title), Text(text=str(value))]))
+
+    meta = get_macro("MetricCard")
+    assert meta is not None
+    assert meta.name == "MetricCard"
+    assert meta.description == "Dashboard metric counter."
+    assert meta.parameters["title"].description == "Title label of the metric."
+    assert meta.parameters["title"].required is True
+    assert meta.parameters["value"].description == "Numerical counter value."
+    assert meta.parameters["value"].required is True
+    assert meta.parameters["unit"].description == "Optional unit label."
+    assert meta.parameters["unit"].required is False
+
+    schema = meta.to_json_schema()
+    assert schema["properties"]["title"]["description"] == "Title label of the metric."
+    assert schema["properties"]["value"]["type"] == "integer"
+    assert schema["required"] == ["title", "value"]
+
+
+def test_macro_naming_conventions():
+    # 1. Automatic snake_to_pascal
+    @macro
+    def employee_roster(team: str) -> Column:
+        return Column(children=[Text(text=team)])
+
+    meta = get_macro("EmployeeRoster")
+    assert meta is not None
+    assert meta.name == "EmployeeRoster"
+
+    # 2. Explicit positional name
+    @macro("CustomAlert")
+    def alert_fn(msg: str) -> Card:
+        return Card(child=Text(text=msg))
+
+    meta2 = get_macro("CustomAlert")
+    assert meta2 is not None
+    assert meta2.name == "CustomAlert"
+
+
+def test_macro_inference_format_pipeline():
+    from a2ui.inference_formats.experimental.express.format import ExpressFormat
+
+    @macro("QuickAlert")
+    def quick_alert(msg: str) -> Card:
+        return Card(child=Text(text=msg, variant="h4"))
+
+    # Verify base_format is required
+    with pytest.raises(ValueError, match="requires a base_format to be passed"):
+        MacroInferenceFormat(macros=[quick_alert])  # type: ignore
+
+    # Verify catalog is required and does NOT default to basic catalog
+    base_no_catalog = ExpressFormat(surface_id="main")
+    with pytest.raises(
+        ValueError, match="A catalog must be provided to MacroInferenceFormat"
+    ):
+        MacroInferenceFormat(base_format=base_no_catalog, macros=[quick_alert])
+
+    base = ExpressFormat(catalog={"components": {}}, surface_id="main")
+    inf_format = MacroInferenceFormat(base_format=base, macros=[quick_alert])
+    assert "QuickAlert" in inf_format.combined_catalog.catalog_schema["components"]
+
+    # Test parser compilation and macro expansion
+    raw_message = [{
+        "surfaceUpdate": {
+            "surfaceId": "main",
+            "components": [{
+                "component": "QuickAlert",
+                "id": "alert_instance_1",
+                "msg": "Payment received!",
+            }],
+        }
+    }]
+
+    from a2ui.parser.parser import Parser
+
+    class MockUnderlyingParser(Parser):
+
+        def has_format_content(self, content: str, *, complete: bool = False) -> bool:
+            return True
+
+        def unwrap(self, content: str):
+            return []
+
+        def compile(self, format_content: str, *, is_final: bool = True):
+            return raw_message
+
+        def parse_response(self, content: str):
+            return []
+
+        @property
+        def supports_streaming(self) -> bool:
+            return False
+
+        def decompile(self, val: Any) -> str:
+            return ""
+
+        def wrap_decompiled_blocks(self, blocks: list[str]) -> str:
+            return ""
+
+    from a2ui.inference_formats.experimental.macros import MacroParser
+
+    macro_parser = MacroParser(MockUnderlyingParser(), processor=MacroProcessor())
+    expanded = macro_parser.compile("dummy")
+
+    assert len(expanded) == 1
+    surf_update = expanded[0]["surfaceUpdate"]
+    comps = surf_update["components"]
+    assert len(comps) == 2
+    card_comp = [c for c in comps if c["component"] == "Card"][0]
+    text_comp = [c for c in comps if c["component"] == "Text"][0]
+    assert card_comp["id"] == "alert_instance_1"
+    assert text_comp["text"] == "Payment received!"
+
+
+def test_canonical_protocol_types_schema():
+    class ThemeEnum(Enum):
+        LIGHT = "light"
+        DARK = "dark"
+
+    @macro
+    def ComplexCard(
+        title: str,
+        dynamic_title: DynamicString,
+        metric: DynamicNumber,
+        is_active: DynamicBoolean,
+        tags: DynamicStringList,
+        anything: DynamicValue,
+        on_click: Action,
+        checks: Sequence[CheckRule],
+        accessibility: AccessibilityAttributes,
+        footer: ComponentRef,
+        items: Sequence[ComponentBuilderNode],
+        theme: Literal["primary", "secondary"],
+        theme_enum: ThemeEnum,
+    ) -> Card:
+        """Card testing all protocol common types."""
+        return Card(child=Text(text="hello"))
+
+    meta = get_macro("ComplexCard")
+    assert meta is not None
+    schema = meta.to_json_schema()
+    props = schema["properties"]
+
+    assert props["title"]["type"] == "string"
+    assert (
+        props["dynamic_title"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString"
+    )
+    assert (
+        props["metric"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicNumber"
+    )
+    assert (
+        props["is_active"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicBoolean"
+    )
+    assert (
+        props["tags"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicStringList"
+    )
+    assert (
+        props["anything"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicValue"
+    )
+    assert (
+        props["on_click"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/Action"
+    )
+    assert props["checks"]["type"] == "array"
+    assert (
+        props["checks"]["items"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/CheckRule"
+    )
+    assert (
+        props["accessibility"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/AccessibilityAttributes"
+    )
+    assert (
+        props["footer"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+    )
+    assert (
+        props["items"]["$ref"]
+        == "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+    )
+    assert props["theme"] == {
+        "type": "string",
+        "enum": ["primary", "secondary"],
+        "description": "Theme",
+    }
+    assert props["theme_enum"] == {
+        "type": "string",
+        "enum": ["light", "dark"],
+        "description": "Theme enum",
+    }
+
+
+def test_processor_argument_coercion():
+    @macro
+    def BoundCard(
+        status: DynamicString,
+        on_click: Action,
+        slot: ComponentRef,
+        accessibility: AccessibilityAttributes,
+    ) -> Card:
+        return Card(
+            child=Column(
+                children=[
+                    Text(text=status),
+                    Button(child=Text(text="Action"), action=on_click),
+                    slot,
+                ]
+            )
+        )
+
+    processor = MacroProcessor()
+    expanded = processor.expand(
+        "BoundCard",
+        {
+            "status": {"path": "/servers/primary/status"},
+            "on_click": "restart_server",
+            "slot": "child_slot_99",
+            "accessibility": {"label": "Server card"},
+        },
+        instance_id="card_1",
+    )
+
+    # Verify root Card ID
+    card = [c for c in expanded if c["component"] == "Card"][0]
+    assert card["id"] == "card_1"
+
+    # Verify Text component has DataBinding dict
+    text = [c for c in expanded if c["component"] == "Text"][0]
+    assert text["text"] == {"path": "/servers/primary/status"}
+
+    # Verify Button action was coerced from string to Action dict
+    button = [c for c in expanded if c["component"] == "Button"][0]
+    assert button["action"] == {"event": {"name": "restart_server"}}
+
+    # Verify Column has the external slot child ID untouched
+    col = [c for c in expanded if c["component"] == "Column"][0]
+    child_ids = col["children"]
+    assert "child_slot_99" in child_ids
+
+
+def test_macro_parser_parse_response():
+    """Verifies that MacroParser.parse_response returns ResponsePart objects with fully expanded macros."""
+    from a2ui.basic_catalog.provider import BasicCatalog
+    from a2ui.schema.catalog import A2uiCatalog
+    from a2ui.schema.constants import (
+        COMMON_TYPES_SCHEMA_KEY,
+        SERVER_TO_CLIENT_SCHEMA_KEY,
+        SPEC_VERSION_MAP,
+    )
+    from a2ui.schema.utils import load_from_bundled_resource
+    from a2ui.inference_formats.experimental.express.format import ExpressFormat
+
+    @macro
+    def UserInfoCard(name: str, role: str = "Engineer") -> Card:
+        return Card(
+            child=Column(
+                children=[
+                    Text(text=name, variant="h3"),
+                    Text(text=role, variant="caption"),
+                ]
+            )
+        )
+
+    basic_config = BasicCatalog.get_config("0.9.1")
+    cat = A2uiCatalog(
+        version="0.9.1",
+        name="basic",
+        catalog_schema=basic_config.provider.load(),
+        s2c_schema=load_from_bundled_resource(
+            "0.9.1", SERVER_TO_CLIENT_SCHEMA_KEY, SPEC_VERSION_MAP
+        ),
+        common_types_schema=load_from_bundled_resource(
+            "0.9.1", COMMON_TYPES_SCHEMA_KEY, SPEC_VERSION_MAP
+        ),
+    )
+
+    fmt = MacroInferenceFormat(
+        base_format=ExpressFormat(
+            catalog=cat, surface_id="test_surf", version="v0.9.1"
+        ),
+        macros=[UserInfoCard],
+    )
+
+    llm_output = (
+        "Here is the requested user profile card:\n"
+        "<a2ui>\n"
+        'root = UserInfoCard(name="Alice Smith", role="Tech Lead")\n'
+        "</a2ui>\n"
+        "Let me know if you need any adjustments."
+    )
+
+    parts = fmt.parser.parse_response(llm_output)
+    assert len(parts) == 2
+    assert "Here is the requested user profile card:" in parts[0].text
+    assert parts[0].a2ui_raw is not None
+    assert parts[0].a2ui_json is not None
+
+    # Verify that the macro was expanded into primitive components
+    components = []
+    for msg in parts[0].a2ui_json:
+        if "updateComponents" in msg:
+            components.extend(msg["updateComponents"].get("components", []))
+        elif "surfaceUpdate" in msg:
+            components.extend(msg["surfaceUpdate"].get("components", []))
+    assert len(components) >= 3
+    # Check that UserInfoCard is NOT in components, but Card and Text are
+    comp_names = [c["component"] for c in components]
+    assert "UserInfoCard" not in comp_names
+    assert "Card" in comp_names
+    assert "Text" in comp_names
+    # Check that texts match arguments
+    text_contents = [c.get("text") for c in components if c["component"] == "Text"]
+    assert "Alice Smith" in text_contents
+    assert "Tech Lead" in text_contents
+
+    assert "Let me know if you need any adjustments." in parts[1].text
+    assert parts[1].a2ui_json is None

--- a/agent_sdks/python/a2ui_agent/tests/test_macros.py
+++ b/agent_sdks/python/a2ui_agent/tests/test_macros.py
@@ -46,7 +46,7 @@ from a2ui.inference_formats.experimental.macros import (
     macro,
 )
 from a2ui.schema.catalog import A2uiCatalog
-from a2ui.builder.catalogs.basic import (
+from a2ui.builder.v0_9.catalogs.basic_catalog import (
     Button,
     Card,
     Column,


### PR DESCRIPTION
## Summary
Introduces the programmatic `@macro` runtime, schema reflection, and parser expansion engine in the Python Agent SDK.

Layer 2 of the builder and macro stack, building directly on the Pydantic fluent builder base classes from Layer 1 (#2425). Part of the Python fluent builder and macro architecture tracked in #2571.

## Architecture Context (Issue #2571)
Leverages the Pydantic v2 fluent builder foundation established in #2425:
- **Macro Expansion via Fluent ASTs**: Macro definitions return typesafe builder nodes (e.g. `Card`, `Column`) authored with full autocomplete and runtime validation.
- **Surface Decoupling**: The runtime calls `node.to_components()` directly to splice expanded component subtrees into host envelopes without mutating surface lifecycle state.
- **Runtime Type Coercion**: `MacroProcessor` coerces incoming JSON macro parameters into rich builder objects and AST subtrees according to reflected parameter schemas.

## Key Capabilities
- **`@macro` Decorator (`src/a2ui/inference_formats/experimental/macros/macro.py`)**:
  - Automatically extracts parameter metadata, types, and descriptions from Google/Sphinx style docstrings.
  - Dynamically synthesizes standard A2UI component JSON schemas from Python type annotations (supports `str`, `int`, `bool`, `Literal`, `Enum`, `DataBinding`, `Action`, `CheckRule`, `AccessibilityAttributes`, child slots, and slot lists).
- **Macro Expansion Runtime (`src/a2ui/inference_formats/experimental/macros/processor.py`)**:
  - `MacroProcessor`: Coerces JSON parameters into rich AST builder objects at runtime.
  - Recursively expands and stitches component trees into flat A2UI envelopes while anchoring the invocation ID to the root component.
- **Envelope Parser (`src/a2ui/inference_formats/experimental/macros/parser.py`)**:
  - `MacroParser`: Decorates underlying parsers (Express, Elemental, Direct JSON) and expands macros found within `surfaceUpdate`, `createSurface`, or `updateComponents`.
- **Inference Format Integration (`src/a2ui/inference_formats/experimental/macros/format.py`)**:
  - `MacroInferenceFormat`: Injects macro schemas into prompt generators and provides end-to-end integration.
- **Catalog Combination (`src/a2ui/schema/catalog.py`)**:
  - Adds `A2uiCatalog.with_components()` to programmatically combine base catalog schemas with synthetic macro schemas without raw dictionary manipulation.
- **Architecture Guide**: Comprehensive documentation in [`src/a2ui/inference_formats/experimental/macros/README.md`](https://github.com/a2ui-project/a2ui/blob/feat/python-agent-sdk-macros/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/macros/README.md).

## Verification
- Unit Tests: `uv run pytest tests/test_macros.py` (18/18 passed)
- Code Formatting: `uv run pyink --check src/a2ui/inference_formats/experimental/macros/ tests/test_macros.py` (clean)
