### PR TITLE
chore(python): upgrade twine to 7.0 so release builds pass `twine check`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 ]
 release = [
     "hatch>=1.14.0",
-    "twine>=6.0.1",
+    "twine>=7.0.0",
     "keyring>=25.6.0",
     "keyrings.google-artifactregistry-auth>=1.1.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ release = [
     { name = "hatch", specifier = ">=1.14.0" },
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "keyrings-google-artifactregistry-auth", specifier = ">=1.1.2" },
-    { name = "twine", specifier = ">=6.0.1" },
+    { name = "twine", specifier = ">=7.0.0" },
 ]
 
 [[package]]
@@ -5021,7 +5021,7 @@ wheels = [
 
 [[package]]
 name = "twine"
-version = "6.2.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
@@ -5034,9 +5034,9 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/3c/58f808a359700f39a967dffede33efeac809262c03303fa3eec6afff8f49/twine-7.0.0.tar.gz", hash = "sha256:85cdb29c518efef867360ae4acd4b0dfd61c8654a22fca08e6f8539f05022177", size = 215032, upload-time = "2026-07-27T15:59:00.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl", hash = "sha256:b854164df26db268af05f49aa5c0344b10e27a494343ff05b1e0bad3b135f5a7", size = 43204, upload-time = "2026-07-27T15:58:59.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`release.sh` fails at the `twine check` step with:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version.
```

I'm not familiar with the intricacies of the release script/process, so all I can report is what an agent told me:

> - hatchling 1.32.0 (2026-08-11) switched its default core metadata version from 2.4 to 2.5. `uv build` resolves `build-system.requires` in an isolated environment, and both SDK packages list `hatchling` there without a bound, so every build now picks up 1.32.0 regardless of what `uv.lock` pins for the dev group.
> - twine 6.2.0 overrides `packaging`'s list of accepted metadata versions with its own, which stops at 2.4. twine 7.0.0 (2026-07-27) drops that override and accepts whatever `packaging` accepts, which includes 2.5 (pypa/twine#1317).
> 
> This raises the `twine` floor in the root `release` dependency group to 7.0.0 and re-locks. Only `twine` moves in `uv.lock`; the locked `packaging` (26.2) already satisfies twine 7's `packaging>=26.1` requirement.
> 
> To reproduce, from `agent_sdks/python/a2ui_agent`:
> 
> ```
> uv build --out-dir dist
> uv run twine check dist/*        # fails on main, passes with this change
> uvx twine@7.0.0 check dist/*     # passes on main
> ```

This makes sense to me, and--at worst--I don't see how this can do any great harm since it only affects release infra.