### PR TITLE
release: bump web SDK packages (web_core 0.10.8, lit 0.11.0, angular 0.10.7, react 0.11.1)

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Unreleased
 
+## 0.10.7
+
 - (v0_9) Fix `ChoicePicker` radio groups colliding across surfaces: the radio group `name` now combines the surface id, component id, and data context path instead of using the surface-scoped component id alone, and checkboxes no longer receive a `name`. [#2447](https://github.com/a2ui-project/a2ui/issues/2447)
+
+## 0.10.6
+
 - (v0_9) Implement `createComponentImplementation` helper and deprecate `extraComponents` and `functions` in `BasicCatalogOptions` to align with the core API. [#2060](https://github.com/a2ui-project/a2ui/pull/2060)
 
 ## 0.10.5

--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-## 0.10.7
+## 0.11.0
 
+- **BREAKING CHANGE**: Require `@a2ui/web_core` `^0.11.0`. Upgrade any direct core dependency alongside this package. Applications also using Lit must upgrade to `@a2ui/lit` `^0.11.0` to avoid duplicate custom element registrations.
 - (v0_9) Fix `ChoicePicker` radio groups colliding across surfaces: the radio group `name` now combines the surface id, component id, and data context path instead of using the surface-scoped component id alone, and checkboxes no longer receive a `name`. [#2447](https://github.com/a2ui-project/a2ui/issues/2447)
 
 ## 0.10.6

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.10.7",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.11.0
+
 - (v0_9) Replace wildcard re-exports in `@a2ui/lit/v0_9` with explicit named exports.
 - (v0_9) Move universal basic catalog component implementations (`A2uiText`, `A2uiButton`, `A2uiCard`, etc.) to `@a2ui/web_core/v0_9/basic_catalog` and re-export them from `@a2ui/lit/v0_9` and `@a2ui/lit/v0_9/catalogs/basic` for backwards compatibility. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - **BREAKING CHANGE**: (v0_9) Align Basic Catalog component DOM structures, behaviors, and styling contracts with the Angular reference implementation: [#2205](https://github.com/a2ui-project/a2ui/pull/2205)

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.11.0
 
-- (v0_9) Replace wildcard re-exports in `@a2ui/lit/v0_9` with explicit named exports.
-- (v0_9) Move universal basic catalog component implementations (`A2uiText`, `A2uiButton`, `A2uiCard`, etc.) to `@a2ui/web_core/v0_9/basic_catalog` and re-export them from `@a2ui/lit/v0_9` and `@a2ui/lit/v0_9/catalogs/basic` for backwards compatibility. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
+- (v0_9) Export `BasicCatalogA2uiLitElement` from `@a2ui/lit/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
+- **BREAKING CHANGE**: (v0_9) `A2uiLitElement.controller` is a read-only getter. Subclasses override `createController()` instead of assigning it. [#2484](https://github.com/a2ui-project/a2ui/pull/2484)
 - **BREAKING CHANGE**: (v0_9) Align Basic Catalog component DOM structures, behaviors, and styling contracts with the Angular reference implementation: [#2205](https://github.com/a2ui-project/a2ui/pull/2205)
   - `DateTimeInput`: Migrate from a single dynamic HTML5 input (`datetime-local`) to dual side-by-side date and time inputs (`.a2ui-date-time-inputs`), support overridable `--a2ui-datetimeinput-width`, and ensure time-only mode preserves time-only strings without invalid date concatenation.
   - `Modal`: Migrate from native `<dialog>` element to an overlay container (`.a2ui-modal-overlay`, `.a2ui-modal-content`) managed with explicit `@state() isOpen` lifecycle tracking, backdrop theming (`--a2ui-modal-backdrop-bg`), and accessible ARIA dialog roles.

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -2,19 +2,26 @@
 
 ## 0.11.0
 
+- **BREAKING CHANGE**: Require `@a2ui/web_core` `^0.11.0`, which now provides the shared basic catalog component implementations. Upgrade any direct core dependency and other A2UI renderer packages used by the application together.
 - (v0_9) Export `BasicCatalogA2uiLitElement` from `@a2ui/lit/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - **BREAKING CHANGE**: (v0_9) `A2uiLitElement.controller` is a read-only getter. Subclasses override `createController()` instead of assigning it. [#2484](https://github.com/a2ui-project/a2ui/pull/2484)
 - **BREAKING CHANGE**: (v0_9) Align Basic Catalog component DOM structures, behaviors, and styling contracts with the Angular reference implementation: [#2205](https://github.com/a2ui-project/a2ui/pull/2205)
   - `DateTimeInput`: Migrate from a single dynamic HTML5 input (`datetime-local`) to dual side-by-side date and time inputs (`.a2ui-date-time-inputs`), support overridable `--a2ui-datetimeinput-width`, and ensure time-only mode preserves time-only strings without invalid date concatenation.
   - `Modal`: Migrate from native `<dialog>` element to an overlay container (`.a2ui-modal-overlay`, `.a2ui-modal-content`) managed with explicit `@state() isOpen` lifecycle tracking, backdrop theming (`--a2ui-modal-backdrop-bg`), and accessible ARIA dialog roles.
   - `Image`: Remove default `width: 100%` constraint on `img` elements to preserve intrinsic aspect ratios and align `fit` default with container layouts.
-  - `Button`: Replace hardcoded disabled button hex colors with `opacity: 0.5; cursor: not-allowed;` so disabled buttons react dynamically to theme backgrounds.
+  - `Button`: Replace hardcoded disabled button hex colors with `opacity: 0.5; cursor: not-allowed;` so disabled buttons react dynamically to theme backgrounds. Set `type="button"` so buttons do not submit an enclosing form.
   - `TextField`: Render all validation error messages in `validationErrors` instead of only the first error, simplify input change handling, and support full-width container styling (`width: var(--a2ui-textfield-width, 100%)`, `box-sizing: border-box`).
   - `Column`: Add consistent flex layout distribution and strict alignment mappings.
   - `Row`, `Column`, `List`: Use Lit `repeat` directive with key extractors to ensure child elements are tracked by key and DOM nodes are preserved across reordering operations.
   - `Tabs`: Reset `activeIndex` to 0 in `willUpdate` when the `tabs` array changes dynamically and index is out of bounds.
   - `Text`: Directly render semantic HTML tags for non-markdown variants (`h1`-`h5`, `caption` wrapped in `<em>`) and add flex weight styling.
   - `Video`: Wrap video in `.a2ui-video-container` with fallback message for unsupported browsers.
+  - `AudioPlayer`: Add `.a2ui-audio-player`, `.a2ui-audio-description`, and `.a2ui-audio` wrappers and styling hooks.
+  - `Card`: Wrap its child in a `.a2ui-card` div.
+  - `CheckBox`: Wrap label text in `.a2ui-check-box-text` and render every validation error with `.a2ui-error-message`.
+  - `Divider`: Render vertical dividers with `<hr>` instead of `<div>`.
+  - `Icon`: Change font icons from `<span class="material-symbol">` to `<i class="material-icons a2ui-icon">` and add `.a2ui-icon` to SVG icons.
+  - `Slider`: Add `.a2ui-slider-container`, `.a2ui-slider-header`, `.a2ui-slider-label`, `.a2ui-slider-value`, and `.a2ui-slider` styling hooks.
   - `ChoicePicker`: Align DOM structures and CSS classes with the Angular reference implementation (`.a2ui-choice-picker`, `.a2ui-option-label`, `.a2ui-option-text`, `.a2ui-chip`, `type="button"`), scope radio input `name` attributes to surface and data context path to prevent cross-surface radio collisions in Light DOM, and omit `name` attributes on checkbox inputs.
 
 ## 0.10.4

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/lit",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "A2UI Lit Library",
   "author": "Google",
   "license": "Apache-2.0",

--- a/renderers/markdown/markdown-it/CHANGELOG.md
+++ b/renderers/markdown/markdown-it/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0
 
-- Expand the `@a2ui/web_core` peer range to `^0.10.6 || ^0.11.0`, preserving its existing `^0.10.6` support while adding support for core 0.11.x.
+- Require `@a2ui/web_core` `^0.11.0`.
 
 ## 0.1.1
 

--- a/renderers/markdown/markdown-it/CHANGELOG.md
+++ b/renderers/markdown/markdown-it/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.2.0
+
+- Expand the `@a2ui/web_core` peer range to `^0.10.6 || ^0.11.0`, preserving its existing `^0.10.6` support while adding support for core 0.11.x.
+
 ## 0.1.1
 
 - Enable `inlineSources` in `tsconfig.json` to populate `sourcesContent` in sourcemaps.

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -61,7 +61,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/web_core": "^0.10.6 || ^0.11.0"
+    "@a2ui/web_core": "workspace:*"
   },
   "wireit": {
     "build": {

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",
@@ -61,7 +61,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/web_core": "workspace:*"
+    "@a2ui/web_core": "^0.10.6 || ^0.11.0"
   },
   "wireit": {
     "build": {

--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.11.1
+
 - (v0_9) Fix `ChoicePicker` radio groups colliding across surfaces: the radio group `name` is now unique per rendered instance instead of derived from the surface-scoped component id ([#2447](https://github.com/a2ui-project/a2ui/issues/2447)).
 
 ## 0.11.0

--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-## 0.11.1
+## 0.12.0
 
+- **BREAKING CHANGE**: Require `@a2ui/web_core` `^0.11.0`. Upgrade any direct core dependency alongside this package. Applications also using Lit must upgrade to `@a2ui/lit` `^0.11.0` to avoid duplicate custom element registrations.
 - (v0_9) Fix `ChoicePicker` radio groups colliding across surfaces: the radio group `name` is now unique per rendered instance instead of derived from the surface-scoped component id ([#2447](https://github.com/a2ui-project/a2ui/issues/2447)).
 
 ## 0.11.0

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/react",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "description": "React renderer for A2UI (Agent-to-User Interface)",
   "homepage": "https://a2ui.org/",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/react",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "React renderer for A2UI (Agent-to-User Interface)",
   "homepage": "https://a2ui.org/",

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## Unreleased
 
+## 0.10.8
+
 - (v0_9) Add unit test coverage for all basic catalog Web Component implementations. [#2357](https://github.com/a2ui-project/a2ui/pull/2357)
 - (v0_9) Replace `A2uiLitElement.controller` property with a read-only getter to disallow external reassignment, simplify style root target resolution, and replace basic catalog barrel wildcard exports with explicit exports.
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
+- (v0_9) `DataModel.set` throws `A2uiDataError` when writing a path into a primitive root and leaves the root unchanged. Previously a truthy primitive root produced a raw `TypeError`, and a falsy one (`false`, `0`, `''`) was silently replaced with an empty object. [#2499](https://github.com/a2ui-project/a2ui/pull/2499)
+
+## 0.10.7
+
 - (v0_9) The child-reference marker on `ComponentIdSchema` and `ChildListSchema` now lives in the schema's metadata, so `.describe()` and other schema-rebuilding methods no longer drop it. Hand-authored `REF:` descriptions are still recognized ([#2393](https://github.com/a2ui-project/a2ui/pull/2393)).
 - (v0_9) Add the node layer: `NodeResolver` resolves a surface's components and data into a live tree of read-only `ComponentNode`s, with dynamic properties resolved to `ResolvedBinding`/`WritableBinding` and distinct pending, unknown-type, and cyclic placeholder states. Sibling instance ids are always distinct, unresolvable and cyclic references are reported through `onError` once per component and data path while the condition persists, model events delivered late reconcile against current model state, and child-reference detection covers `ChildList` unions and plain arrays of component ids ([#2077](https://github.com/a2ui-project/a2ui/pull/2077), [#2393](https://github.com/a2ui-project/a2ui/pull/2393)).
 - (v0_9) Emit `$ref` in inline-catalog capabilities for the basic catalog's child-reference properties even when a per-usage description is set; new `componentId()`/`childList()` helpers compose custom descriptions without losing the `$ref` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.10.8
 
-- (v0_9) Add unit test coverage for all basic catalog Web Component implementations. [#2357](https://github.com/a2ui-project/a2ui/pull/2357)
-- (v0_9) Replace `A2uiLitElement.controller` property with a read-only getter to disallow external reassignment, simplify style root target resolution, and replace basic catalog barrel wildcard exports with explicit exports.
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) `DataModel.set` throws `A2uiDataError` when writing a path into a primitive root and leaves the root unchanged. Previously a truthy primitive root produced a raw `TypeError`, and a falsy one (`false`, `0`, `''`) was silently replaced with an empty object. [#2499](https://github.com/a2ui-project/a2ui/pull/2499)

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
-## 0.10.8
+## 0.11.0
 
-- (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`). [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
+- **BREAKING CHANGE**: (v0_9) Expand the existing `@a2ui/web_core/v0_9/basic_catalog` entrypoint with the universal Web Component implementations of the basic catalog components (`A2uiText`, `A2uiButton`, and so on) and `basicCatalog`. Importing this entrypoint now loads Lit and registers the components' custom element tags, including when importing only a schema or style helper. Use `@a2ui/lit` 0.11.0 or later in the 0.11 release line; Lit 0.10.x registers its own copies of these tags and can fail with duplicate-registration errors. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
+- **BREAKING CHANGE**: (v0_9) `injectBasicCatalogStyles`, `computeColorVariant`, `ColorVariantLightDarkOptions`, and `ColorVariantHoverOptions` are no longer exported from `@a2ui/web_core/v0_9`. Import them from `@a2ui/web_core/v0_9/basic_catalog` instead, noting its new registration side effects. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
+- **BREAKING CHANGE**: (v0_9) `@a2ui/web_core/v0_9` now exports Lit-based rendering helpers and loads Lit at runtime. Upgrade the packages your application uses together: `@a2ui/web_core` 0.11.0, `@a2ui/lit` 0.11.0, `@a2ui/angular` 0.11.0, `@a2ui/react` 0.12.0, and `@a2ui/markdown-it` 0.2.0. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) Export Web Component base class `A2uiLitElement` from `@a2ui/web_core/v0_9`. [#2190](https://github.com/a2ui-project/a2ui/pull/2190)
 - (v0_9) `DataModel.set` throws `A2uiDataError` when writing a path into a primitive root and leaves the root unchanged. Previously a truthy primitive root produced a raw `TypeError`, and a falsy one (`false`, `0`, `''`) was silently replaced with an empty object. [#2499](https://github.com/a2ui-project/a2ui/pull/2499)
 

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "A2UI Core Library",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.10.8",
+  "version": "0.11.0",
   "description": "A2UI Core Library",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,7 +255,7 @@ __metadata:
     typescript: "npm:5.9.3"
     wireit: "npm:^0.15.0-pre.2"
   peerDependencies:
-    "@a2ui/web_core": ^0.10.6 || ^0.11.0
+    "@a2ui/web_core": "workspace:*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,7 +255,7 @@ __metadata:
     typescript: "npm:5.9.3"
     wireit: "npm:^0.15.0-pre.2"
   peerDependencies:
-    "@a2ui/web_core": "workspace:*"
+    "@a2ui/web_core": ^0.10.6 || ^0.11.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
(note: PR description now out of date; not updating since this is closed)

### Summary

Bumps the web packages that have unreleased changes and moves their `## Unreleased` changelog entries into release sections.

`@a2ui/lit` gets a minor bump instead of a patch because #2205 changes the DOM structure and CSS class names of several Basic Catalog components.

### Version bumps

- **`@a2ui/web_core`**: `0.10.7` -> `0.10.8`
- **`@a2ui/lit`**: `0.10.4` -> `0.11.0`
- **`@a2ui/angular`**: `0.10.6` -> `0.10.7`
- **`@a2ui/react`**: `0.11.0` -> `0.11.1`

### Changelog fixes

- `renderers/web_core/CHANGELOG.md`: restores the `## 0.10.7` header that #2190 removed. Without it, the six entries #2451 listed under that header sat under `## Unreleased`.
- `renderers/angular/CHANGELOG.md`: restores the `## 0.10.6` header that #2449 removed. Without it, the entry #2451 listed under that header sat under `## Unreleased`.
- Adds an entry under `web_core` 0.10.8 for the `DataModel.set` change in #2499, which shipped without one.
- Drops entries under `lit` 0.11.0 and `web_core` 0.10.8 for changes with no effect on the published packages: test coverage, and an export cleanup and a getter change to code that was itself unreleased.
- Rewrites the `lit` entry for #2190. `@a2ui/lit/v0_9` does not re-export the component classes and never did; what it gains is `BasicCatalogA2uiLitElement`. The `A2uiLitElement.controller` getter is a break for `@a2ui/lit` subclasses, so its entry lives there.


### Verification

- Versions incremented with `./renderers/scripts/increment_version.mjs`.
- `npm view @a2ui/<package> version` matches the left-hand number of each bullet above.
