### PR TITLE
Fix issue #2545: Move non-spec proposals to docs/proposals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ To scale development across multiple programming languages and UI frameworks, th
 - **Concrete Codebases** track their module compliance by git commit hash using a `codebase.blueprint.md` file stored under `blueprints/codebases/<relative_codebase_path>/codebase.blueprint.md`.
 - **SDD Skills**: SDD skills live in `blueprints/skills/` and can be symlinked into `.agents/skills/` by running `./blueprints/link_skills.sh`. To remove them when done, remove the `.agents/skills/a2ui-*` symlinks.
 
-For a detailed explanation of the methodology, lifecycle, and workflows, read the [Spec-Driven Development Proposal](specification/proposals/spec_driven_development.md).
+For a detailed explanation of the methodology, lifecycle, and workflows, read the [Spec-Driven Development Proposal](docs/proposals/spec_driven_development.md).
 
 ---
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -58,4 +58,4 @@ rm -f .agents/skills/a2ui-blueprint-navigator \
 - **Feature Blueprints (`features/`)**: Standalone specification files for new features. Features begin as optional specs in `features/<feature_name>.blueprint.md`. When merged into a Module Blueprint, the feature blueprint file is moved to `features/archived/<feature_name>.blueprint.md`.
 - **Codebase Blueprints (`codebases/`)**: Track each concrete codebase implementation's compliance with its associated Module Blueprint at a specific git commit hash (`module_blueprint_commit`), along with any optional features it implements (`implemented_features`).
 
-For full details on the SDD workflow, read [`specification/proposals/spec_driven_development.md`](../specification/proposals/spec_driven_development.md).
+For full details on the SDD workflow, read [`docs/proposals/spec_driven_development.md`](../docs/proposals/spec_driven_development.md).

--- a/docs/proposals/eval_suite_expansion.md
+++ b/docs/proposals/eval_suite_expansion.md
@@ -204,8 +204,8 @@ Across the LLM ecosystem (OpenAI, Anthropic, LiteLLM, Ollama, and Inspect AI), `
 - **Direct framework alignment**: Inspect AI stores conversation turns in `state.messages`. Using `messages` in our YAML schema creates a 1:1 conceptual mapping.
 - **Avoids ambiguity**: The word "context" is overloaded in AI (often referring to RAG retrieval chunks, context windows, or A2UI action event contexts like `action.event.context`). `messages` unambiguously refers to the chat history.
 - **Consistent single-turn and multi-turn authoring**:
-  - **Single-turn prompt**: `messages` contains a single user turn (`role: user`, `content: "Create a login form"`).
-  - **Multi-turn conversation**: `messages` contains prior user, assistant, and tool turns, ending with the user turn that prompts the UI response.
+    - **Single-turn prompt**: `messages` contains a single user turn (`role: user`, `content: "Create a login form"`).
+    - **Multi-turn conversation**: `messages` contains prior user, assistant, and tool turns, ending with the user turn that prompts the UI response.
 
 #### 3. `target` vs `description`
 
@@ -423,12 +423,12 @@ The solver invokes `measured_generate()`, passing the assembled message list to 
 ### Step 4: Multi-stage scoring
 
 1. **Programmatic validation ([a2ui_scorer](../../eval/a2ui_eval/scorers.py))**:
-   - Resolves the required `catalog` path specified in the data point.
-   - Parses JSON from `<a2ui-json>` tags.
-   - Runs the catalog validator ([A2uiValidator](../../agent_sdks/python/a2ui_agent/README.md)) to verify schema adherence, parent-child references, and root component presence.
+    - Resolves the required `catalog` path specified in the data point.
+    - Parses JSON from `<a2ui-json>` tags.
+    - Runs the catalog validator ([A2uiValidator](../../agent_sdks/python/a2ui_agent/README.md)) to verify schema adherence, parent-child references, and root component presence.
 2. **LLM judge scoring ([measured_model_graded_qa](../../eval/a2ui_eval/scorers.py))**:
-   - Evaluates the generated UI against the `target` criteria using the grading model (e.g. `google/gemini-3.5-flash`).
-   - Produces a grade of `C` (Correct), `P` (Partial Credit), or `I` (Incorrect).
+    - Evaluates the generated UI against the `target` criteria using the grading model (e.g. `google/gemini-3.5-flash`).
+    - Produces a grade of `C` (Correct), `P` (Partial Credit), or `I` (Incorrect).
 
 ---
 

--- a/docs/proposals/spec_driven_development.md
+++ b/docs/proposals/spec_driven_development.md
@@ -110,7 +110,7 @@ Allow agents or clients to dynamically adjust the visual theme of an active surf
 ## **Links**
 
 - RFC/Discussion: [Issue #452](https://github.com/a2ui-project/a2ui/issues/452)
-- Protocol Specification: [a2ui_protocol.md](../v1_0/docs/a2ui_protocol.md)
+- Protocol Specification: [a2ui_protocol.md](../../specification/v1_0/docs/a2ui_protocol.md)
 
 ## **Test Cases & Conformance**
 
@@ -236,14 +236,14 @@ This section explains what steps will be taken by developers and agents to perfo
 1. Read the relevant module blueprint
 2. Search for all codebases that associated with the module
 3. Analyse every codebase associated with the module, identifying:
-   1. Required features that are missing from each codebase
-   2. Discrepancies between the blueprint and the actual implementation e.g. API names or structures which are inconsistent
-   3. Discrepancies between the codebases, for which the module blueprint provides no guidance.
+    1. Required features that are missing from each codebase
+    2. Discrepancies between the blueprint and the actual implementation e.g. API names or structures which are inconsistent
+    3. Discrepancies between the codebases, for which the module blueprint provides no guidance.
 4. Report the above and propose actions to take to reduce the inconsistencies including:
-   1. Adding additional detail to the blueprints to reduce ambiguity
-   2. Update the module blueprint to explicitly mark a detail as being a codebase-level decision
-   3. Updating codebases to match the module blueprints
-   4. Update the codebase blueprint to document a reason that it has intentionally deviated from the module blueprint for a language-specific reason.
+    1. Adding additional detail to the blueprints to reduce ambiguity
+    2. Update the module blueprint to explicitly mark a detail as being a codebase-level decision
+    3. Updating codebases to match the module blueprints
+    4. Update the codebase blueprint to document a reason that it has intentionally deviated from the module blueprint for a language-specific reason.
 5. Implement some of the proposed actions, based on human discretion **(significant human input required)**
 6. Send PR for review.
 


### PR DESCRIPTION
### Summary & Rationale
Moved non-specification proposal documents (`spec_driven_development.md` and `eval_suite_expansion.md`) from `specification/proposals/` to a new `docs/proposals/` directory. These proposals address repository-level development methodologies (Spec-Driven Development / blueprints) and testing infrastructure (evaluation framework expansion), rather than core A2UI wire format specifications and catalogs.

### Key Changes
- Moved `spec_driven_development.md` and `eval_suite_expansion.md` from `specification/proposals/` to `docs/proposals/`.
- Updated cross-document references in `AGENTS.md` and `blueprints/README.md` to point to `docs/proposals/spec_driven_development.md`.
- Updated relative link to `a2ui_protocol.md` inside `docs/proposals/spec_driven_development.md`.
- Preserved specification proposals (`user_initiated_functions.md` and inference formats `atom/`, `elemental/`, `express/`) under `specification/proposals/`.

### Verification & Testing
- Validated specification schemas and examples: `./bin/python3 specification/scripts/validate.py` (Overall Validation: PASSED).
- Verified eval test suite: `uv run --project eval pytest eval/tests` (33 passed).
- Verified agent SDK test suite: `uv run --project agent_sdks/python/a2ui_agent pytest agent_sdks/python/a2ui_agent/tests/` (589 passed).
- Verified Express DSL integration and CLI tools: `uv run --project agent_sdks/python/a2ui_agent pytest agent_sdks/python/a2ui_agent/tests/express/` (75 passed).
- Verified licensing and formatting: `./bin/python3 ./scripts/fix_licenses.py --check` and Prettier format check.

Closes #2545