### PR TITLE
refactor(angular): remove markdown-it dynamic import and optional peer dependency

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) **BREAKING CHANGE**: Removed automatic dynamic import of `@a2ui/markdown-it` from `DefaultMarkdownRenderer` and dropped `@a2ui/markdown-it` from peer dependencies. Applications requiring markdown rendering should now configure it explicitly by providing `provideMarkdownRenderer(renderMarkdown)` from `@a2ui/markdown-it` in their application providers. [#2533](https://github.com/a2ui-project/a2ui/pull/2533)
 - (v0_9) Fix `ChoicePicker` radio groups colliding across surfaces: the radio group `name` now combines the surface id, component id, and data context path instead of using the surface-scoped component id alone, and checkboxes no longer receive a `name`. [#2447](https://github.com/a2ui-project/a2ui/issues/2447)
 - (v0_9) Implement `createComponentImplementation` helper and deprecate `extraComponents` and `functions` in `BasicCatalogOptions` to align with the core API. [#2060](https://github.com/a2ui-project/a2ui/pull/2060)
 

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -41,15 +41,9 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@a2ui/markdown-it": "workspace:*",
     "@angular/common": "^21.2.5",
     "@angular/core": "^21.2.5",
     "@angular/platform-browser": "^21.2.5"
-  },
-  "peerDependenciesMeta": {
-    "@a2ui/markdown-it": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@a2ui/markdown-it": "workspace:*",

--- a/renderers/angular/src/v0_9/core/markdown.spec.ts
+++ b/renderers/angular/src/v0_9/core/markdown.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {MarkdownRenderer, DefaultMarkdownRenderer, provideMarkdownRenderer} from './markdown';
+
+describe('MarkdownRenderer (v0.9)', () => {
+  describe('DefaultMarkdownRenderer', () => {
+    let renderer: DefaultMarkdownRenderer;
+
+    beforeEach(() => {
+      renderer = new DefaultMarkdownRenderer();
+    });
+
+    it('returns the markdown string as plain text fallback', async () => {
+      const input = '# Heading\n**Bold text**';
+      const result = await renderer.render(input);
+      expect(result).toBe(input);
+    });
+
+    it('handles empty strings cleanly', async () => {
+      const result = await renderer.render('');
+      expect(result).toBe('');
+    });
+  });
+
+  describe('provideMarkdownRenderer', () => {
+    it('provides DefaultMarkdownRenderer when called without arguments', () => {
+      TestBed.configureTestingModule({
+        providers: [provideMarkdownRenderer()],
+      });
+
+      const renderer = TestBed.inject(MarkdownRenderer);
+      expect(renderer).toBeInstanceOf(DefaultMarkdownRenderer);
+    });
+
+    it('provides custom renderer when a custom renderFn is passed', async () => {
+      const customRenderFn = jasmine.createSpy('customRenderFn').and.resolveTo('<em>rendered</em>');
+
+      TestBed.configureTestingModule({
+        providers: [provideMarkdownRenderer(customRenderFn)],
+      });
+
+      const renderer = TestBed.inject(MarkdownRenderer);
+      const output = await renderer.render('*input*');
+
+      expect(customRenderFn).toHaveBeenCalledWith('*input*');
+      expect(output).toBe('<em>rendered</em>');
+    });
+  });
+});

--- a/renderers/angular/src/v0_9/core/markdown.ts
+++ b/renderers/angular/src/v0_9/core/markdown.ts
@@ -30,21 +30,15 @@ export abstract class MarkdownRenderer {
 export class DefaultMarkdownRenderer extends MarkdownRenderer {
   private static warningLogged = false;
 
-  override async render(markdown: string, options?: MarkdownRendererOptions): Promise<string> {
-    try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - optional peer dependency throws TS1323 under Angular compiler but not under NodeNext
-      const {renderMarkdown} = await import('@a2ui/markdown-it');
-      return await renderMarkdown(markdown, options as any);
-    } catch {
-      if (!DefaultMarkdownRenderer.warningLogged) {
-        console.warn(
-          '[DefaultMarkdownRenderer] Failed to load optional `@a2ui/markdown-it` renderer. Using fallback.',
-        );
-        DefaultMarkdownRenderer.warningLogged = true;
-      }
-      return markdown;
+  override async render(markdown: string, _options?: MarkdownRendererOptions): Promise<string> {
+    if (!DefaultMarkdownRenderer.warningLogged) {
+      console.warn(
+        '[DefaultMarkdownRenderer] No MarkdownRenderer configured. Plain text fallback used. ' +
+          'Provide a renderer via `provideMarkdownRenderer(...)` with `@a2ui/markdown-it` if markdown formatting is required.',
+      );
+      DefaultMarkdownRenderer.warningLogged = true;
     }
+    return markdown;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,13 +116,9 @@ __metadata:
     wireit: "npm:^0.15.0-pre.2"
     zod: "npm:^3.25.76"
   peerDependencies:
-    "@a2ui/markdown-it": "workspace:*"
     "@angular/common": ^21.2.5
     "@angular/core": ^21.2.5
     "@angular/platform-browser": ^21.2.5
-  peerDependenciesMeta:
-    "@a2ui/markdown-it":
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Refactors the v0.9 Angular renderer to remove the implicit dynamic `import('@a2ui/markdown-it')` and optional `@a2ui/markdown-it` peer dependency:

- **BREAKING CHANGE (Markdown Rendering Fallback)**: Replaces the automatic runtime dynamic `import('@a2ui/markdown-it')` in `DefaultMarkdownRenderer` with a safe, zero-dependency plain-text fallback and a one-time console warning. Angular applications requiring markdown rendering must now explicitly provide a renderer via `provideMarkdownRenderer(renderMarkdown)` (e.g., from `@a2ui/markdown-it`).
- **BREAKING CHANGE (Peer Dependency Cleanup)**: Removes `@a2ui/markdown-it` from `peerDependencies` and `peerDependenciesMeta` in `@a2ui/angular/package.json`.
- **Explicit Consumer Configuration**: In `@a2ui/angular-explorer`, explicitly provides `renderMarkdown` from `@a2ui/markdown-it` through `provideMarkdownRenderer(renderMarkdown)`.
- **Defensive Property Handling**: Coerces non-string text values safely in `TextComponent`.
- **Unit Tests**: Adds comprehensive unit tests in `markdown.spec.ts` covering `DefaultMarkdownRenderer` fallback behavior and custom renderer injection via `provideMarkdownRenderer`.

## Changes

- `renderers/angular/src/v0_9/core/markdown.ts`: Remove dynamic import, provide fallback plain-text rendering and informative warning.
- `renderers/angular/src/v0_9/core/markdown.spec.ts`: Add tests for `DefaultMarkdownRenderer` and `provideMarkdownRenderer`.
- `renderers/angular/package.json`: Remove `@a2ui/markdown-it` peer dependency.
- `renderers/angular/CHANGELOG.md`: Document breaking change under `## Unreleased`.
- `renderers/angular/a2ui_explorer/src/app/app.config.ts` & `test_utils.ts`: Explicitly configure `provideMarkdownRenderer(renderMarkdown)`.
- `renderers/angular/src/v0_9/catalog/basic/text.component.ts`: Safely coerce dynamic text prop values to strings.

## Pre-launch Checklist

- [x] I read the [Contributors Guide].
- [x] My code changes have unit tests.
- [x] All unit and integration tests pass locally.
- [x] Formatted and linted according to repository standards.