### PR TITLE
fix(web_core): make the setter for a binding-only prop callable

### DIFF
--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Fix the setter `GenericBinder` generates for a property declared as a binding with no literal branch: its parameter resolved to `never`, making the setter uncallable. It now falls back to `unknown`, matching the fallback `ResolveA2uiProp` already applies to the resolved property ([#2528](https://github.com/a2ui-project/a2ui/issues/2528)).
 - (v0_9) Deprecate `injectBasicCatalogStyles`, `computeColorVariant`, `ColorVariantLightDarkOptions`, and `ColorVariantHoverOptions` exports from `@a2ui/web_core/v0_9`. Consumers should import them from `@a2ui/web_core/v0_9/basic_catalog` instead.
 - (v0_9) An invalid number literal in an expression, such as `${1.2.3}`, now throws `A2uiExpressionError` instead of being handed back as `NaN`. The accepted shape — digits, an optional decimal point and optional further digits — is stated in the parser rather than inherited from `Number()`, so every implementation accepts the same literals. ([#2497](https://github.com/a2ui-project/a2ui/pull/2497))
 - (v0_9) The expression parser now runs the shared conformance suite at `conformance/core/expressions.yaml`, alongside the Dart client. Adds `js-yaml` as a dev dependency to read it. ([#2497](https://github.com/a2ui-project/a2ui/pull/2497))

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -17,12 +17,12 @@
 import * as assert from 'node:assert';
 import {describe, it} from 'node:test';
 import {z} from 'zod';
-import {GenericBinder, scrapeSchemaBehavior} from './generic-binder.js';
+import {GenericBinder, scrapeSchemaBehavior, type GenerateSetters} from './generic-binder.js';
 import {ComponentContext} from './component-context.js';
 import {SurfaceModel} from '../state/surface-model.js';
 import {Catalog} from '../catalog/types.js';
 import {ComponentModel} from '../state/component-model.js';
-import {CommonSchemas} from '../schema/common-types.js';
+import {CommonSchemas, type DataBinding, type FunctionCall} from '../schema/common-types.js';
 
 describe('GenericBinder Checkable Trait', () => {
   const mockCatalog = new Catalog('test', [], []);
@@ -399,6 +399,24 @@ describe('GenericBinder Checkable Trait', () => {
           context: {userId: {path: '/user/id'}},
         },
       });
+    });
+  });
+
+  describe('Generated setter types', () => {
+    it('keeps the setter callable for a property declared with no literal branch', () => {
+      const bindingOnly: GenerateSetters<{value: DataBinding | FunctionCall}> = {
+        setValue: () => {},
+      };
+      bindingOnly.setValue('anything');
+      const value: unknown = {selected: true};
+      bindingOnly.setValue(value);
+
+      const withLiteral: GenerateSetters<{value: string | DataBinding | FunctionCall}> = {
+        setValue: () => {},
+      };
+      withLiteral.setValue('ok');
+      // @ts-expect-error a literal branch must still constrain the setter.
+      withLiteral.setValue(123);
     });
   });
 });

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -179,10 +179,14 @@ export type ResolveA2uiProp<T> = [NonNullable<T>] extends [Action]
 /**
  * Automatically generates two-way binding setters for dynamic properties.
  * If a schema has a `value: DynamicString`, this type generates a `setValue(val: string)` method.
+ * A property declared as a binding with no literal branch has no such value type, so its setter
+ * falls back to `unknown`, mirroring the fallback `ResolveA2uiProp` applies to the read side.
  */
 export type GenerateSetters<T> = {
   [K in keyof T as IsDynamic<T[K]> extends true ? `set${Capitalize<string & K>}` : never]-?: (
-    value: Exclude<NonNullable<T[K]>, DynamicTypes>,
+    value: [Exclude<NonNullable<T[K]>, DynamicTypes>] extends [never]
+      ? unknown
+      : Exclude<NonNullable<T[K]>, DynamicTypes>,
   ) => void;
 };
 

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -180,7 +180,7 @@ export type ResolveA2uiProp<T> = [NonNullable<T>] extends [Action]
  * Automatically generates two-way binding setters for dynamic properties.
  * If a schema has a `value: DynamicString`, this type generates a `setValue(val: string)` method.
  * A property declared as a binding with no literal branch has no such value type, so its setter
- * falls back to `unknown`, mirroring the fallback `ResolveA2uiProp` applies to the read side.
+ * falls back to `unknown`.
  */
 export type GenerateSetters<T> = {
   [K in keyof T as IsDynamic<T[K]> extends true ? `set${Capitalize<string & K>}` : never]-?: (


### PR DESCRIPTION
# Description

`GenerateSetters` types a generated setter's parameter as `never` when the property is declared as a binding with no literal branch, making the setter uncallable. Fixes #2528.

## Fix

Give the write side the fallback the read side already has:

```diff
-    value: Exclude<NonNullable<T[K]>, DynamicTypes>,
+    value: [Exclude<NonNullable<T[K]>, DynamicTypes>] extends [never]
+      ? unknown
+      : Exclude<NonNullable<T[K]>, DynamicTypes>,
```

`unknown` rather than `any`: it accepts every argument while keeping the value checked at the call site, and does not add to the `any` count tracked in #1296.

**Non-breaking.** A parameter of type `never` admits no argument, so widening it can only permit calls that previously failed to compile. No existing call site can change meaning.

**No runtime change.** The edit is a type annotation inside a type alias. 

## Verification

- `@a2ui/web_core`: 458/458 existing tests pass, `tsc --noEmit` clean, `format:check` clean, lint
  reports 0 errors (402 pre-existing warnings, unchanged).
- `@a2ui/react`: `typecheck` clean.
- `@a2ui/lit`, `@a2ui/react`: one pre-existing failure each, `Live Invitation Builder should
  render date`, which asserts on a locale/timezone-formatted date and fails identically on a
  clean checkout of `main` in this environment. Unrelated to this change, which emits no
  JavaScript.

## Scope

No component in the basic catalog declares a binding-only property, and `DataBinding` is absent
from `COMMON_TYPE_SCHEMAS` in `src/v0_9/catalog/schema_loader.ts`, so JSON-defined catalogs
cannot declare one. The case is reachable from hand-written Zod component schemas.

## Related, not addressed here

`ResolveA2uiProp` types a bound property by its literal branches, so a `DynamicString` property whose path holds a non-string is still typed `string`. That is a separate problem with a different fix, and is closer to #846 than to this PR.

## Update after review (09.10.26)

Added a compile-time test in `generic-binder.test.ts` covering this type, per review feedback: it asserts the setter accepts a value when the property has no literal branch, and that a literal branch still constrains the setter (`@ts-expect-error`).

Dropped the `ResolveA2uiProp` comparison from the `GenerateSetters` doc comment, per review feedback.

Verified the test fails without the fix: reverting the type edit makes `tsc` exit 2 with `error TS2345: Argument of type '"anything"' is not assignable to parameter of type 'never'`, and the same for the `unknown` value. With the fix restored, `@a2ui/web_core` is 496/496 tests passing, `tsc --noEmit` clean, `format:check` clean, lint 0 errors (402 warnings, unchanged). The library JavaScript in `dist` is still byte-identical to `main`; only the test file is new.

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
      No test accompanies this change. It is a type-only edit with no runtime behaviour to
      exercise, and the repository has no existing type-level test harness.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
