### PR TITLE
Use absolute raw URL for gallery image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ optimized for representing updatable agent-generated
 UIs and an initial set of renderers, that allows agents
 to generate or populate rich user interfaces.
 
-<img src="docs/public/assets/a2ui_gallery_examples.png" alt="Gallery of A2UI components" height="400">
+<img src="https://raw.githubusercontent.com/a2ui-project/a2ui/main/docs/public/assets/a2ui_gallery_examples.png" alt="Gallery of A2UI components" height="400">
 
 _A gallery of A2UI rendered cards, showing a variety of UI compositions that A2UI can achieve._
 


### PR DESCRIPTION
Relative paths to `docs/public/assets/` fail to resolve when the README is mirrored or rendered in environments that do not import the full `docs/` hierarchy (such as internal Google3 / g3doc). Using the absolute raw GitHub URL ensures the image renders reliably across all surfaces.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
