### PR TITLE
fix(web_core): classify dynamic unions nested inside wider unions as DYNAMIC

### DIFF
--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) `GenericBinder` schema scraping now classifies a `Dynamic*` schema composed into a wider union as `DYNAMIC`, so bindings on such properties (e.g. the basic catalog's `DateTimeInput` `min`/`max`) resolve and subscribe instead of passing through as raw `{path}` objects.
 - (v0_9) Deprecate `injectBasicCatalogStyles`, `computeColorVariant`, `ColorVariantLightDarkOptions`, and `ColorVariantHoverOptions` exports from `@a2ui/web_core/v0_9`. Consumers should import them from `@a2ui/web_core/v0_9/basic_catalog` instead.
 - (v0_9) An invalid number literal in an expression, such as `${1.2.3}`, now throws `A2uiExpressionError` instead of being handed back as `NaN`. The accepted shape — digits, an optional decimal point and optional further digits — is stated in the parser rather than inherited from `Number()`, so every implementation accepts the same literals. ([#2497](https://github.com/a2ui-project/a2ui/pull/2497))
 - (v0_9) The expression parser now runs the shared conformance suite at `conformance/core/expressions.yaml`, alongside the Dart client. Adds `js-yaml` as a dev dependency to read it. ([#2497](https://github.com/a2ui-project/a2ui/pull/2497))

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -383,6 +383,19 @@ describe('GenericBinder Checkable Trait', () => {
       assert.deepStrictEqual((behavior as any).shape.min, {type: 'DYNAMIC'});
       assert.deepStrictEqual((behavior as any).shape.deep, {type: 'DYNAMIC'});
     });
+
+    it('should see dynamic branches through Optional/Nullable/Default wrappers', () => {
+      const schema = z.object({
+        a: z.union([DynamicStringSchema.nullable(), z.number()]),
+        b: z.union([DynamicStringSchema.optional(), z.number()]),
+        c: z.union([DynamicStringSchema.default('fallback'), z.number()]),
+      });
+
+      const behavior = scrapeSchemaBehavior(schema);
+      assert.deepStrictEqual((behavior as any).shape.a, {type: 'DYNAMIC'});
+      assert.deepStrictEqual((behavior as any).shape.b, {type: 'DYNAMIC'});
+      assert.deepStrictEqual((behavior as any).shape.c, {type: 'DYNAMIC'});
+    });
   });
 
   describe('Static behavior for unannotated schemas', () => {

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -22,7 +22,7 @@ import {ComponentContext} from './component-context.js';
 import {SurfaceModel} from '../state/surface-model.js';
 import {Catalog} from '../catalog/types.js';
 import {ComponentModel} from '../state/component-model.js';
-import {CommonSchemas} from '../schema/common-types.js';
+import {CommonSchemas, DynamicStringSchema} from '../schema/common-types.js';
 
 describe('GenericBinder Checkable Trait', () => {
   const mockCatalog = new Catalog('test', [], []);
@@ -362,6 +362,26 @@ describe('GenericBinder Checkable Trait', () => {
       assert.strictEqual(nestedBehavior.type, 'OBJECT');
       assert.strictEqual((nestedBehavior as any).shape.value.type, 'OBJECT');
       assert.strictEqual((nestedBehavior as any).shape.text.type, 'ARRAY');
+    });
+  });
+
+  describe('scrapeSchemaBehavior nested dynamic unions', () => {
+    it('should classify a union containing a Dynamic* schema as DYNAMIC', () => {
+      // The basic catalog's DateTimeInput declares min/max exactly like this: the
+      // outer describe() replaces the REF: marker and DynamicStringSchema is a
+      // nested union, so neither detection path may rely on one level only.
+      const schema = z.object({
+        min: z
+          .union([DynamicStringSchema, z.string().date(), z.string().time(), z.string().datetime()])
+          .describe('The minimum allowed date/time in ISO 8601 format.')
+          .optional(),
+        deep: z.union([z.union([z.string(), z.object({path: z.string()})]), z.number()]),
+      });
+
+      const behavior = scrapeSchemaBehavior(schema);
+      assert.strictEqual(behavior.type, 'OBJECT');
+      assert.deepStrictEqual((behavior as any).shape.min, {type: 'DYNAMIC'});
+      assert.deepStrictEqual((behavior as any).shape.deep, {type: 'DYNAMIC'});
     });
   });
 

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -367,9 +367,8 @@ describe('GenericBinder Checkable Trait', () => {
 
   describe('scrapeSchemaBehavior nested dynamic unions', () => {
     it('should classify a union containing a Dynamic* schema as DYNAMIC', () => {
-      // The basic catalog's DateTimeInput declares min/max exactly like this: the
-      // outer describe() replaces the REF: marker and DynamicStringSchema is a
-      // nested union, so neither detection path may rely on one level only.
+      // Matches DateTimeInput's min/max schema, where DynamicStringSchema
+      // is nested inside another union.
       const schema = z.object({
         min: z
           .union([DynamicStringSchema, z.string().date(), z.string().time(), z.string().datetime()])

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -66,6 +66,18 @@ const ACTION_REF = 'REF:common_types.json#/$defs/Action';
 const DATA_BINDING_REF = 'REF:common_types.json#/$defs/DataBinding';
 const DYNAMIC_REF_PREFIX = '#/$defs/Dynamic';
 
+function unwrapModifiers(type: z.ZodTypeAny): z.ZodTypeAny {
+  let current = type;
+  while (
+    current._def.typeName === 'ZodOptional' ||
+    current._def.typeName === 'ZodNullable' ||
+    current._def.typeName === 'ZodDefault'
+  ) {
+    current = current._def.innerType;
+  }
+  return current;
+}
+
 function getFieldBehavior(type: z.ZodTypeAny, propertyName?: string): BehaviorNode {
   let current = type;
 
@@ -116,13 +128,15 @@ function getFieldBehavior(type: z.ZodTypeAny, propertyName?: string): BehaviorNo
 
     // Dynamic strings/values are unions containing DataBindingSchema { path: ... } but NOT
     // { componentId: ... }. The binding branch may sit inside a nested union, e.g. a Dynamic*
-    // schema composed into a wider union of literal formats.
+    // schema composed into a wider union of literal formats, and each option may itself be
+    // wrapped in optional/nullable/default modifiers.
     const hasDynamicBranch = (opts: z.ZodTypeAny[]): boolean =>
-      opts.some(o =>
-        o._def.typeName === 'ZodUnion'
+      opts.some(rawOption => {
+        const o = unwrapModifiers(rawOption);
+        return o._def.typeName === 'ZodUnion'
           ? hasDynamicBranch(o._def.options as z.ZodTypeAny[])
-          : o._def.typeName === 'ZodObject' && o._def.shape().path && !o._def.shape().componentId,
-      );
+          : o._def.typeName === 'ZodObject' && o._def.shape().path && !o._def.shape().componentId;
+      });
     if (hasDynamicBranch(options)) return {type: 'DYNAMIC'};
 
     // ChildList is a union containing an array and an object with { componentId, path }

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -114,11 +114,16 @@ function getFieldBehavior(type: z.ZodTypeAny, propertyName?: string): BehaviorNo
     const isAction = options.some(o => o._def.typeName === 'ZodObject' && o._def.shape().event);
     if (isAction) return {type: 'ACTION'};
 
-    // Dynamic strings/values are unions containing DataBindingSchema { path: ... } but NOT { componentId: ... }
-    const isDynamic = options.some(
-      o => o._def.typeName === 'ZodObject' && o._def.shape().path && !o._def.shape().componentId,
-    );
-    if (isDynamic) return {type: 'DYNAMIC'};
+    // Dynamic strings/values are unions containing DataBindingSchema { path: ... } but NOT
+    // { componentId: ... }. The binding branch may sit inside a nested union, e.g. a Dynamic*
+    // schema composed into a wider union of literal formats.
+    const hasDynamicBranch = (opts: z.ZodTypeAny[]): boolean =>
+      opts.some(o =>
+        o._def.typeName === 'ZodUnion'
+          ? hasDynamicBranch(o._def.options as z.ZodTypeAny[])
+          : o._def.typeName === 'ZodObject' && o._def.shape().path && !o._def.shape().componentId,
+      );
+    if (hasDynamicBranch(options)) return {type: 'DYNAMIC'};
 
     // ChildList is a union containing an array and an object with { componentId, path }
     const isChildList = options.some(


### PR DESCRIPTION
# Description

`GenericBinder`'s schema scraper checks a union's options for the binding shape one level deep, so a `Dynamic*` schema composed into a wider union scrapes as `STATIC` and its bindings are silently ignored. The basic catalog's `DateTimeInput` `min`/`max` are declared exactly this way. Full mechanism and reproduction in the issue. Fixes #2530!

## Fix

Make the structural union check recurse into nested union options:

```diff
-    // Dynamic strings/values are unions containing DataBindingSchema { path: ... } but NOT { componentId: ... }
-    const isDynamic = options.some(
-      o => o._def.typeName === 'ZodObject' && o._def.shape().path && !o._def.shape().componentId,
-    );
-    if (isDynamic) return {type: 'DYNAMIC'};
+    // Dynamic strings/values are unions containing DataBindingSchema { path: ... } but NOT
+    // { componentId: ... }. The binding branch may sit inside a nested union, e.g. a Dynamic*
+    // schema composed into a wider union of literal formats.
+    const hasDynamicBranch = (opts: z.ZodTypeAny[]): boolean =>
+      opts.some(o =>
+        o._def.typeName === 'ZodUnion'
+          ? hasDynamicBranch(o._def.options as z.ZodTypeAny[])
+          : o._def.typeName === 'ZodObject' && o._def.shape().path && !o._def.shape().componentId,
+      );
+    if (hasDynamicBranch(options)) return {type: 'DYNAMIC'};
```

The predicate cannot misfire on the other special unions: `ActionSchema`'s branches are `{event}` / `{functionCall}` objects with no `path`, and `ChildList`'s dynamic-template object carries `componentId`, which the predicate excludes.

**Behavior change, and an intended one.** `DateTimeInput` `min`/`max` bindings now resolve, subscribe, and update reactively, and the runtime `setMin`/`setMax` setters exist as the resolved props type has always promised. A catalog schema that composes a `Dynamic*` schema into a wider union gets the same correction.

## Verification

- `@a2ui/web_core`: 459/459 tests pass (458 pre-existing plus a new regression test covering the `min`/`max` shape and a description-less nested union). `format:check` clean; lint reports 0 errors (404 warnings vs 402 on `main`. Two new ones are `(behavior as any)` casts in the new test, matching the idiom of the surrounding scraper tests).
- Scraping the shipped `DateTimeInputApi.schema` now yields `DYNAMIC` for `min`, `max`, and `value`; on `main` it yields `STATIC` for `min`/`max`.
- `@a2ui/react`: 131/132, `@a2ui/lit`: 137/138. The single failure in each is the pre-existing `Live Invitation Builder should render date` test, which asserts on a locale/timezone formatted date and fails identically on a clean checkout of `main` in this environment.

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples