### PR TITLE
chore(python): bump a2ui_agent version to 0.6.0

### DIFF
--- a/agent_sdks/python/a2ui_agent/CHANGELOG.md
+++ b/agent_sdks/python/a2ui_agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.6.0
+
 - Add support for keyword arguments (`param=value`) and mixed positional/keyword argument syntax in A2UI Express DSL component constructors and catalog function calls (#2131).
 - Add multi-version output support (`v0.9`, `v0.9.1`, `v1.0`) to `ExpressCompiler`, emitting standard `v0.9.1` message sequences or `v1.0` unified surface envelopes based on target configuration (#2131).
 - Add top-level `surface()` and `deleteSurface()` directive support in Express DSL to target or delete UI surfaces (#2163).

--- a/agent_sdks/python/a2ui_agent/src/a2ui/version.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/version.py
@@ -21,4 +21,4 @@
 #   Switch to VCS-based versioning which derives version
 #   from Git tags automatically with the hatch-vcs plugin
 #   when we start using Git tags.
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
To prepare for the next weekly release.