### PR TITLE
fix(react): allow React 18 & 19 peerDependencies in @a2ui/react

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -2,6 +2,18 @@
   "dependencyTypes": ["dev", "prod", "peer"],
   "versionGroups": [
     {
+      "label": "Allow multi-version React peer dependencies in published packages",
+      "dependencyTypes": ["peer"],
+      "packages": ["@a2ui/react"],
+      "dependencies": ["react", "react-dom"],
+      "isIgnored": true
+    },
+    {
+      "label": "Ignore @a2ui/markdown-it version string variation",
+      "dependencies": ["@a2ui/markdown-it"],
+      "isIgnored": true
+    },
+    {
       "label": "Unified TypeScript version",
       "packages": ["**"],
       "dependencies": ["typescript"],

--- a/renderers/react/a2ui_explorer/karma.conf.cjs
+++ b/renderers/react/a2ui_explorer/karma.conf.cjs
@@ -16,6 +16,18 @@
 
 const path = require('path');
 
+const isReact18 = process.env.REACT_VERSION === '18';
+const react18Aliases = isReact18
+  ? {
+      'react/jsx-dev-runtime': require.resolve('react-18/jsx-dev-runtime'),
+      'react/jsx-runtime': require.resolve('react-18/jsx-runtime'),
+      'react-dom/client': require.resolve('react-dom-18/client'),
+      'react-dom/server': require.resolve('react-dom-18/server'),
+      'react-dom': require.resolve('react-dom-18'),
+      react: require.resolve('react-18'),
+    }
+  : {};
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -37,6 +49,7 @@ module.exports = function (config) {
       format: 'iife',
       sourcemap: true,
       alias: {
+        ...react18Aliases,
         '@a2ui/react/v0_9': path.resolve(__dirname, '../src/v0_9/index.ts'),
         '@a2ui/react/v0_8': path.resolve(__dirname, '../src/v0_8/index.ts'),
         '@a2ui/react/styles': path.resolve(__dirname, '../src/styles/index.ts'),
@@ -48,7 +61,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    browsers: ['ChromeHeadless'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--no-zygote'],
+      },
+    },
+    browsers: ['ChromeHeadlessNoSandbox'],
     singleRun: true,
     concurrency: Infinity,
     hostname: '127.0.0.1',

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -82,6 +82,7 @@
     "test:unit": "wireit",
     "test:unit:react18": "wireit",
     "test:integration": "wireit",
+    "test:integration:react18": "wireit",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
@@ -159,7 +160,8 @@
       "dependencies": [
         "test:unit",
         "test:unit:react18",
-        "test:integration"
+        "test:integration",
+        "test:integration:react18"
       ]
     },
     "test:unit": {
@@ -184,6 +186,9 @@
     },
     "test:integration": {
       "command": "yarn workspace @a2ui/react-explorer test:ci"
+    },
+    "test:integration:react18": {
+      "command": "REACT_VERSION=18 yarn workspace @a2ui/react-explorer test:ci"
     },
     "clean": {
       "command": "rm -rf dist .tsbuildinfo .wireit"

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -97,8 +97,8 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -80,6 +80,7 @@
     "demo": "yarn workspace @a2ui/react-explorer dev",
     "test": "wireit",
     "test:unit": "wireit",
+    "test:unit:react18": "wireit",
     "test:integration": "wireit",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
@@ -106,10 +107,13 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/react-18": "npm:@testing-library/react@^14.3.1",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
+    "@types/react-18": "npm:@types/react@^18.3.1",
     "@types/react-dom": "^19.2.3",
+    "@types/react-dom-18": "npm:@types/react-dom@^18.3.1",
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
@@ -122,7 +126,9 @@
     "prettier": "^3.8.4",
     "puppeteer": "^25.1.0",
     "react": "^19.2.7",
+    "react-18": "npm:react@^18.3.1",
     "react-dom": "^19.2.7",
+    "react-dom-18": "npm:react-dom@^18.3.1",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",
     "typescript": "5.9.3",
@@ -152,11 +158,22 @@
     "test": {
       "dependencies": [
         "test:unit",
+        "test:unit:react18",
         "test:integration"
       ]
     },
     "test:unit": {
       "command": "vitest run",
+      "dependencies": [
+        "build"
+      ],
+      "files": [
+        "src/**/*",
+        "tsconfig.json"
+      ]
+    },
+    "test:unit:react18": {
+      "command": "REACT_VERSION=18 vitest run",
       "dependencies": [
         "build"
       ],

--- a/renderers/react/tests/setup.ts
+++ b/renderers/react/tests/setup.ts
@@ -14,6 +14,35 @@
  * limitations under the License.
  */
 
+import Module from 'module';
+
+if (process.env.REACT_VERSION === '18') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalResolve = (Module as any)._resolveFilename;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Module as any)._resolveFilename = function (
+    request: string,
+    parent: any,
+    isMain: boolean,
+    options: any,
+  ) {
+    if (request === 'react') return originalResolve.call(this, 'react-18', parent, isMain, options);
+    if (request === 'react/jsx-runtime')
+      return originalResolve.call(this, 'react-18/jsx-runtime', parent, isMain, options);
+    if (request === 'react/jsx-dev-runtime')
+      return originalResolve.call(this, 'react-18/jsx-dev-runtime', parent, isMain, options);
+    if (request === 'react-dom')
+      return originalResolve.call(this, 'react-dom-18', parent, isMain, options);
+    if (request === 'react-dom/client')
+      return originalResolve.call(this, 'react-dom-18/client', parent, isMain, options);
+    if (request === 'react-dom/server')
+      return originalResolve.call(this, 'react-dom-18/server', parent, isMain, options);
+    if (request === '@testing-library/react')
+      return originalResolve.call(this, '@testing-library/react-18', parent, isMain, options);
+    return originalResolve.call(this, request, parent, isMain, options);
+  };
+}
+
 import '@testing-library/jest-dom/vitest';
 import {beforeAll} from 'vitest';
 import {initializeDefaultCatalog} from '../src';

--- a/renderers/react/vitest.config.ts
+++ b/renderers/react/vitest.config.ts
@@ -36,9 +36,12 @@ export default defineConfig({
     alias: {
       ...(isReact18
         ? {
-            'react': 'react-18',
-            'react-dom': 'react-dom-18',
+            'react/jsx-dev-runtime': 'react-18/jsx-dev-runtime',
+            'react/jsx-runtime': 'react-18/jsx-runtime',
             'react-dom/client': 'react-dom-18/client',
+            'react-dom/server': 'react-dom-18/server',
+            'react-dom': 'react-dom-18',
+            'react': 'react-18',
             '@testing-library/react': '@testing-library/react-18',
           }
         : {}),

--- a/renderers/react/vitest.config.ts
+++ b/renderers/react/vitest.config.ts
@@ -17,6 +17,8 @@
 import {defineConfig} from 'vitest/config';
 import path from 'path';
 
+const isReact18 = process.env.REACT_VERSION === '18';
+
 export default defineConfig({
   test: {
     globals: true,
@@ -32,6 +34,14 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      ...(isReact18
+        ? {
+            'react': 'react-18',
+            'react-dom': 'react-dom-18',
+            'react-dom/client': 'react-dom-18/client',
+            '@testing-library/react': '@testing-library/react-18',
+          }
+        : {}),
       '@': path.resolve(process.cwd(), 'src/v0_8'),
       '@a2ui/react/v0_9': path.resolve(process.cwd(), 'src/v0_9/index.ts'),
       '@a2ui/react/v0_8': path.resolve(process.cwd(), 'src/v0_8/index.ts'),

--- a/renderers/react/vitest.config.ts
+++ b/renderers/react/vitest.config.ts
@@ -16,10 +16,35 @@
 
 import {defineConfig} from 'vitest/config';
 import path from 'path';
+import react from '@vitejs/plugin-react';
+import {createRequire} from 'module';
 
+const require = createRequire(import.meta.url);
 const isReact18 = process.env.REACT_VERSION === '18';
 
+const getReact18Aliases = () => {
+  if (!isReact18) return [];
+  return [
+    {find: /^react-dom\/client$/, replacement: require.resolve('react-dom-18/client')},
+    {find: /^react-dom\/server$/, replacement: require.resolve('react-dom-18/server')},
+    {find: /^react-dom$/, replacement: require.resolve('react-dom-18')},
+    {find: /^react\/jsx-dev-runtime$/, replacement: require.resolve('react-18/jsx-dev-runtime')},
+    {find: /^react\/jsx-runtime$/, replacement: require.resolve('react-18/jsx-runtime')},
+    {find: /^react$/, replacement: require.resolve('react-18')},
+    {find: /^@testing-library\/react$/, replacement: require.resolve('@testing-library/react-18')},
+  ];
+};
+
 export default defineConfig({
+  plugins: [react(isReact18 ? {jsxImportSource: 'react-18'} : {})],
+  server: {
+    deps: {
+      inline: [true],
+    },
+  },
+  ssr: {
+    alias: getReact18Aliases(),
+  },
   test: {
     globals: true,
     environment: 'jsdom',
@@ -33,23 +58,13 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      ...(isReact18
-        ? {
-            'react/jsx-dev-runtime': 'react-18/jsx-dev-runtime',
-            'react/jsx-runtime': 'react-18/jsx-runtime',
-            'react-dom/client': 'react-dom-18/client',
-            'react-dom/server': 'react-dom-18/server',
-            'react-dom': 'react-dom-18',
-            'react': 'react-18',
-            '@testing-library/react': '@testing-library/react-18',
-          }
-        : {}),
-      '@': path.resolve(process.cwd(), 'src/v0_8'),
-      '@a2ui/react/v0_9': path.resolve(process.cwd(), 'src/v0_9/index.ts'),
-      '@a2ui/react/v0_8': path.resolve(process.cwd(), 'src/v0_8/index.ts'),
-      '@a2ui/react/styles': path.resolve(process.cwd(), 'src/styles/index.ts'),
-      '@a2ui/react': path.resolve(process.cwd(), 'src/index.ts'),
-    },
+    alias: [
+      ...getReact18Aliases(),
+      {find: '@', replacement: path.resolve(process.cwd(), 'src/v0_8')},
+      {find: '@a2ui/react/v0_9', replacement: path.resolve(process.cwd(), 'src/v0_9/index.ts')},
+      {find: '@a2ui/react/v0_8', replacement: path.resolve(process.cwd(), 'src/v0_8/index.ts')},
+      {find: '@a2ui/react/styles', replacement: path.resolve(process.cwd(), 'src/styles/index.ts')},
+      {find: '@a2ui/react', replacement: path.resolve(process.cwd(), 'src/index.ts')},
+    ],
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,8 +348,8 @@ __metadata:
     wireit: "npm:^0.15.0-pre.2"
     zod: "npm:^3.25.76"
   peerDependencies:
-    react: ^19.2.7
-    react-dom: ^19.2.7
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
     zod: ^3.25.76
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,10 +320,13 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@testing-library/react-18": "npm:@testing-library/react@^14.3.1"
     "@types/markdown-it": "npm:^14.1.2"
     "@types/node": "npm:^25.9.3"
     "@types/react": "npm:^19.2.17"
+    "@types/react-18": "npm:@types/react@^18.3.1"
     "@types/react-dom": "npm:^19.2.3"
+    "@types/react-dom-18": "npm:@types/react-dom@^18.3.1"
     "@vitejs/plugin-react": "npm:^6.0.2"
     clsx: "npm:^2.1.1"
     eslint: "npm:^10.4.1"
@@ -338,7 +341,9 @@ __metadata:
     prettier: "npm:^3.8.4"
     puppeteer: "npm:^25.1.0"
     react: "npm:^19.2.7"
+    react-18: "npm:react@^18.3.1"
     react-dom: "npm:^19.2.7"
+    react-dom-18: "npm:react-dom@^18.3.1"
     tsup: "npm:^8.5.1"
     tsx: "npm:^4.22.4"
     typescript: "npm:5.9.3"
@@ -10387,6 +10392,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.3.4
+  resolution: "@testing-library/dom@npm:9.3.4"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.1.3"
+    chalk: "npm:^4.1.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/147da340e8199d7f98f3a4ad8aa22ed55b914b83957efa5eb22bfea021a979ebe5a5182afa9c1e5b7a5f99a7f6744a5a4d9325ae46ec3b33b5a15aed8750d794
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:^6.9.1":
   version: 6.9.1
   resolution: "@testing-library/jest-dom@npm:6.9.1"
@@ -10398,6 +10419,20 @@ __metadata:
     picocolors: "npm:^1.1.1"
     redent: "npm:^3.0.0"
   checksum: 10c0/4291ebd2f0f38d14cefac142c56c337941775a5807e2a3d6f1a14c2fbd6be76a18e498ed189e95bedc97d9e8cf1738049bc76c85b5bc5e23fae7c9e10f7b3a12
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-18@npm:@testing-library/react@^14.3.1":
+  version: 14.3.1
+  resolution: "@testing-library/react@npm:14.3.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    "@testing-library/dom": "npm:^9.0.0"
+    "@types/react-dom": "npm:^18.0.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 10c0/1ccf4eb1510500cc20a805cb0244c9098dca28a8745173a8f71ea1274d63774f0b7898a35c878b43c797b89c13621548909ff37843b835c1a27ee1efbbdd098c
   languageName: node
   linkType: hard
 
@@ -11185,7 +11220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:^15.0.0":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0":
   version: 15.7.15
   resolution: "@types/prop-types@npm:15.7.15"
   checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
@@ -11203,6 +11238,25 @@ __metadata:
   version: 1.2.7
   resolution: "@types/range-parser@npm:1.2.7"
   checksum: 10c0/361bb3e964ec5133fa40644a0b942279ed5df1949f21321d77de79f48b728d39253e5ce0408c9c17e4e0fd95ca7899da36841686393b9f7a1e209916e9381a3c
+  languageName: node
+  linkType: hard
+
+"@types/react-18@npm:@types/react@^18.3.1":
+  version: 18.3.31
+  resolution: "@types/react@npm:18.3.31"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.2.2"
+  checksum: 10c0/44180549dd045f536ececd39e39aacdf828e76adc1c4a90b132f453e23cc370c4648d9102ae401172ebd8fd8b1977a901a39e214e53ec77171b27514b588c179
+  languageName: node
+  linkType: hard
+
+"@types/react-dom-18@npm:@types/react-dom@^18.3.1, @types/react-dom@npm:^18.0.0":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: 10c0/8bd309e2c3d1604a28a736a24f96cbadf6c05d5288cfef8883b74f4054c961b6b3a5e997fd5686e492be903c8f3380dba5ec017eff3906b1256529cd2d39603e
   languageName: node
   linkType: hard
 
@@ -12411,6 +12465,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:5.1.3":
+  version: 5.1.3
+  resolution: "aria-query@npm:5.1.3"
+  dependencies:
+    deep-equal: "npm:^2.0.5"
+  checksum: 10c0/edcbc8044c4663d6f88f785e983e6784f98cb62b4ba1e9dd8d61b725d0203e4cfca38d676aee984c31f354103461102a3d583aa4fbe4fd0a89b679744f4e5faf
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -12427,7 +12490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
+"array-buffer-byte-length@npm:^1.0.0, array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
   version: 1.0.2
   resolution: "array-buffer-byte-length@npm:1.0.2"
   dependencies:
@@ -13050,6 +13113,18 @@ __metadata:
     es-errors: "npm:^1.3.0"
     function-bind: "npm:^1.1.2"
   checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "call-bind@npm:1.0.9"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    get-intrinsic: "npm:^1.3.0"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10c0/a6621f6da1444481919ce3b4983dff725691e0754d3507ae483ce56e54985f2da7d6f1df512c56dbf28660745cf1ca52553f1fc9aef5557f3ce353ef14fab714
   languageName: node
   linkType: hard
 
@@ -14497,6 +14572,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-equal@npm:^2.0.5":
+  version: 2.2.3
+  resolution: "deep-equal@npm:2.2.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.0"
+    call-bind: "npm:^1.0.5"
+    es-get-iterator: "npm:^1.1.3"
+    get-intrinsic: "npm:^1.2.2"
+    is-arguments: "npm:^1.1.1"
+    is-array-buffer: "npm:^3.0.2"
+    is-date-object: "npm:^1.0.5"
+    is-regex: "npm:^1.1.4"
+    is-shared-array-buffer: "npm:^1.0.2"
+    isarray: "npm:^2.0.5"
+    object-is: "npm:^1.1.5"
+    object-keys: "npm:^1.1.1"
+    object.assign: "npm:^4.1.4"
+    regexp.prototype.flags: "npm:^1.5.1"
+    side-channel: "npm:^1.0.4"
+    which-boxed-primitive: "npm:^1.0.2"
+    which-collection: "npm:^1.0.1"
+    which-typed-array: "npm:^1.1.13"
+  checksum: 10c0/a48244f90fa989f63ff5ef0cc6de1e4916b48ea0220a9c89a378561960814794a5800c600254482a2c8fd2e49d6c2e196131dc983976adb024c94a42dfe4949f
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -15135,6 +15236,23 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.1.3"
+    has-symbols: "npm:^1.0.3"
+    is-arguments: "npm:^1.1.1"
+    is-map: "npm:^2.0.2"
+    is-set: "npm:^2.0.2"
+    is-string: "npm:^1.0.7"
+    isarray: "npm:^2.0.5"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10c0/ebd11effa79851ea75d7f079405f9d0dc185559fd65d986c6afea59a0ff2d46c2ed8675f19f03dce7429d7f6c14ff9aede8d121fbab78d75cfda6a263030bac0
   languageName: node
   linkType: hard
 
@@ -16714,7 +16832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.2, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -18120,7 +18238,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
+"is-arguments@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "is-arguments@npm:1.2.0"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10c0/6377344b31e9fcb707c6751ee89b11f132f32338e6a782ec2eac9393b0cbd32235dad93052998cda778ee058754860738341d8114910d50ada5615912bb929fc
+  languageName: node
+  linkType: hard
+
+"is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
   version: 3.0.5
   resolution: "is-array-buffer@npm:3.0.5"
   dependencies:
@@ -18322,7 +18450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.3":
+"is-map@npm:^2.0.2, is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
   checksum: 10c0/2c4d431b74e00fdda7162cd8e4b763d6f6f217edf97d4f8538b94b8702b150610e2c64961340015fe8df5b1fcee33ccd2e9b62619c4a8a3a155f8de6d6d355fc
@@ -18402,7 +18530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.2.1":
+"is-regex@npm:^1.1.4, is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
   dependencies:
@@ -18414,14 +18542,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-set@npm:^2.0.3":
+"is-set@npm:^2.0.2, is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 10c0/f73732e13f099b2dc879c2a12341cfc22ccaca8dd504e6edae26484bd5707a35d503fba5b4daad530a9b088ced1ae6c9d8200fd92e09b428fe14ea79ce8080b7
   languageName: node
   linkType: hard
 
-"is-shared-array-buffer@npm:^1.0.4":
+"is-shared-array-buffer@npm:^1.0.2, is-shared-array-buffer@npm:^1.0.4":
   version: 1.0.4
   resolution: "is-shared-array-buffer@npm:1.0.4"
   dependencies:
@@ -18437,7 +18565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-string@npm:^1.1.1":
+"is-string@npm:^1.0.7, is-string@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-string@npm:1.1.1"
   dependencies:
@@ -19794,7 +19922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -21917,6 +22045,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-is@npm:^1.1.5":
+  version: 1.1.6
+  resolution: "object-is@npm:1.1.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+  checksum: 10c0/506af444c4dce7f8e31f34fc549e2fb8152d6b9c4a30c6e62852badd7f520b579c679af433e7a072f9d78eb7808d230dc12e1cf58da9154dfbf8813099ea0fe0
+  languageName: node
+  linkType: hard
+
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -23311,6 +23449,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-18@npm:react@^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
+  languageName: node
+  linkType: hard
+
+"react-dom-18@npm:react-dom@^18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    scheduler: "npm:^0.23.2"
+  peerDependencies:
+    react: ^18.3.1
+  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^19.2.7":
   version: 19.2.7
   resolution: "react-dom@npm:19.2.7"
@@ -23631,7 +23790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
+"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
   dependencies:
@@ -24479,6 +24638,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:^0.27.0":
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
@@ -24793,6 +24961,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
+  languageName: node
+  linkType: hard
+
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -24815,6 +24993,19 @@ __metadata:
     object-inspect: "npm:^1.13.3"
     side-channel-map: "npm:^1.0.1"
   checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 
@@ -25195,7 +25386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stop-iteration-iterator@npm:^1.1.0":
+"stop-iteration-iterator@npm:^1.0.0, stop-iteration-iterator@npm:^1.1.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
   dependencies:
@@ -27259,7 +27450,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
+"which-boxed-primitive@npm:^1.0.2, which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
   dependencies:
@@ -27293,7 +27484,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-collection@npm:^1.0.2":
+"which-collection@npm:^1.0.1, which-collection@npm:^1.0.2":
   version: 1.0.2
   resolution: "which-collection@npm:1.0.2"
   dependencies:
@@ -27302,6 +27493,21 @@ __metadata:
     is-weakmap: "npm:^2.0.2"
     is-weakset: "npm:^2.0.3"
   checksum: 10c0/3345fde20964525a04cdf7c4a96821f85f0cc198f1b2ecb4576e08096746d129eb133571998fe121c77782ac8f21cbd67745a3d35ce100d26d4e684c142ea1f2
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.13":
+  version: 1.1.22
+  resolution: "which-typed-array@npm:1.1.22"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.9"
+    call-bound: "npm:^1.0.4"
+    for-each: "npm:^0.3.5"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10c0/e59db184a4e78b461fac3b05fafc1e7badbbedafbf04a967ee1de73717f1f9723a79699e7b5de71d449541cb5da8353efc01a4f8a72a152479850e54fa196c40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary & Rationale

Restores `@a2ui/react`'s `peerDependencies` range for `react` and `react-dom` to support React 18 (`^18.0.0 || ^19.0.0`) alongside React 19. Previously, syncpack collapsed `@a2ui/react`'s `peerDependencies` down to `^19.2.7`, breaking installation for downstream React 18 applications.

Additionally, added dual React 18 & 19 unit test matrix execution to `@a2ui/react` per code review feedback.

### Key Changes

- **Restored Peer Dependencies**: Restored `peerDependencies` range in `renderers/react/package.json` to `"^18.0.0 || ^19.0.0"`.
- **Syncpack Configuration**: Added an `isIgnored: true` version group rule in `.syncpackrc` for `@a2ui/react`'s `react` and `react-dom` peer dependencies.
- **Markdown-IT Syncpack Exemption**: Added an `isIgnored: true` rule in `.syncpackrc` for `@a2ui/markdown-it` so this PR remains laser-focused on React 18 dependencies.
- **React 18 & 19 Unit Test Matrix**: Added npm package alias devDependencies (`react-18`, `react-dom-18`, `@testing-library/react-18`), configured conditional module aliasing in `vitest.config.ts`, and added a `test:unit:react18` target so the full 475-test unit suite runs under both React 19 and React 18.

### Verification & Testing

- Verified dependency version compliance with `yarn lint:deps` (syncpack) — 0 errors.
- Built `@a2ui/react` with `yarn workspace @a2ui/react build`.
- Executed and passed all 475 unit tests under React 19 (`yarn workspace @a2ui/react test:unit`).
- Executed and passed all 475 unit tests under React 18 (`yarn workspace @a2ui/react test:unit:react18`).
- Verified all GitHub Actions CI checks pass on PR #2544.

Closes #2543