### PR TITLE
refactor(deps): standardize @a2ui/markdown-it workspace dependencies

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -12,6 +12,12 @@
       "packages": ["**"],
       "dependencies": ["zod"],
       "pinVersion": "^3.25.76"
+    },
+    {
+      "label": "Unified @a2ui/markdown-it version",
+      "packages": ["**"],
+      "dependencies": ["@a2ui/markdown-it"],
+      "pinVersion": "workspace:*"
     }
   ]
 }

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -41,7 +41,7 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@angular/common": "^21.2.5",
     "@angular/core": "^21.2.5",
     "@angular/platform-browser": "^21.2.5"
@@ -52,7 +52,7 @@
     }
   },
   "devDependencies": {
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@angular/build": "^21.2.5",
     "@angular/cli": "^21.2.5",
     "@angular/common": "^21.2.5",

--- a/renderers/lit/a2ui_explorer/package.json
+++ b/renderers/lit/a2ui_explorer/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@a2ui/lit": "workspace:*",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "@lit-labs/signals": "^0.3.0",
     "@lit/context": "^1.1.6",

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -121,7 +121,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/markdown-it": "*"
+    "@a2ui/markdown-it": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@a2ui/markdown-it": {

--- a/renderers/react/a2ui_explorer/package.json
+++ b/renderers/react/a2ui_explorer/package.json
@@ -88,7 +88,7 @@
     }
   },
   "dependencies": {
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/react": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "react": "^19.2.7",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -90,7 +90,7 @@
     "clean": "wireit"
   },
   "dependencies": {
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "clsx": "^2.1.1",
     "markdown-it": "^14.2.0",

--- a/renderers/react/visual-parity/package.json
+++ b/renderers/react/visual-parity/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@a2ui/lit": "workspace:*",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/react": "workspace:*",
     "@lit/context": "^1.1.6",
     "lit": "^3.3.3",

--- a/samples/client/angular/package.json
+++ b/samples/client/angular/package.json
@@ -21,7 +21,7 @@
   "private": true,
   "dependencies": {
     "@a2a-js/sdk": "^0.3.13",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "@angular/cdk": "^21.2.5",
     "@angular/common": "^21.2.5",

--- a/samples/client/angular/projects/restaurant/package.json
+++ b/samples/client/angular/projects/restaurant/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@a2ui/angular": "workspace:*",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/web_core": "workspace:*"
   },
   "devDependencies": {

--- a/samples/client/lit/package.json
+++ b/samples/client/lit/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@a2a-js/sdk": "^0.3.13",
     "@a2ui/lit": "workspace:*",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "@google/genai": "^2.8.0",
     "@lit-labs/signals": "^0.3.0",

--- a/samples/client/lit/shell/package.json
+++ b/samples/client/lit/shell/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@a2a-js/sdk": "^0.3.13",
     "@a2ui/lit": "workspace:*",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "@google/genai": "^2.8.0",
     "@lit-labs/signals": "^0.3.0",

--- a/samples/client/react/shell/package.json
+++ b/samples/client/react/shell/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.13",
-    "@a2ui/markdown-it": "*",
+    "@a2ui/markdown-it": "workspace:*",
     "@a2ui/react": "workspace:*",
     "@a2ui/web_core": "workspace:*",
     "react": "^19.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@a2ui/angular@workspace:renderers/angular"
   dependencies:
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@angular/build": "npm:^21.2.5"
     "@angular/cli": "npm:^21.2.5"
@@ -116,7 +116,7 @@ __metadata:
     wireit: "npm:^0.15.0-pre.2"
     zod: "npm:^3.25.76"
   peerDependencies:
-    "@a2ui/markdown-it": "*"
+    "@a2ui/markdown-it": "workspace:*"
     "@angular/common": ^21.2.5
     "@angular/core": ^21.2.5
     "@angular/platform-browser": ^21.2.5
@@ -170,7 +170,7 @@ __metadata:
   resolution: "@a2ui/lit-explorer@workspace:renderers/lit/a2ui_explorer"
   dependencies:
     "@a2ui/lit": "workspace:*"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@lit-labs/signals": "npm:^0.3.0"
     "@lit/context": "npm:^1.1.6"
@@ -199,7 +199,7 @@ __metadata:
   dependencies:
     "@a2a-js/sdk": "npm:^0.3.13"
     "@a2ui/lit": "workspace:*"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@google/genai": "npm:^2.8.0"
     "@lit-labs/signals": "npm:^0.3.0"
@@ -230,7 +230,7 @@ __metadata:
     wireit: "npm:^0.15.0-pre.2"
     zod: "npm:^3.25.76"
   peerDependencies:
-    "@a2ui/markdown-it": "*"
+    "@a2ui/markdown-it": "workspace:*"
   peerDependenciesMeta:
     "@a2ui/markdown-it":
       optional: true
@@ -263,7 +263,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@a2ui/react-explorer@workspace:renderers/react/a2ui_explorer"
   dependencies:
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/react": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@types/jasmine": "npm:^6.0.0"
@@ -289,7 +289,7 @@ __metadata:
   resolution: "@a2ui/react-shell@workspace:samples/client/react/shell"
   dependencies:
     "@a2a-js/sdk": "npm:^0.3.13"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/react": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@types/node": "npm:^25.9.3"
@@ -314,7 +314,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@a2ui/react@workspace:renderers/react"
   dependencies:
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@eslint/js": "npm:^10.0.1"
     "@testing-library/dom": "npm:^10.4.1"
@@ -368,7 +368,7 @@ __metadata:
   resolution: "@a2ui/restaurant@workspace:samples/client/angular/projects/restaurant"
   dependencies:
     "@a2ui/angular": "workspace:*"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     wireit: "npm:^0.15.0-pre.2"
   languageName: unknown
@@ -380,7 +380,7 @@ __metadata:
   dependencies:
     "@a2a-js/sdk": "npm:^0.3.13"
     "@a2ui/lit": "workspace:*"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@google/genai": "npm:^2.8.0"
     "@lit-labs/signals": "npm:^0.3.0"
@@ -431,7 +431,7 @@ __metadata:
   resolution: "@a2ui/visual-parity@workspace:renderers/react/visual-parity"
   dependencies:
     "@a2ui/lit": "workspace:*"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/react": "workspace:*"
     "@lit/context": "npm:^1.1.6"
     "@playwright/test": "npm:1.58.1"
@@ -12236,7 +12236,7 @@ __metadata:
   resolution: "angular-a2ui@workspace:samples/client/angular"
   dependencies:
     "@a2a-js/sdk": "npm:^0.3.13"
-    "@a2ui/markdown-it": "npm:*"
+    "@a2ui/markdown-it": "workspace:*"
     "@a2ui/web_core": "workspace:*"
     "@angular/build": "npm:^21.2.5"
     "@angular/cdk": "npm:^21.2.5"


### PR DESCRIPTION
### Summary & Rationale

Standardizes `@a2ui/markdown-it` dependency declarations across all internal workspace packages to use `workspace:*`. Previously, some packages used `*` while others used `workspace:*`, causing syncpack mismatch warnings when syncpack linting was run.

### Key Changes

- **Syncpack Configuration**: Added a `.syncpackrc` version group rule pinning `@a2ui/markdown-it` to `workspace:*`.
- **Package Manifest Updates**: Updated 12 `package.json` files across `renderers/` and `samples/` to use `"@a2ui/markdown-it": "workspace:*"`.
- **Lockfile**: Updated `yarn.lock`.

### Verification & Testing

- Verified dependency version compliance with `yarn lint:deps` (syncpack) — 0 errors.
- Verified all workspace builds and tests pass.