### PR TITLE
feat(web_core): add backwards compatibility shims for v1.0 migration

### DIFF
--- a/typescript/web_core/src/processing/message-processor.test.ts
+++ b/typescript/web_core/src/processing/message-processor.test.ts
@@ -1635,4 +1635,47 @@ describe('MessageProcessor', () => {
       assert.strictEqual(surface.componentsModel.size, 2);
     });
   });
+
+  describe('Backwards Compatibility Shims', () => {
+    it('provides getClientCapabilities alias', () => {
+      const cat = new Catalog('test-cat', []);
+      const proc = new MessageProcessor([cat]);
+      const caps = proc.getClientCapabilities();
+      assert.deepStrictEqual(caps, proc.getRendererCapabilities());
+      assert.deepStrictEqual(caps.supportedCatalogIds, ['test-cat']);
+    });
+
+    it('provides getClientDataModel alias', () => {
+      const cat = new Catalog('test-cat', []);
+      const proc = new MessageProcessor([cat]);
+      proc.processMessages({
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 's1',
+          catalogId: 'test-cat',
+          sendDataModel: true,
+        },
+      });
+      proc.processMessages({
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          path: '/user/name',
+          value: 'Alice',
+        },
+      });
+      const dataModel = proc.getClientDataModel('v0.9');
+      assert.deepStrictEqual(dataModel, proc.getRendererDataModel('v0.9'));
+      assert.deepStrictEqual((dataModel?.surfaces as any)?.s1, {user: {name: 'Alice'}});
+    });
+
+    it('provides resolvePath method on MessageProcessor', () => {
+      const cat = new Catalog('test-cat', []);
+      const proc = new MessageProcessor([cat]);
+      assert.strictEqual(proc.resolvePath('/absolute/path'), '/absolute/path');
+      assert.strictEqual(proc.resolvePath('relative', '/base'), '/base/relative');
+      assert.strictEqual(proc.resolvePath('relative', '/base/'), '/base/relative');
+      assert.strictEqual(proc.resolvePath('standalone'), '/standalone');
+    });
+  });
 });

--- a/typescript/web_core/src/processing/message-processor.ts
+++ b/typescript/web_core/src/processing/message-processor.ts
@@ -20,6 +20,7 @@ import {generateCatalogSchema} from '../catalog/schema_generator.js';
 import {SurfaceGroupModel} from '../state/surface-group-model.js';
 import {ComponentModel} from '../state/component-model.js';
 import {SurfaceComponentsModel} from '../state/surface-components-model.js';
+import {DataModel} from '../state/data-model.js';
 import {Subscription} from '../common/events.js';
 import {z} from 'zod';
 
@@ -68,7 +69,7 @@ export type ProcessableMessagePayload =
   | V09A2uiMessageListWrapper
   | {readonly messages: readonly ProcessableMessage[]};
 
-export type {RendererCapabilities, ValidationConfig};
+export type {RendererCapabilities, RendererCapabilities as ClientCapabilities, ValidationConfig};
 export {STRICT_VALIDATION, RELAXED_VALIDATION};
 
 /**
@@ -244,6 +245,17 @@ export class MessageProcessor<T extends ComponentApi = ComponentApi> {
   }
 
   /**
+   * Generates the client/renderer capabilities object for the current processor.
+   *
+   * @deprecated Use `getRendererCapabilities` instead.
+   * @param options Configuration for capability generation.
+   * @returns The capabilities object.
+   */
+  getClientCapabilities(options?: CapabilitiesOptions): RendererCapabilities {
+    return this.getRendererCapabilities(options);
+  }
+
+  /**
    * Generates a backwards-compatible inline catalog representation for v0.8/v0.9/v0.9.1.
    *
    * @param catalog The catalog instance to serialize.
@@ -309,6 +321,29 @@ export class MessageProcessor<T extends ComponentApi = ComponentApi> {
       version,
       surfaces,
     };
+  }
+
+  /**
+   * Aggregates active client/renderer data models.
+   *
+   * @deprecated Use `getRendererDataModel` instead.
+   * @param version Protocol version to format data models for.
+   * @returns Serialized data model payload, or undefined if no surfaces stream data models.
+   */
+  getClientDataModel(version: ProtocolVersion = this.version): Record<string, unknown> | undefined {
+    return this.getRendererDataModel(version);
+  }
+
+  /**
+   * Resolves a relative path against a context path.
+   *
+   * @deprecated Use `DataModel.resolvePath` instead.
+   * @param path The path to resolve.
+   * @param contextPath The base path (optional).
+   * @returns The resolved absolute path.
+   */
+  resolvePath(path: string, contextPath?: string): string {
+    return DataModel.resolvePath(path, contextPath);
   }
 
   /**

--- a/typescript/web_core/src/state/component-model.test.ts
+++ b/typescript/web_core/src/state/component-model.test.ts
@@ -84,4 +84,12 @@ describe('ComponentModel', () => {
     assert.strictEqual(customComp.catalog, testCatalog);
     assert.strictEqual(customComp.catalog.id, 'custom-cat');
   });
+
+  it('allows instantiation without catalog for backwards compatibility', () => {
+    const legacyComp = new ComponentModel('c3', 'Text', {text: 'Legacy'});
+    assert.strictEqual(legacyComp.id, 'c3');
+    assert.strictEqual(legacyComp.type, 'Text');
+    assert.deepStrictEqual(legacyComp.properties, {text: 'Legacy'});
+    assert.strictEqual(legacyComp.catalog, undefined);
+  });
 });

--- a/typescript/web_core/src/state/component-model.ts
+++ b/typescript/web_core/src/state/component-model.ts
@@ -35,13 +35,13 @@ export class ComponentModel {
    * @param id The unique identifier for this component.
    * @param type The component type name.
    * @param initialProperties The initial properties for the component.
-   * @param catalog Catalog associated with this component.
+   * @param catalog Optional catalog associated with this component.
    */
   constructor(
     readonly id: string,
     readonly type: string,
     initialProperties: Record<string, any>,
-    readonly catalog: Catalog<any, any>,
+    readonly catalog?: Catalog<any, any>,
   ) {
     this._properties = initialProperties;
   }

--- a/typescript/web_core/src/state/surface-components-model.ts
+++ b/typescript/web_core/src/state/surface-components-model.ts
@@ -164,9 +164,9 @@ export class SurfaceComponentsModel {
     if (!comp) return [];
 
     const refMap: ComponentRefMap =
-      comp.catalog.components.size > 0
+      comp.catalog && comp.catalog.components && comp.catalog.components.size > 0
         ? comp.catalog.componentRefMap
-        : (this.refMap ?? comp.catalog.componentRefMap);
+        : (this.refMap ?? comp.catalog?.componentRefMap ?? {});
     return Array.from(
       getComponentReferences({id: comp.id, component: comp.type, ...comp.properties}, refMap),
     );

--- a/typescript/web_core/src/state/surface-components-model.ts
+++ b/typescript/web_core/src/state/surface-components-model.ts
@@ -163,10 +163,9 @@ export class SurfaceComponentsModel {
     const comp = this.components.get(componentId);
     if (!comp) return [];
 
-    const refMap: ComponentRefMap =
-      comp.catalog && comp.catalog.components && comp.catalog.components.size > 0
-        ? comp.catalog.componentRefMap
-        : (this.refMap ?? comp.catalog?.componentRefMap ?? {});
+    const refMap: ComponentRefMap = comp.catalog?.components.size
+      ? comp.catalog.componentRefMap
+      : (this.refMap ?? comp.catalog?.componentRefMap ?? {});
     return Array.from(
       getComponentReferences({id: comp.id, component: comp.type, ...comp.properties}, refMap),
     );

--- a/typescript/web_core/src/v0_9/nodes/node-resolver.test.ts
+++ b/typescript/web_core/src/v0_9/nodes/node-resolver.test.ts
@@ -1295,4 +1295,36 @@ describe('NodeResolver constructor checks and disposal', () => {
     surface.dataModel.set('/items', [{name: 'X'}]);
     assert.strictEqual(resolver.activeNodeCount, 0);
   });
+
+  it('resolves component models instantiated without a catalog or with empty catalog', () => {
+    const {surface, resolver} = setup();
+    // 1. Component without catalog (3-argument ComponentModel)
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Column', {children: ['child1', 'child2']}),
+    );
+    // 2. Component with empty catalog
+    const emptyCat = new Catalog('empty', []);
+    surface.componentsModel.addComponent(
+      new ComponentModel('child1', 'Text', {text: 'Without Catalog'}),
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('child2', 'Text', {text: 'Empty Catalog'}, emptyCat),
+    );
+
+    const root = getValue(resolver.rootNode);
+    assert.ok(root);
+    assert.strictEqual(root.type, 'Column');
+
+    const c1 = child(root, 'children', 0);
+    assert.ok(c1);
+    assert.strictEqual(c1.type, 'Text');
+    assert.strictEqual(bound(c1, 'text'), 'Without Catalog');
+
+    const c2 = child(root, 'children', 1);
+    assert.ok(c2);
+    assert.strictEqual(c2.type, 'Text');
+    assert.strictEqual(bound(c2, 'text'), 'Empty Catalog');
+
+    resolver.dispose();
+  });
 });

--- a/typescript/web_core/src/v0_9/nodes/node-resolver.ts
+++ b/typescript/web_core/src/v0_9/nodes/node-resolver.ts
@@ -306,9 +306,8 @@ export class NodeResolver<
     }
 
     const compCatalog =
-      (model.catalog && model.catalog.components && model.catalog.components.size > 0
-        ? (model.catalog as Catalog<C, F>)
-        : undefined) ?? this.catalog;
+      (model.catalog?.components.size ? (model.catalog as Catalog<C, F>) : undefined) ??
+      this.catalog;
     const api = compCatalog.components.get(model.type);
     if (!api) {
       this.dispatchOnce(
@@ -451,9 +450,8 @@ export class NodeResolver<
     if (existing && !existing.disposed) {
       const model = this.surface.componentsModel.get(componentId);
       const compCatalog =
-        (model?.catalog && model.catalog.components && model.catalog.components.size > 0
-          ? (model.catalog as Catalog<C, F>)
-          : undefined) ?? this.catalog;
+        (model?.catalog?.components.size ? (model.catalog as Catalog<C, F>) : undefined) ??
+        this.catalog;
       const api = model ? compCatalog.components.get(model.type) : undefined;
       // A placeholder stays up to date only while its own state's
       // preconditions hold, so a pending node whose definition arrives with

--- a/typescript/web_core/src/v0_9/nodes/node-resolver.ts
+++ b/typescript/web_core/src/v0_9/nodes/node-resolver.ts
@@ -305,7 +305,10 @@ export class NodeResolver<
       return record.node;
     }
 
-    const compCatalog = (model.catalog as Catalog<C, F>) ?? this.catalog;
+    const compCatalog =
+      (model.catalog && model.catalog.components && model.catalog.components.size > 0
+        ? (model.catalog as Catalog<C, F>)
+        : undefined) ?? this.catalog;
     const api = compCatalog.components.get(model.type);
     if (!api) {
       this.dispatchOnce(
@@ -447,7 +450,10 @@ export class NodeResolver<
     }
     if (existing && !existing.disposed) {
       const model = this.surface.componentsModel.get(componentId);
-      const compCatalog = (model?.catalog as Catalog<C, F>) ?? this.catalog;
+      const compCatalog =
+        (model?.catalog && model.catalog.components && model.catalog.components.size > 0
+          ? (model.catalog as Catalog<C, F>)
+          : undefined) ?? this.catalog;
       const api = model ? compCatalog.components.get(model.type) : undefined;
       // A placeholder stays up to date only while its own state's
       // preconditions hold, so a pending node whose definition arrives with


### PR DESCRIPTION
## Summary

Adds backwards compatibility shims in `@a2ui/web_core` for APIs modified or relocated during the v1.0 refactor, easing integration between `v1_0` and `main`.

## Changes

- **`ComponentModel` Constructor:** Made `catalog?: Catalog<any, any>` optional (defaulting to `undefined`) in `src/state/component-model.ts`, restoring compatibility with 3-argument legacy instantiations (`new ComponentModel(id, type, properties)`).
- **Catalog Fallback in `SurfaceComponentsModel` & `NodeResolver`:** Updated `getChildReferences` in `src/state/surface-components-model.ts` and node creation/update logic in `src/v0_9/nodes/node-resolver.ts` to check `comp.catalog?.components?.size > 0`. When a component model lacks a catalog or provides an empty catalog, resolution safely falls back to the surface catalog instead of throwing `TypeError` or `UNKNOWN_COMPONENT_TYPE`.
- **`MessageProcessor` Shims:** Added deprecated delegation methods on `MessageProcessor` in `src/processing/message-processor.ts`:
  - `getClientCapabilities(options?: CapabilitiesOptions)`: Delegates to `getRendererCapabilities`.
  - `getClientDataModel(version?: ProtocolVersion)`: Delegates to `getRendererDataModel`.
  - `resolvePath(path: string, contextPath?: string)`: Delegates to `DataModel.resolvePath`.
- **Type Aliases:** Re-exported `type {RendererCapabilities as ClientCapabilities}` from `src/processing/message-processor.ts`.
- **Unit Tests:**
  - Added unit test in `src/state/component-model.test.ts` verifying 3-argument instantiation without a catalog.
  - Added unit test in `src/v0_9/nodes/node-resolver.test.ts` verifying node resolution with omitted and empty catalogs.
  - Added unit tests in `src/processing/message-processor.test.ts` covering `getClientCapabilities`, `getClientDataModel`, and `resolvePath` shims.

## Impact & Risks

- **Breaking Changes:** None. All additions are non-breaking backwards compatibility shims and fallbacks.
- **Deprecations:** Marks `getClientCapabilities`, `getClientDataModel`, and `resolvePath` on `MessageProcessor` with `@deprecated` JSDoc annotations directing callers to their canonical v1.0 counterparts.

## Testing

1. Verified all unit tests pass in `typescript/web_core`:
   ```bash
   yarn --cwd typescript/web_core test
   ```
   (566 passed, 0 failed)
2. Verified linting, formatting, and builds in `typescript/web_core`:
   ```bash
   yarn --cwd typescript/web_core lint
   yarn --cwd typescript/web_core format:check
   yarn --cwd typescript/web_core build
   ```
3. Verified downstream renderer packages pass unit tests:
   ```bash
   yarn --cwd renderers/react test
   yarn --cwd renderers/lit test
   yarn --cwd renderers/angular test
   ```
