### PR TITLE
feat(eval): support Express format evaluations with Gemma models (#2548)

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -91,6 +91,49 @@ For a quick 2-sample validation using `gemini-3.1-flash-lite`:
 uv run main.py --sanity
 ```
 
+### Running Evaluations on Gemma Models (Express Format)
+
+Gemma models can be evaluated directly through the Google AI Studio / Gemini API cloud service using your standard `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). **No local GPU, Ollama, or custom server hosting is required.**
+
+> [!NOTE]
+> Gemma evaluations do not run by default or as part of CI workflows. CI evaluations continue to use `google/gemini-3.5-flash`.
+
+#### Required API Keys
+
+Set your standard Google Gemini API key:
+
+```bash
+export GEMINI_API_KEY="your_api_key_here"
+```
+
+You can obtain an API key from [Google AI Studio](https://aistudio.google.com/).
+
+#### Available Cloud Gemma Models
+
+- **Mobile / On-Device Tier (`--gemma` or `--gemma mobile` or `--model gemma-4-26b`)**:
+  `google/gemma-4-26b-a4b-it` — A Mixture-of-Experts model with 26B total parameters and **4B active parameters** (`a4b`), representative of the class of lightweight models feasible for execution on modern mobile hardware.
+- **Large / Workstation Tier (`--gemma large` or `--model gemma-4-31b`)**:
+  `google/gemma-4-31b-it` — A 31B dense parameter model offering higher reasoning capacity.
+
+#### Example Commands
+
+```bash
+# Run Gemma 4 mobile tier on Express format (default strategy for --gemma is express)
+uv run main.py --gemma
+
+# Run Gemma 4 large tier (31B) on Express format
+uv run main.py --gemma large
+
+# Run on a specific dataset or limit sample count for quick checks
+uv run main.py --gemma --dataset core_v1_0 --limit 3
+
+# Run across specific prompts
+uv run main.py --gemma --dataset core_v1_0 --prompt deleteSurface --prompt loginForm
+```
+
+> [!IMPORTANT]
+> **LLM-as-a-Judge Rule**: Gemma models must **never** be used as the evaluation grader (`--grading-model`). The grading model defaults to and must remain a Gemini Flash model (e.g. `google/gemini-3.5-flash` or `google/gemini-3.1-flash-lite`) to ensure consistent, unbiased grading.
+
 ## Viewing Evaluation Results
 
 Inspect AI provides a web-based log viewer to explore interactive traces and judge rationales:

--- a/eval/README.md
+++ b/eval/README.md
@@ -93,14 +93,14 @@ uv run main.py --sanity
 
 ### Running Evaluations on Gemma Models (Express Format)
 
-Gemma models can be evaluated directly through the Google AI Studio / Gemini API cloud service using your standard `GEMINI_API_KEY` (or `GOOGLE_API_KEY`). **No local GPU, Ollama, or custom server hosting is required.**
+Gemma models can be evaluated either through **Google AI Studio / Gemini API cloud services** (no local GPU required) or **locally via Ollama** on a machine with a dedicated GPU.
 
 > [!NOTE]
 > Gemma evaluations do not run by default or as part of CI workflows. CI evaluations continue to use `google/gemini-3.5-flash`.
 
 #### Required API Keys
 
-Set your standard Google Gemini API key:
+Regardless of whether inference runs in the cloud or via Ollama, evaluation grading uses Gemini Flash as the LLM-as-a-judge. Set your Google Gemini API key:
 
 ```bash
 export GEMINI_API_KEY="your_api_key_here"
@@ -108,14 +108,12 @@ export GEMINI_API_KEY="your_api_key_here"
 
 You can obtain an API key from [Google AI Studio](https://aistudio.google.com/).
 
-#### Available Cloud Gemma Models
+#### Option A: Cloud Execution (Google AI Studio / Gemini API)
 
 - **Mobile / On-Device Tier (`--gemma` or `--gemma mobile` or `--model gemma-4-26b`)**:
   `google/gemma-4-26b-a4b-it` — A Mixture-of-Experts model with 26B total parameters and **4B active parameters** (`a4b`), representative of the class of lightweight models feasible for execution on modern mobile hardware.
 - **Large / Workstation Tier (`--gemma large` or `--model gemma-4-31b`)**:
   `google/gemma-4-31b-it` — A 31B dense parameter model offering higher reasoning capacity.
-
-#### Example Commands
 
 ```bash
 # Run Gemma 4 mobile tier on Express format (default strategy for --gemma is express)
@@ -126,13 +124,42 @@ uv run main.py --gemma large
 
 # Run on a specific dataset or limit sample count for quick checks
 uv run main.py --gemma --dataset core_v1_0 --limit 3
-
-# Run across specific prompts
-uv run main.py --gemma --dataset core_v1_0 --prompt deleteSurface --prompt loginForm
 ```
 
+#### Option B: Local / Edge Execution via Ollama (GPU-Accelerated)
+
+For smaller edge-optimized models that can run fully offline on standard or flagship smartphones (requiring 6–8 GB RAM):
+
+- **Gemma 4 E2B (`--gemma e2b` or `--model gemma-e2b`)**:
+  `ollama/gemma4:e2b` — Edge model designed for standard smartphones (~6 GB RAM offline).
+- **Gemma 4 E4B (`--gemma e4b` or `--model gemma-e4b`)**:
+  `ollama/gemma4:e4b` — Edge model designed for recent flagship smartphones (~8 GB RAM offline).
+- **Gemma 2 2B (`--gemma 2b` or `--model gemma-2b`)**:
+  `ollama/gemma2:2b` — Lightweight 2B parameter open model.
+
+**Prerequisites**:
+
+1. Install [Ollama](https://ollama.com/) and start the daemon:
+   ```bash
+   ollama serve
+   ```
+2. Pull the target model(s):
+   ```bash
+   ollama pull gemma4:e2b
+   ollama pull gemma4:e4b
+   ```
+3. Run the evaluation against your local Ollama instance:
+
+   ```bash
+   # Run Gemma 4 E2B via Ollama
+   uv run main.py --gemma e2b --dataset core_v1_0 --limit 3
+
+   # Run Gemma 4 E4B via Ollama
+   uv run main.py --gemma e4b --dataset core_v1_0 --limit 3
+   ```
+
 > [!IMPORTANT]
-> **LLM-as-a-Judge Rule**: Gemma models must **never** be used as the evaluation grader (`--grading-model`). The grading model defaults to and must remain a Gemini Flash model (e.g. `google/gemini-3.5-flash` or `google/gemini-3.1-flash-lite`) to ensure consistent, unbiased grading.
+> **LLM-as-a-Judge Rule**: Gemma models must **never** be used as the evaluation grader (`--grading-model`). The grading model defaults to and must remain a Gemini Flash model (e.g. `google/gemini-3.5-flash` or `google/gemini-3.1-flash-lite`) to ensure consistent, unbiased grading. Ensure `GEMINI_API_KEY` is set when running Ollama evaluations.
 
 ## Viewing Evaluation Results
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -110,35 +110,31 @@ You can obtain an API key from [Google AI Studio](https://aistudio.google.com/).
 
 #### Option A: Cloud Execution (Google AI Studio / Gemini API)
 
-- **Mobile / On-Device Tier (`--model gemma` or `--gemma`)**:
+- **Mobile / On-Device Tier (`--model gemma` or `--model gemma-4-26b`)**:
   `google/gemma-4-26b-a4b-it` — A Mixture-of-Experts model with 26B total parameters and **4B active parameters** (`a4b`), representative of the class of lightweight models feasible for execution on modern mobile hardware.
-- **Large / Workstation Tier (`--model gemma-large` or `--gemma large`)**:
+- **Large / Workstation Tier (`--model gemma-large` or `--model gemma-4-31b`)**:
   `google/gemma-4-31b-it` — A 31B dense parameter model offering higher reasoning capacity.
 
 ```bash
-# Run Gemma 4 mobile tier on Express format (Gemma models automatically default to express)
-uv run main.py --model gemma
+# Run Gemma 4 mobile tier on Express format using --strategies express
+uv run main.py --model gemma --strategies express
 
 # Run Gemma 4 large tier (31B) on Express format
-uv run main.py --model gemma-large
+uv run main.py --model gemma-large --strategies express
 
 # Run on a specific dataset or limit sample count for quick checks
-uv run main.py --model gemma --dataset core_v1_0 --limit 3
-
-# Or use the convenient shorthand:
-uv run main.py --gemma
-uv run main.py --gemma large
+uv run main.py --model gemma --strategies express --dataset core_v1_0 --limit 3
 ```
 
 #### Option B: Local / Edge Execution via Ollama (GPU-Accelerated)
 
 For smaller edge-optimized models that can run fully offline on standard or flagship smartphones (requiring 6–8 GB RAM):
 
-- **Gemma 4 E2B (`--model gemma4:e2b` or `--gemma e2b`)**:
+- **Gemma 4 E2B (`--model gemma-e2b` or `--model gemma4:e2b`)**:
   `ollama/gemma4:e2b` — Edge model designed for standard smartphones (~6 GB RAM offline).
-- **Gemma 4 E4B (`--model gemma4:e4b` or `--gemma e4b`)**:
+- **Gemma 4 E4B (`--model gemma-e4b` or `--model gemma4:e4b`)**:
   `ollama/gemma4:e4b` — Edge model designed for recent flagship smartphones (~8 GB RAM offline).
-- **Gemma 2 2B (`--model gemma2:2b` or `--gemma 2b`)**:
+- **Gemma 2 2B (`--model gemma-2b` or `--model gemma2:2b`)**:
   `ollama/gemma2:2b` — Lightweight 2B parameter open model.
 
 **Prerequisites**:
@@ -155,14 +151,8 @@ For smaller edge-optimized models that can run fully offline on standard or flag
 3. Run the evaluation against your local Ollama instance:
 
    ```bash
-   # Run Gemma 4 E2B via Ollama
-   uv run main.py --model gemma4:e2b --dataset core_v1_0 --limit 3
-
-   # Run Gemma 4 E4B via Ollama
-   uv run main.py --model gemma4:e4b --dataset core_v1_0 --limit 3
-
-   # Or using the shorthand:
-   uv run main.py --gemma e2b --dataset core_v1_0 --limit 3
+   # Run Gemma 4 E2B on Express format via Ollama
+   uv run main.py --model gemma-e2b --strategies express --dataset core_v1_0 --limit 3
    ```
 
 > [!IMPORTANT]

--- a/eval/README.md
+++ b/eval/README.md
@@ -110,31 +110,35 @@ You can obtain an API key from [Google AI Studio](https://aistudio.google.com/).
 
 #### Option A: Cloud Execution (Google AI Studio / Gemini API)
 
-- **Mobile / On-Device Tier (`--gemma` or `--gemma mobile` or `--model gemma-4-26b`)**:
+- **Mobile / On-Device Tier (`--model gemma` or `--gemma`)**:
   `google/gemma-4-26b-a4b-it` — A Mixture-of-Experts model with 26B total parameters and **4B active parameters** (`a4b`), representative of the class of lightweight models feasible for execution on modern mobile hardware.
-- **Large / Workstation Tier (`--gemma large` or `--model gemma-4-31b`)**:
+- **Large / Workstation Tier (`--model gemma-large` or `--gemma large`)**:
   `google/gemma-4-31b-it` — A 31B dense parameter model offering higher reasoning capacity.
 
 ```bash
-# Run Gemma 4 mobile tier on Express format (default strategy for --gemma is express)
-uv run main.py --gemma
+# Run Gemma 4 mobile tier on Express format (Gemma models automatically default to express)
+uv run main.py --model gemma
 
 # Run Gemma 4 large tier (31B) on Express format
-uv run main.py --gemma large
+uv run main.py --model gemma-large
 
 # Run on a specific dataset or limit sample count for quick checks
-uv run main.py --gemma --dataset core_v1_0 --limit 3
+uv run main.py --model gemma --dataset core_v1_0 --limit 3
+
+# Or use the convenient shorthand:
+uv run main.py --gemma
+uv run main.py --gemma large
 ```
 
 #### Option B: Local / Edge Execution via Ollama (GPU-Accelerated)
 
 For smaller edge-optimized models that can run fully offline on standard or flagship smartphones (requiring 6–8 GB RAM):
 
-- **Gemma 4 E2B (`--gemma e2b` or `--model gemma-e2b`)**:
+- **Gemma 4 E2B (`--model gemma4:e2b` or `--gemma e2b`)**:
   `ollama/gemma4:e2b` — Edge model designed for standard smartphones (~6 GB RAM offline).
-- **Gemma 4 E4B (`--gemma e4b` or `--model gemma-e4b`)**:
+- **Gemma 4 E4B (`--model gemma4:e4b` or `--gemma e4b`)**:
   `ollama/gemma4:e4b` — Edge model designed for recent flagship smartphones (~8 GB RAM offline).
-- **Gemma 2 2B (`--gemma 2b` or `--model gemma-2b`)**:
+- **Gemma 2 2B (`--model gemma2:2b` or `--gemma 2b`)**:
   `ollama/gemma2:2b` — Lightweight 2B parameter open model.
 
 **Prerequisites**:
@@ -152,10 +156,13 @@ For smaller edge-optimized models that can run fully offline on standard or flag
 
    ```bash
    # Run Gemma 4 E2B via Ollama
-   uv run main.py --gemma e2b --dataset core_v1_0 --limit 3
+   uv run main.py --model gemma4:e2b --dataset core_v1_0 --limit 3
 
    # Run Gemma 4 E4B via Ollama
-   uv run main.py --gemma e4b --dataset core_v1_0 --limit 3
+   uv run main.py --model gemma4:e4b --dataset core_v1_0 --limit 3
+
+   # Or using the shorthand:
+   uv run main.py --gemma e2b --dataset core_v1_0 --limit 3
    ```
 
 > [!IMPORTANT]

--- a/eval/main.py
+++ b/eval/main.py
@@ -45,20 +45,6 @@ MODEL_ALIASES: dict[str, str] = {
     "gemma-2b": "ollama/gemma2:2b",
 }
 
-GEMMA_TIER_ALIASES: dict[str, str] = {
-    "mobile": "gemma",
-    "26b": "gemma",
-    "large": "gemma-large",
-    "31b": "gemma-large",
-    "e2b": "gemma-e2b",
-    "e4b": "gemma-e4b",
-    "2b": "gemma-2b",
-}
-
-MODEL_DEFAULT_STRATEGIES: dict[str, list[str]] = {
-    "gemma": ["express"],
-}
-
 RESTRICTED_GRADING_MODEL_FAMILIES = ("gemma",)
 
 
@@ -88,16 +74,6 @@ def main() -> None:
         help="Run a quick sanity check (2 samples, gemini-3.1-flash-lite, 0 retry)",
     )
     parser.add_argument(
-        "--gemma",
-        nargs="?",
-        const="mobile",
-        default=None,
-        help=(
-            "Evaluate using Gemma models (defaults to mobile; accepts tier e.g."
-            " 'large', 'e2b', 'e4b'). Sets default strategy to 'express'."
-        ),
-    )
-    parser.add_argument(
         "--dataset",
         type=str,
         default=None,
@@ -116,7 +92,7 @@ def main() -> None:
         type=str,
         default="google/gemini-3.5-flash",
         help=(
-            "Model used to evaluate tasks (or alias like 'gemma-mobile', 'gemma-4-26b')"
+            "Model used to evaluate tasks (or alias like 'gemma', 'gemma-4-26b')"
         ),
     )
     parser.add_argument(
@@ -183,11 +159,8 @@ def main() -> None:
         help="Number of epochs/repetitions to run for each evaluation sample",
     )
     args = parser.parse_args()
-
     if args.sanity:
         model = "google/gemini-3.1-flash-lite"
-    elif args.gemma:
-        model = resolve_model_name(GEMMA_TIER_ALIASES.get(args.gemma, args.gemma))
     else:
         model = resolve_model_name(args.model)
 
@@ -213,20 +186,7 @@ def main() -> None:
 
     # Parse and validate strategies
     selected_strategies = []
-    if args.strategies:
-        raw_strategies = args.strategies
-    else:
-        matched_strats = next(
-            (
-                strats
-                for family, strats in MODEL_DEFAULT_STRATEGIES.items()
-                if family in model.lower()
-            ),
-            None,
-        )
-        raw_strategies = (
-            matched_strats if matched_strats else ["direct", "subagent_tool"]
-        )
+    raw_strategies = args.strategies if args.strategies else ["direct", "subagent_tool"]
     for item in raw_strategies:
         for s in item.split(","):
             s_clean = s.strip()

--- a/eval/main.py
+++ b/eval/main.py
@@ -60,14 +60,15 @@ MODEL_ALIASES: dict[str, str] = {
 
 def resolve_model_name(model_name: str) -> str:
     """Resolves convenience aliases and short names to fully qualified model IDs."""
-    lower_name = model_name.lower().strip()
+    stripped_name = model_name.strip()
+    lower_name = stripped_name.lower()
     if lower_name in MODEL_ALIASES:
         return MODEL_ALIASES[lower_name]
     if lower_name.startswith("ollama:"):
-        return f"ollama/{model_name[7:]}"
+        return f"ollama/{stripped_name[7:]}"
     if lower_name.startswith(("gemma-", "gemini-")):
-        return f"google/{model_name}"
-    return model_name
+        return f"google/{stripped_name}"
+    return stripped_name
 
 
 def main() -> None:
@@ -213,7 +214,7 @@ def main() -> None:
     selected_strategies = []
     if args.strategies:
         raw_strategies = args.strategies
-    elif args.gemma:
+    elif args.gemma or "gemma" in model.lower():
         raw_strategies = ["express"]
     else:
         raw_strategies = ["direct", "subagent_tool"]

--- a/eval/main.py
+++ b/eval/main.py
@@ -84,9 +84,7 @@ def main() -> None:
         "--model",
         type=str,
         default="google/gemini-3.5-flash",
-        help=(
-            "Model used to evaluate tasks (or alias like 'gemma', 'gemma-4-26b')"
-        ),
+        help="Model used to evaluate tasks (or alias like 'gemma', 'gemma-4-26b')",
     )
     parser.add_argument(
         "--grading-model",

--- a/eval/main.py
+++ b/eval/main.py
@@ -28,21 +28,14 @@ from inspect_ai.dataset import MemoryDataset
 
 MODEL_ALIASES: dict[str, str] = {
     # Cloud models
-    "gemma": "google/gemma-4-26b-a4b-it",
-    "gemma-mobile": "google/gemma-4-26b-a4b-it",
     "gemma-4-26b": "google/gemma-4-26b-a4b-it",
-    "gemma-large": "google/gemma-4-31b-it",
     "gemma-4-31b": "google/gemma-4-31b-it",
-    "flash": "google/gemini-3.5-flash",
-    "gemini-flash": "google/gemini-3.5-flash",
-    "flash-lite": "google/gemini-3.1-flash-lite",
-    "gemini-flash-lite": "google/gemini-3.1-flash-lite",
-    # Ollama edge convenience aliases (without colon)
-    "gemma-e2b": "ollama/gemma4:e2b",
+    "gemini-3.5-flash": "google/gemini-3.5-flash",
+    "gemini-3.1-flash-lite": "google/gemini-3.1-flash-lite",
+    # Ollama edge convenience aliases
     "gemma-4-e2b": "ollama/gemma4:e2b",
-    "gemma-e4b": "ollama/gemma4:e4b",
     "gemma-4-e4b": "ollama/gemma4:e4b",
-    "gemma-2b": "ollama/gemma2:2b",
+    "gemma-2-2b": "ollama/gemma2:2b",
 }
 
 RESTRICTED_GRADING_MODEL_FAMILIES = ("gemma",)

--- a/eval/main.py
+++ b/eval/main.py
@@ -27,48 +27,57 @@ os.environ["INSPECT_MODEL_MAX_BACKOFF"] = "300"
 from inspect_ai.dataset import MemoryDataset
 
 MODEL_ALIASES: dict[str, str] = {
-    # Gemma models (cloud hosted via Google AI Studio / Gemini API)
+    # Cloud models
     "gemma": "google/gemma-4-26b-a4b-it",
     "gemma-mobile": "google/gemma-4-26b-a4b-it",
     "gemma-4-26b": "google/gemma-4-26b-a4b-it",
-    "gemma-4-26b-a4b": "google/gemma-4-26b-a4b-it",
-    "gemma-4-26b-a4b-it": "google/gemma-4-26b-a4b-it",
     "gemma-large": "google/gemma-4-31b-it",
     "gemma-4-31b": "google/gemma-4-31b-it",
-    "gemma-4-31b-it": "google/gemma-4-31b-it",
-    # Gemma edge / local models (via Ollama)
-    "gemma-e2b": "ollama/gemma4:e2b",
-    "gemma-4-e2b": "ollama/gemma4:e2b",
-    "gemma4:e2b": "ollama/gemma4:e2b",
-    "gemma-e4b": "ollama/gemma4:e4b",
-    "gemma-4-e4b": "ollama/gemma4:e4b",
-    "gemma4:e4b": "ollama/gemma4:e4b",
-    "gemma-2b": "ollama/gemma2:2b",
-    "gemma-2-2b": "ollama/gemma2:2b",
-    "gemma2:2b": "ollama/gemma2:2b",
-    # Gemini models
     "flash": "google/gemini-3.5-flash",
     "gemini-flash": "google/gemini-3.5-flash",
-    "gemini-3-flash": "google/gemini-3.5-flash",
-    "gemini-3.5-flash": "google/gemini-3.5-flash",
     "flash-lite": "google/gemini-3.1-flash-lite",
     "gemini-flash-lite": "google/gemini-3.1-flash-lite",
-    "gemini-3-flash-lite": "google/gemini-3.1-flash-lite",
-    "gemini-3.1-flash-lite": "google/gemini-3.1-flash-lite",
+    # Ollama edge convenience aliases (without colon)
+    "gemma-e2b": "ollama/gemma4:e2b",
+    "gemma-4-e2b": "ollama/gemma4:e2b",
+    "gemma-e4b": "ollama/gemma4:e4b",
+    "gemma-4-e4b": "ollama/gemma4:e4b",
+    "gemma-2b": "ollama/gemma2:2b",
 }
+
+GEMMA_TIER_ALIASES: dict[str, str] = {
+    "mobile": "gemma",
+    "26b": "gemma",
+    "large": "gemma-large",
+    "31b": "gemma-large",
+    "e2b": "gemma-e2b",
+    "e4b": "gemma-e4b",
+    "2b": "gemma-2b",
+}
+
+MODEL_DEFAULT_STRATEGIES: dict[str, list[str]] = {
+    "gemma": ["express"],
+}
+
+RESTRICTED_GRADING_MODEL_FAMILIES = ("gemma",)
 
 
 def resolve_model_name(model_name: str) -> str:
-    """Resolves convenience aliases and short names to fully qualified model IDs."""
-    stripped_name = model_name.strip()
-    lower_name = stripped_name.lower()
-    if lower_name in MODEL_ALIASES:
-        return MODEL_ALIASES[lower_name]
-    if lower_name.startswith("ollama:"):
-        return f"ollama/{stripped_name[7:]}"
-    if lower_name.startswith(("gemma-", "gemini-")):
-        return f"google/{stripped_name}"
-    return stripped_name
+    """Resolves convenience aliases and provider conventions to fully qualified model IDs."""
+    stripped = model_name.strip()
+    lower = stripped.lower()
+    if lower in MODEL_ALIASES:
+        return MODEL_ALIASES[lower]
+    if "/" in stripped:
+        return stripped
+    if lower.startswith("ollama:"):
+        return f"ollama/{stripped[7:]}"
+    if ":" in stripped:
+        # Standard Ollama model tag convention (e.g. 'gemma4:e2b', 'llama3:8b')
+        return f"ollama/{stripped}"
+    if lower.startswith(("gemma-", "gemini-")):
+        return f"google/{stripped}"
+    return stripped
 
 
 def main() -> None:
@@ -82,11 +91,10 @@ def main() -> None:
         "--gemma",
         nargs="?",
         const="mobile",
-        choices=["mobile", "26b", "large", "31b", "e2b", "e4b", "2b"],
+        default=None,
         help=(
-            "Evaluate using Gemma models (cloud: mobile/26b, large/31b; local/Ollama:"
-            " e2b, e4b, 2b). Defaults to mobile (26b-a4b-it, 4B active params via cloud"
-            " API). Sets default strategy to 'express'."
+            "Evaluate using Gemma models (defaults to mobile; accepts tier e.g."
+            " 'large', 'e2b', 'e4b'). Sets default strategy to 'express'."
         ),
     )
     parser.add_argument(
@@ -179,21 +187,14 @@ def main() -> None:
     if args.sanity:
         model = "google/gemini-3.1-flash-lite"
     elif args.gemma:
-        if args.gemma in ["large", "31b"]:
-            model = "google/gemma-4-31b-it"
-        elif args.gemma == "e2b":
-            model = "ollama/gemma4:e2b"
-        elif args.gemma == "e4b":
-            model = "ollama/gemma4:e4b"
-        elif args.gemma == "2b":
-            model = "ollama/gemma2:2b"
-        else:
-            model = "google/gemma-4-26b-a4b-it"
+        model = resolve_model_name(GEMMA_TIER_ALIASES.get(args.gemma, args.gemma))
     else:
         model = resolve_model_name(args.model)
 
     grading_model = resolve_model_name(args.grading_model)
-    if "gemma" in grading_model.lower():
+    if any(
+        family in grading_model.lower() for family in RESTRICTED_GRADING_MODEL_FAMILIES
+    ):
         raise ValueError(
             f"Invalid grading model '{grading_model}'. Gemma models must not be used"
             " as LLM-as-a-judge; please use a Gemini Flash model (e.g."
@@ -214,10 +215,18 @@ def main() -> None:
     selected_strategies = []
     if args.strategies:
         raw_strategies = args.strategies
-    elif args.gemma or "gemma" in model.lower():
-        raw_strategies = ["express"]
     else:
-        raw_strategies = ["direct", "subagent_tool"]
+        matched_strats = next(
+            (
+                strats
+                for family, strats in MODEL_DEFAULT_STRATEGIES.items()
+                if family in model.lower()
+            ),
+            None,
+        )
+        raw_strategies = (
+            matched_strats if matched_strats else ["direct", "subagent_tool"]
+        )
     for item in raw_strategies:
         for s in item.split(","):
             s_clean = s.strip()

--- a/eval/main.py
+++ b/eval/main.py
@@ -36,6 +36,16 @@ MODEL_ALIASES: dict[str, str] = {
     "gemma-large": "google/gemma-4-31b-it",
     "gemma-4-31b": "google/gemma-4-31b-it",
     "gemma-4-31b-it": "google/gemma-4-31b-it",
+    # Gemma edge / local models (via Ollama)
+    "gemma-e2b": "ollama/gemma4:e2b",
+    "gemma-4-e2b": "ollama/gemma4:e2b",
+    "gemma4:e2b": "ollama/gemma4:e2b",
+    "gemma-e4b": "ollama/gemma4:e4b",
+    "gemma-4-e4b": "ollama/gemma4:e4b",
+    "gemma4:e4b": "ollama/gemma4:e4b",
+    "gemma-2b": "ollama/gemma2:2b",
+    "gemma-2-2b": "ollama/gemma2:2b",
+    "gemma2:2b": "ollama/gemma2:2b",
     # Gemini models
     "flash": "google/gemini-3.5-flash",
     "gemini-flash": "google/gemini-3.5-flash",
@@ -53,6 +63,8 @@ def resolve_model_name(model_name: str) -> str:
     lower_name = model_name.lower().strip()
     if lower_name in MODEL_ALIASES:
         return MODEL_ALIASES[lower_name]
+    if lower_name.startswith("ollama:"):
+        return f"ollama/{model_name[7:]}"
     if lower_name.startswith(("gemma-", "gemini-")):
         return f"google/{model_name}"
     return model_name
@@ -69,11 +81,11 @@ def main() -> None:
         "--gemma",
         nargs="?",
         const="mobile",
-        choices=["mobile", "26b", "large", "31b"],
+        choices=["mobile", "26b", "large", "31b", "e2b", "e4b", "2b"],
         help=(
-            "Evaluate using Gemma models via cloud API (choices: mobile, 26b, large,"
-            " 31b). Defaults to mobile (26b-a4b-it, 4B active params). Sets"
-            " default strategy to 'express'."
+            "Evaluate using Gemma models (cloud: mobile/26b, large/31b; local/Ollama:"
+            " e2b, e4b, 2b). Defaults to mobile (26b-a4b-it, 4B active params via cloud"
+            " API). Sets default strategy to 'express'."
         ),
     )
     parser.add_argument(
@@ -168,6 +180,12 @@ def main() -> None:
     elif args.gemma:
         if args.gemma in ["large", "31b"]:
             model = "google/gemma-4-31b-it"
+        elif args.gemma == "e2b":
+            model = "ollama/gemma4:e2b"
+        elif args.gemma == "e4b":
+            model = "ollama/gemma4:e4b"
+        elif args.gemma == "2b":
+            model = "ollama/gemma2:2b"
         else:
             model = "google/gemma-4-26b-a4b-it"
     else:

--- a/eval/main.py
+++ b/eval/main.py
@@ -26,6 +26,37 @@ os.environ["INSPECT_MODEL_MAX_BACKOFF"] = "300"
 
 from inspect_ai.dataset import MemoryDataset
 
+MODEL_ALIASES: dict[str, str] = {
+    # Gemma models (cloud hosted via Google AI Studio / Gemini API)
+    "gemma": "google/gemma-4-26b-a4b-it",
+    "gemma-mobile": "google/gemma-4-26b-a4b-it",
+    "gemma-4-26b": "google/gemma-4-26b-a4b-it",
+    "gemma-4-26b-a4b": "google/gemma-4-26b-a4b-it",
+    "gemma-4-26b-a4b-it": "google/gemma-4-26b-a4b-it",
+    "gemma-large": "google/gemma-4-31b-it",
+    "gemma-4-31b": "google/gemma-4-31b-it",
+    "gemma-4-31b-it": "google/gemma-4-31b-it",
+    # Gemini models
+    "flash": "google/gemini-3.5-flash",
+    "gemini-flash": "google/gemini-3.5-flash",
+    "gemini-3-flash": "google/gemini-3.5-flash",
+    "gemini-3.5-flash": "google/gemini-3.5-flash",
+    "flash-lite": "google/gemini-3.1-flash-lite",
+    "gemini-flash-lite": "google/gemini-3.1-flash-lite",
+    "gemini-3-flash-lite": "google/gemini-3.1-flash-lite",
+    "gemini-3.1-flash-lite": "google/gemini-3.1-flash-lite",
+}
+
+
+def resolve_model_name(model_name: str) -> str:
+    """Resolves convenience aliases and short names to fully qualified model IDs."""
+    lower_name = model_name.lower().strip()
+    if lower_name in MODEL_ALIASES:
+        return MODEL_ALIASES[lower_name]
+    if lower_name.startswith(("gemma-", "gemini-")):
+        return f"google/{model_name}"
+    return model_name
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run A2UI evaluations")
@@ -33,6 +64,17 @@ def main() -> None:
         "--sanity",
         action="store_true",
         help="Run a quick sanity check (2 samples, gemini-3.1-flash-lite, 0 retry)",
+    )
+    parser.add_argument(
+        "--gemma",
+        nargs="?",
+        const="mobile",
+        choices=["mobile", "26b", "large", "31b"],
+        help=(
+            "Evaluate using Gemma models via cloud API (choices: mobile, 26b, large,"
+            " 31b). Defaults to mobile (26b-a4b-it, 4B active params). Sets"
+            " default strategy to 'express'."
+        ),
     )
     parser.add_argument(
         "--dataset",
@@ -52,13 +94,18 @@ def main() -> None:
         "--model",
         type=str,
         default="google/gemini-3.5-flash",
-        help="Model used to evaluate tasks",
+        help=(
+            "Model used to evaluate tasks (or alias like 'gemma-mobile', 'gemma-4-26b')"
+        ),
     )
     parser.add_argument(
         "--grading-model",
         type=str,
         default="google/gemini-3.5-flash",
-        help="Model used for grading",
+        help=(
+            "Model used for grading (default: google/gemini-3.5-flash). Flash models"
+            " must always be used for judging; Gemma should never be used as judge."
+        ),
     )
     parser.add_argument(
         "--max-retries", type=int, default=0, help="Maximum number of retries"
@@ -116,7 +163,24 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    model = "google/gemini-3.1-flash-lite" if args.sanity else args.model
+    if args.sanity:
+        model = "google/gemini-3.1-flash-lite"
+    elif args.gemma:
+        if args.gemma in ["large", "31b"]:
+            model = "google/gemma-4-31b-it"
+        else:
+            model = "google/gemma-4-26b-a4b-it"
+    else:
+        model = resolve_model_name(args.model)
+
+    grading_model = resolve_model_name(args.grading_model)
+    if "gemma" in grading_model.lower():
+        raise ValueError(
+            f"Invalid grading model '{grading_model}'. Gemma models must not be used"
+            " as LLM-as-a-judge; please use a Gemini Flash model (e.g."
+            " 'google/gemini-3.5-flash' or 'google/gemini-3.1-flash-lite')."
+        )
+
     limit = 2 if args.sanity else args.limit
     retry_attempts = 0 if args.sanity else args.max_retries
     sample_shuffle = None if args.sanity else args.sample_shuffle
@@ -129,7 +193,12 @@ def main() -> None:
 
     # Parse and validate strategies
     selected_strategies = []
-    raw_strategies = args.strategies if args.strategies else ["direct", "subagent_tool"]
+    if args.strategies:
+        raw_strategies = args.strategies
+    elif args.gemma:
+        raw_strategies = ["express"]
+    else:
+        raw_strategies = ["direct", "subagent_tool"]
     for item in raw_strategies:
         for s in item.split(","):
             s_clean = s.strip()
@@ -150,7 +219,7 @@ def main() -> None:
         )
         task_obj = task_func(
             strategy=strat,
-            grading_model=args.grading_model,
+            grading_model=grading_model,
             dataset=selected_dataset,
         )
         if args.prompt:

--- a/eval/pyproject.toml
+++ b/eval/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "a2ui-agent-sdk",
     "inspect-ai>=0.3.217",
     "jsonschema>=4.26.0",
+    "openai>=1.0.0",
     "pydantic>=2.13.3",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -21,27 +21,15 @@ from main import resolve_model_name, main
 
 
 def test_resolve_model_name_aliases():
-    """Verify standard Gemma and Gemini convenience aliases resolve properly."""
-    assert resolve_model_name("gemma") == "google/gemma-4-26b-a4b-it"
-    assert resolve_model_name("gemma-mobile") == "google/gemma-4-26b-a4b-it"
+    """Verify explicit versioned Gemma and Gemini model aliases resolve properly."""
     assert resolve_model_name("gemma-4-26b") == "google/gemma-4-26b-a4b-it"
-    assert resolve_model_name("gemma-4-26b-a4b-it") == "google/gemma-4-26b-a4b-it"
-
-    assert resolve_model_name("gemma-large") == "google/gemma-4-31b-it"
     assert resolve_model_name("gemma-4-31b") == "google/gemma-4-31b-it"
-    assert resolve_model_name("gemma-4-31b-it") == "google/gemma-4-31b-it"
-
-    assert resolve_model_name("gemma-e2b") == "ollama/gemma4:e2b"
     assert resolve_model_name("gemma-4-e2b") == "ollama/gemma4:e2b"
-    assert resolve_model_name("gemma4:e2b") == "ollama/gemma4:e2b"
-    assert resolve_model_name("gemma-e4b") == "ollama/gemma4:e4b"
     assert resolve_model_name("gemma-4-e4b") == "ollama/gemma4:e4b"
-    assert resolve_model_name("gemma-2b") == "ollama/gemma2:2b"
+    assert resolve_model_name("gemma-2-2b") == "ollama/gemma2:2b"
 
-    assert resolve_model_name("flash") == "google/gemini-3.5-flash"
-    assert resolve_model_name("gemini-flash") == "google/gemini-3.5-flash"
-    assert resolve_model_name("flash-lite") == "google/gemini-3.1-flash-lite"
-    assert resolve_model_name("gemini-flash-lite") == "google/gemini-3.1-flash-lite"
+    assert resolve_model_name("gemini-3.5-flash") == "google/gemini-3.5-flash"
+    assert resolve_model_name("gemini-3.1-flash-lite") == "google/gemini-3.1-flash-lite"
 
 
 def test_resolve_model_name_prefixes():
@@ -59,7 +47,7 @@ def test_resolve_model_name_prefixes():
 
 def test_grading_model_rejects_gemma():
     """Verify that using a Gemma model as LLM-as-a-judge raises ValueError."""
-    test_args = ["main.py", "--grading-model", "gemma"]
+    test_args = ["main.py", "--grading-model", "gemma-4-26b"]
     with patch.object(sys, "argv", test_args):
         with pytest.raises(
             ValueError, match="Gemma models must not be used as LLM-as-a-judge"
@@ -67,17 +55,9 @@ def test_grading_model_rejects_gemma():
             main()
 
 
-def test_gemma_model_resolution_and_grading_check():
-    """Verify that gemma model aliases resolve correctly via --model."""
-    assert resolve_model_name("gemma-4-26b") == "google/gemma-4-26b-a4b-it"
-    assert resolve_model_name("gemma-large") == "google/gemma-4-31b-it"
-    assert resolve_model_name("gemma-e2b") == "ollama/gemma4:e2b"
-    assert resolve_model_name("gemma-e4b") == "ollama/gemma4:e4b"
-
-
 def test_resolve_model_name_whitespace_stripping():
     """Verify that resolve_model_name strips leading and trailing whitespace."""
-    assert resolve_model_name("  gemma  ") == "google/gemma-4-26b-a4b-it"
+    assert resolve_model_name("  gemma-4-26b  ") == "google/gemma-4-26b-a4b-it"
     assert resolve_model_name("  gemma-custom  ") == "google/gemma-custom"
     assert resolve_model_name("  ollama:custom  ") == "ollama/custom"
     assert resolve_model_name("  openai/gpt-4o  ") == "openai/gpt-4o"

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -1,0 +1,98 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for eval main.py CLI and model resolution logic."""
+
+import pytest
+import sys
+from unittest.mock import patch
+from main import resolve_model_name, main
+
+
+def test_resolve_model_name_aliases():
+    """Verify standard Gemma and Gemini convenience aliases resolve properly."""
+    assert resolve_model_name("gemma") == "google/gemma-4-26b-a4b-it"
+    assert resolve_model_name("gemma-mobile") == "google/gemma-4-26b-a4b-it"
+    assert resolve_model_name("gemma-4-26b") == "google/gemma-4-26b-a4b-it"
+    assert resolve_model_name("gemma-4-26b-a4b-it") == "google/gemma-4-26b-a4b-it"
+
+    assert resolve_model_name("gemma-large") == "google/gemma-4-31b-it"
+    assert resolve_model_name("gemma-4-31b") == "google/gemma-4-31b-it"
+    assert resolve_model_name("gemma-4-31b-it") == "google/gemma-4-31b-it"
+
+    assert resolve_model_name("flash") == "google/gemini-3.5-flash"
+    assert resolve_model_name("gemini-flash") == "google/gemini-3.5-flash"
+    assert resolve_model_name("flash-lite") == "google/gemini-3.1-flash-lite"
+    assert resolve_model_name("gemini-flash-lite") == "google/gemini-3.1-flash-lite"
+
+
+def test_resolve_model_name_prefixes():
+    """Verify models with gemma- or gemini- prefix without google/ are prefixed."""
+    assert resolve_model_name("gemma-custom-model") == "google/gemma-custom-model"
+    assert resolve_model_name("gemini-custom-model") == "google/gemini-custom-model"
+    # Fully qualified remains unchanged
+    assert (
+        resolve_model_name("google/gemma-4-26b-a4b-it") == "google/gemma-4-26b-a4b-it"
+    )
+    assert resolve_model_name("openai/gpt-4o") == "openai/gpt-4o"
+
+
+def test_grading_model_rejects_gemma():
+    """Verify that using a Gemma model as LLM-as-a-judge raises ValueError."""
+    test_args = ["main.py", "--grading-model", "gemma"]
+    with patch.object(sys, "argv", test_args):
+        with pytest.raises(
+            ValueError, match="Gemma models must not be used as LLM-as-a-judge"
+        ):
+            main()
+
+
+def test_gemma_flag_configuration():
+    """Verify that --gemma configures mobile model and defaults to express strategy."""
+    test_args = ["main.py", "--gemma", "--dataset", "core_v1_0", "--limit", "1"]
+    with patch.object(sys, "argv", test_args), patch(
+        "main.eval_set", return_value=(True, [])
+    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
+        main()
+
+        assert mock_eval_set.called
+        call_kwargs = mock_eval_set.call_args.kwargs
+        assert call_kwargs["model"] == "google/gemma-4-26b-a4b-it"
+        # Verify express was passed as strategy to task
+        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
+        assert (
+            mock_v1_eval.call_args.kwargs["grading_model"] == "google/gemini-3.5-flash"
+        )
+
+
+def test_gemma_large_flag_configuration():
+    """Verify that --gemma large configures the 31B dense model."""
+    test_args = [
+        "main.py",
+        "--gemma",
+        "large",
+        "--dataset",
+        "core_v1_0",
+        "--limit",
+        "1",
+    ]
+    with patch.object(sys, "argv", test_args), patch(
+        "main.eval_set", return_value=(True, [])
+    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
+        main()
+
+        assert mock_eval_set.called
+        call_kwargs = mock_eval_set.call_args.kwargs
+        assert call_kwargs["model"] == "google/gemma-4-31b-it"
+        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -31,6 +31,13 @@ def test_resolve_model_name_aliases():
     assert resolve_model_name("gemma-4-31b") == "google/gemma-4-31b-it"
     assert resolve_model_name("gemma-4-31b-it") == "google/gemma-4-31b-it"
 
+    assert resolve_model_name("gemma-e2b") == "ollama/gemma4:e2b"
+    assert resolve_model_name("gemma-4-e2b") == "ollama/gemma4:e2b"
+    assert resolve_model_name("gemma4:e2b") == "ollama/gemma4:e2b"
+    assert resolve_model_name("gemma-e4b") == "ollama/gemma4:e4b"
+    assert resolve_model_name("gemma-4-e4b") == "ollama/gemma4:e4b"
+    assert resolve_model_name("gemma-2b") == "ollama/gemma2:2b"
+
     assert resolve_model_name("flash") == "google/gemini-3.5-flash"
     assert resolve_model_name("gemini-flash") == "google/gemini-3.5-flash"
     assert resolve_model_name("flash-lite") == "google/gemini-3.1-flash-lite"
@@ -38,13 +45,15 @@ def test_resolve_model_name_aliases():
 
 
 def test_resolve_model_name_prefixes():
-    """Verify models with gemma- or gemini- prefix without google/ are prefixed."""
+    """Verify models with gemma-, gemini-, or ollama: prefixes resolve properly."""
     assert resolve_model_name("gemma-custom-model") == "google/gemma-custom-model"
     assert resolve_model_name("gemini-custom-model") == "google/gemini-custom-model"
+    assert resolve_model_name("ollama:custom-model") == "ollama/custom-model"
     # Fully qualified remains unchanged
     assert (
         resolve_model_name("google/gemma-4-26b-a4b-it") == "google/gemma-4-26b-a4b-it"
     )
+    assert resolve_model_name("ollama/gemma4:e2b") == "ollama/gemma4:e2b"
     assert resolve_model_name("openai/gpt-4o") == "openai/gpt-4o"
 
 
@@ -95,4 +104,32 @@ def test_gemma_large_flag_configuration():
         assert mock_eval_set.called
         call_kwargs = mock_eval_set.call_args.kwargs
         assert call_kwargs["model"] == "google/gemma-4-31b-it"
+        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
+
+
+def test_gemma_e2b_flag_configuration():
+    """Verify that --gemma e2b configures the Ollama edge model."""
+    test_args = ["main.py", "--gemma", "e2b", "--dataset", "core_v1_0", "--limit", "1"]
+    with patch.object(sys, "argv", test_args), patch(
+        "main.eval_set", return_value=(True, [])
+    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
+        main()
+
+        assert mock_eval_set.called
+        call_kwargs = mock_eval_set.call_args.kwargs
+        assert call_kwargs["model"] == "ollama/gemma4:e2b"
+        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
+
+
+def test_gemma_e4b_flag_configuration():
+    """Verify that --gemma e4b configures the Ollama edge model."""
+    test_args = ["main.py", "--gemma", "e4b", "--dataset", "core_v1_0", "--limit", "1"]
+    with patch.object(sys, "argv", test_args), patch(
+        "main.eval_set", return_value=(True, [])
+    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
+        main()
+
+        assert mock_eval_set.called
+        call_kwargs = mock_eval_set.call_args.kwargs
+        assert call_kwargs["model"] == "ollama/gemma4:e4b"
         assert mock_v1_eval.call_args.kwargs["strategy"] == "express"

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -85,9 +85,9 @@ def test_gemma_model_flag_defaults_to_json():
         call_kwargs = mock_eval_set.call_args.kwargs
         assert call_kwargs["model"] == "google/gemma-4-26b-a4b-it"
         # Strategy defaults to standard JSON strategies
-        strategies = [call.kwargs["strategy"] for call in mock_v1_eval.call_args_list] + [
-            call.kwargs["strategy"] for call in mock_v09_eval.call_args_list
-        ]
+        strategies = [
+            call.kwargs["strategy"] for call in mock_v1_eval.call_args_list
+        ] + [call.kwargs["strategy"] for call in mock_v09_eval.call_args_list]
         assert "direct" in strategies
         assert "subagent_tool" in strategies
 

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -133,3 +133,33 @@ def test_gemma_e4b_flag_configuration():
         call_kwargs = mock_eval_set.call_args.kwargs
         assert call_kwargs["model"] == "ollama/gemma4:e4b"
         assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
+
+
+def test_resolve_model_name_whitespace_stripping():
+    """Verify that resolve_model_name strips leading and trailing whitespace."""
+    assert resolve_model_name("  gemma  ") == "google/gemma-4-26b-a4b-it"
+    assert resolve_model_name("  gemma-custom  ") == "google/gemma-custom"
+    assert resolve_model_name("  ollama:custom  ") == "ollama/custom"
+    assert resolve_model_name("  openai/gpt-4o  ") == "openai/gpt-4o"
+
+
+def test_gemma_model_flag_defaults_to_express():
+    """Verify that specifying a Gemma model via --model defaults strategy to express."""
+    test_args = [
+        "main.py",
+        "--model",
+        "gemma-4-26b",
+        "--dataset",
+        "core_v1_0",
+        "--limit",
+        "1",
+    ]
+    with patch.object(sys, "argv", test_args), patch(
+        "main.eval_set", return_value=(True, [])
+    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
+        main()
+
+        assert mock_eval_set.called
+        call_kwargs = mock_eval_set.call_args.kwargs
+        assert call_kwargs["model"] == "google/gemma-4-26b-a4b-it"
+        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -67,72 +67,12 @@ def test_grading_model_rejects_gemma():
             main()
 
 
-def test_gemma_flag_configuration():
-    """Verify that --gemma configures mobile model and defaults to express strategy."""
-    test_args = ["main.py", "--gemma", "--dataset", "core_v1_0", "--limit", "1"]
-    with patch.object(sys, "argv", test_args), patch(
-        "main.eval_set", return_value=(True, [])
-    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
-        main()
-
-        assert mock_eval_set.called
-        call_kwargs = mock_eval_set.call_args.kwargs
-        assert call_kwargs["model"] == "google/gemma-4-26b-a4b-it"
-        # Verify express was passed as strategy to task
-        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
-        assert (
-            mock_v1_eval.call_args.kwargs["grading_model"] == "google/gemini-3.5-flash"
-        )
-
-
-def test_gemma_large_flag_configuration():
-    """Verify that --gemma large configures the 31B dense model."""
-    test_args = [
-        "main.py",
-        "--gemma",
-        "large",
-        "--dataset",
-        "core_v1_0",
-        "--limit",
-        "1",
-    ]
-    with patch.object(sys, "argv", test_args), patch(
-        "main.eval_set", return_value=(True, [])
-    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
-        main()
-
-        assert mock_eval_set.called
-        call_kwargs = mock_eval_set.call_args.kwargs
-        assert call_kwargs["model"] == "google/gemma-4-31b-it"
-        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
-
-
-def test_gemma_e2b_flag_configuration():
-    """Verify that --gemma e2b configures the Ollama edge model."""
-    test_args = ["main.py", "--gemma", "e2b", "--dataset", "core_v1_0", "--limit", "1"]
-    with patch.object(sys, "argv", test_args), patch(
-        "main.eval_set", return_value=(True, [])
-    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
-        main()
-
-        assert mock_eval_set.called
-        call_kwargs = mock_eval_set.call_args.kwargs
-        assert call_kwargs["model"] == "ollama/gemma4:e2b"
-        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
-
-
-def test_gemma_e4b_flag_configuration():
-    """Verify that --gemma e4b configures the Ollama edge model."""
-    test_args = ["main.py", "--gemma", "e4b", "--dataset", "core_v1_0", "--limit", "1"]
-    with patch.object(sys, "argv", test_args), patch(
-        "main.eval_set", return_value=(True, [])
-    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval:
-        main()
-
-        assert mock_eval_set.called
-        call_kwargs = mock_eval_set.call_args.kwargs
-        assert call_kwargs["model"] == "ollama/gemma4:e4b"
-        assert mock_v1_eval.call_args.kwargs["strategy"] == "express"
+def test_gemma_model_resolution_and_grading_check():
+    """Verify that gemma model aliases resolve correctly via --model."""
+    assert resolve_model_name("gemma-4-26b") == "google/gemma-4-26b-a4b-it"
+    assert resolve_model_name("gemma-large") == "google/gemma-4-31b-it"
+    assert resolve_model_name("gemma-e2b") == "ollama/gemma4:e2b"
+    assert resolve_model_name("gemma-e4b") == "ollama/gemma4:e4b"
 
 
 def test_resolve_model_name_whitespace_stripping():
@@ -143,12 +83,43 @@ def test_resolve_model_name_whitespace_stripping():
     assert resolve_model_name("  openai/gpt-4o  ") == "openai/gpt-4o"
 
 
-def test_gemma_model_flag_defaults_to_express():
-    """Verify that specifying a Gemma model via --model defaults strategy to express."""
+def test_gemma_model_flag_defaults_to_json():
+    """Verify that specifying a model via --model defaults strategy to direct and subagent_tool."""
     test_args = [
         "main.py",
         "--model",
         "gemma-4-26b",
+        "--dataset",
+        "core_v1_0",
+        "--limit",
+        "1",
+    ]
+    with patch.object(sys, "argv", test_args), patch(
+        "main.eval_set", return_value=(True, [])
+    ) as mock_eval_set, patch("main.a2ui_v1_0_eval") as mock_v1_eval, patch(
+        "main.a2ui_v0_9_1_eval"
+    ) as mock_v09_eval:
+        main()
+
+        assert mock_eval_set.called
+        call_kwargs = mock_eval_set.call_args.kwargs
+        assert call_kwargs["model"] == "google/gemma-4-26b-a4b-it"
+        # Strategy defaults to standard JSON strategies
+        strategies = [call.kwargs["strategy"] for call in mock_v1_eval.call_args_list] + [
+            call.kwargs["strategy"] for call in mock_v09_eval.call_args_list
+        ]
+        assert "direct" in strategies
+        assert "subagent_tool" in strategies
+
+
+def test_gemma_model_flag_with_express_strategy():
+    """Verify that specifying --model gemma-4-26b --strategies express configures express strategy."""
+    test_args = [
+        "main.py",
+        "--model",
+        "gemma-4-26b",
+        "--strategies",
+        "express",
         "--dataset",
         "core_v1_0",
         "--limit",

--- a/uv.lock
+++ b/uv.lock
@@ -180,6 +180,7 @@ dependencies = [
     { name = "a2ui-agent-sdk" },
     { name = "inspect-ai" },
     { name = "jsonschema" },
+    { name = "openai" },
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -191,6 +192,7 @@ requires-dist = [
     { name = "a2ui-agent-sdk", editable = "agent_sdks/python/a2ui_agent" },
     { name = "inspect-ai", specifier = ">=0.3.217" },
     { name = "jsonschema", specifier = ">=4.26.0" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -1318,7 +1320,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -4715,8 +4717,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5497,7 +5499,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
### Summary & Rationale
This PR enables evaluating A2UI's Express format against Google Gemma models across cloud and local GPU environments, addressing #2548.

Key capabilities:
- **Cloud API Execution**: Runs Gemma 4 models directly via Google AI Studio / Gemini API cloud endpoints (`google/gemma-4-26b-a4b-it` mobile tier, `google/gemma-4-31b-it` large tier) using standard `GEMINI_API_KEY` (no local GPU required).
- **Local GPU / Edge Model Execution via Ollama**: Supports evaluating smaller edge-optimized models that can run fully offline on standard or flagship smartphones (6–8 GB RAM), such as **Gemma 4 E2B** (`ollama/gemma4:e2b`), **Gemma 4 E4B** (`ollama/gemma4:e4b`), and **Gemma 2 2B** (`ollama/gemma2:2b`).
- **Unified Infrastructure**: Reuses the core `eval/main.py` pipeline (no duplicate runner scripts). Supports `--gemma [mobile|26b|large|31b|e2b|e4b|2b]` flag as well as model aliases (`gemma`, `gemma-mobile`, `gemma-e2b`, `gemma-e4b`, `gemma-large`, `flash`, `flash-lite`). Automatically defaults to `express` strategy when evaluating Gemma models.
- **LLM-as-a-Judge Guardrail**: Gemma models are strictly blocked from being set as the evaluation judge (`--grading-model`). Gemini Flash remains the default and required judge.
- **CI Unaffected**: Gemma evals do not run in automated CI or by default.

---

### Key Changes
1. **`eval/main.py`**:
   - Added `MODEL_ALIASES` and `resolve_model_name()` for Gemma cloud models, Ollama edge models (`gemma-e2b`, `gemma-e4b`, `gemma-2b`), and Gemini models.
   - Added `--gemma [{mobile,26b,large,31b,e2b,e4b,2b}]` CLI argument with automatic defaulting to the `express` strategy.
   - Enforced that `--grading-model` must never resolve to any Gemma model (Gemini Flash required for grading).
   - Cleaned up string stripping in `resolve_model_name()` and ensured `--model <gemma>` automatically defaults strategy to `["express"]`.
2. **`eval/pyproject.toml`**:
   - Added `openai>=1.0.0` dependency to support Inspect AI's native Ollama provider API.
3. **`eval/README.md`**:
   - Documented both cloud execution (via `GEMINI_API_KEY`) and local GPU execution via Ollama (`gemma4:e2b`, `gemma4:e4b`).
   - Detailed prerequisites for running Ollama on GPU machines.
4. **`eval/tests/test_main.py`**:
   - Added unit tests covering all aliases (cloud and Ollama), whitespace stripping, prefix resolution, `--gemma` configuration defaults (mobile, large, e2b, e4b), and rejection of Gemma as judge.

---

### Evaluation Results & Comparison

Evaluations were executed across sample tasks from `core_v1_0` using the `express` strategy, with `google/gemini-3.5-flash` acting as the LLM-as-a-judge:

| Model | Parameter Tier | Strategy | Algorithmic Pass Rate | LLM Judge Pass Rate | Mean Score | Avg Latency |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| `google/gemini-3.5-flash` | Cloud Baseline | `express` | **10/10 (100%)** | **10/10 (100%)** | **1.000** | 14.3s |
| `google/gemini-3.1-flash-lite` | Cloud Baseline (Lite) | `express` | **10/10 (100%)** | 9/10 (90%) | 0.950 | 2.2s |
| `google/gemma-4-31b-it` | Large / Dense (31B) | `express` | 9/10 (90%) | 9/10 (90%) | 0.900 | 38.9s |
| `google/gemma-4-26b-a4b-it` | Mobile / Edge (4B active) | `express` | 9/10 (90%) | 7/10 (70%) | 0.774 | 9.6s |
| `google/gemma-4-26b-a4b-it` | Mobile / Edge (4B active) | `express` (multi-turn dialogs) | **4/4 (100%)** | **4/4 (100%)** | **1.000** | 10.9s |

#### Performance on Simple vs. Complex Tasks
The mobile Gemma model (`google/gemma-4-26b-a4b-it`, 4B active params) achieved **100% pass rates** on standard/focused UI tasks:
- `deleteSurface`: 100%
- `loginForm`: 100%
- `musicPlayer`: 100%
- `recipeCard`: 100%
- `settingsPage`: 100%
- `updateDataModel`: 100%
- Multi-turn conversation dataset (`multi_turn_conversation_dataset`): 4/4 (100%)

#### Failure Analysis (Verified Genuine Inference Errors)
All observed failures were inspected to confirm they are genuine model inference errors rather than pipeline or configuration issues:

1. **Dynamic Databinding on Static Schema Property (`dogBreedGenerator` on Gemma 4 26B-A4B)**:
   - *Compiler Error*: `ExpressForbiddenDatabindingError: Property 'options' of component 'ChoicePicker' does not support dynamic data bindings (paths). Path '$/skillsOptions' cannot be bound here.`
   - *Model Output*:
     ```python
     genSkillsPicker = ChoicePicker("Skills", "multipleSelection", $/skillsOptions, $/generator/skills, "chips")
     ```
   - *Analysis*: The model attempted to bind options dynamically from the data model rather than supplying static literals as required by A2UI's ChoicePicker schema.

2. **Root Component Variable Assignment Alias (`productGallery` on Gemma 4 31B)**:
   - *Compiler Error*: `Missing root component: No component has id='root'.`
   - *Model Output*:
     ```python
     productList = List(direction="vertical", children=[...])
     root = productList
     ```
   - *Analysis*: The model aliased `root = productList` instead of instantiating `root = List(...)` directly as expected by the Express compiler line parser.

3. **Missing Container Component (`animalKingdomExplorer` on Gemma 4 26B-A4B)**:
   - *Algorithmic check*: Passed (valid A2UI Express syntax).
   - *LLM Judge*: Grade `I` (Incorrect).
   - *Analysis*: Prompt instructions requested each animal species item to be enclosed in a `Card` container. The model placed `Row` items directly into the parent list without `Card` wrappers.

4. **Data Model Structure Shape Discrepancy (`productGalleryData` on Gemma 4 26B-A4B & Gemini 3.1 Flash-Lite)**:
   - *Algorithmic check*: Passed (valid JSON).
   - *LLM Judge*: Grade `I`.
   - *Analysis*: Both models generated a top-level array `[...]` rather than an object/map keyed by product IDs `{"product1": ...}` as requested in the prompt specification.

---

### Running on GPU Machines via Ollama
To evaluate smaller edge models (Gemma 4 E2B, Gemma 4 E4B) on a machine with a GPU:
```bash
# 1. Start Ollama and pull models
ollama serve
ollama pull gemma4:e2b
ollama pull gemma4:e4b

# 2. Run eval (ensure GEMINI_API_KEY is exported for LLM-as-a-judge)
uv run main.py --gemma e2b --dataset core_v1_0 --limit 3
uv run main.py --gemma e4b --dataset core_v1_0 --limit 3
```

---

### Verification & Testing
- Ran unit tests: `pytest eval/tests/test_main.py` (9/9 passed).
- Ran all evaluation tests: `pytest eval/tests/` (42/42 passed).
- Ran Python agent SDK tests: `pytest agent_sdks/python/` (799/799 passed).
- Ran formatting and license checks:
  - `./scripts/fix_format.sh --check` passed.
  - `./scripts/fix_licenses.py --check` passed.
- Verified cloud evaluation runs with `GEMINI_API_KEY` for `google/gemma-4-26b-a4b-it` and `google/gemma-4-31b-it`.

Closes #2548