### PR TITLE
docs(python): update a2ui_agent CHANGELOG with unreleased Express format features

### DIFF
--- a/agent_sdks/python/a2ui_agent/CHANGELOG.md
+++ b/agent_sdks/python/a2ui_agent/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 
-- Invoke ANTLR from the grammar's directory when regenerating the Express parser, so generated file headers no longer embed the absolute path of the machine that built them.
-- Stop rewriting the non-package fallback import in the generated Express visitor to a relative import, which pointed at a module name the rename step had already replaced. A from-source build now leaves the working tree clean.
+- Add support for keyword arguments (`param=value`) and mixed positional/keyword argument syntax in A2UI Express DSL component constructors and catalog function calls (#2131).
+- Add multi-version output support (`v0.9`, `v0.9.1`, `v1.0`) to `ExpressCompiler`, emitting standard `v0.9.1` message sequences or `v1.0` unified surface envelopes based on target configuration (#2131).
+- Add top-level `surface()` and `deleteSurface()` directive support in Express DSL to target or delete UI surfaces (#2163).
+- Invoke ANTLR from the grammar's directory when regenerating the Express parser, so generated file headers no longer embed the absolute path of the machine that built them (#2371).
+- Stop rewriting the non-package fallback import in the generated Express visitor to a relative import, which pointed at a module name the rename step had already replaced. A from-source build now leaves the working tree clean (#2371).
 
 ## 0.5.0
 


### PR DESCRIPTION
### Summary & Rationale
Updates `agent_sdks/python/a2ui_agent/CHANGELOG.md` under `## Unreleased` to document previously merged Express format capabilities (PR #2131 and PR #2163) in preparation for the next Python SDK release.

### Key Changes
- Documented support for keyword arguments (`param=value`) and mixed positional/keyword syntax in Express DSL component constructors and catalog function calls (#2131).
- Documented multi-version output support (`v0.9`, `v0.9.1`, `v1.0`) in `ExpressCompiler` (#2131).
- Documented top-level `surface()` and `deleteSurface()` directive support in Express DSL (#2163).
- Added PR reference tags for recent Express parser reproducibility fixes (#2371).

### Verification & Testing
- Verified `agent_sdks/python/a2ui_agent/CHANGELOG.md` syntax and formatting.
- Verified test suite: `uv run python -m unittest discover -s tests/express` (75 tests pass).