### PR TITLE
feat(common): implement SemVer 2.0.0 parsing and standardize version comparisons

### DIFF
--- a/conformance/core/message_processor_v0_8.yaml
+++ b/conformance/core/message_processor_v0_8.yaml
@@ -100,7 +100,7 @@
         - "cat-v08"
 
 - name: test_v08_rejects_v09_create_surface_action
-  description: Tests that v0.8 MessageProcessor ignores v0.9 createSurface action when protocolVersion is v0.8.
+  description: Tests that v0.8 MessageProcessor rejects v0.9 createSurface action when protocolVersion is v0.8.
   action: process_messages
   protocolVersion: "v0.8"
   messages:
@@ -108,10 +108,8 @@
       createSurface:
         surfaceId: "s_v08_invalid"
         catalogId: "v08-cat"
-  expect:
-    surfaces:
-      s_v08_invalid:
-        exists: false
+  expectError:
+    category: "ValidationError"
 
 - name: test_v08_multiple_conflicting_update_types_error
   description: Tests that a single v0.8 message envelope containing multiple conflicting update actions raises a ValidationError.

--- a/conformance/core/message_processor_v0_8.yaml
+++ b/conformance/core/message_processor_v0_8.yaml
@@ -110,6 +110,22 @@
         catalogId: "v08-cat"
   expectError:
     category: "ValidationError"
+    message: "action 'createSurface' is not supported in protocol version v0.8"
+
+- name: test_v08_catalog_rejects_v09_create_surface_message
+  description: Tests that v0.9 createSurface message is rejected when catalog protocolVersion is v0.8.
+  action: process_messages
+  catalogs:
+    - catalogId: "v08-cat"
+      protocolVersion: "v0.8"
+  messages:
+    - version: "v0.9"
+      createSurface:
+        surfaceId: "s_v08_invalid"
+        catalogId: "v08-cat"
+  expectError:
+    category: "ValidationError"
+    message: "does not match message protocol version (v0.9)"
 
 - name: test_v08_multiple_conflicting_update_types_error
   description: Tests that a single v0.8 message envelope containing multiple conflicting update actions raises a ValidationError.

--- a/conformance/core/message_processor_v0_9.yaml
+++ b/conformance/core/message_processor_v0_9.yaml
@@ -941,7 +941,7 @@
               type: "string"
 
 - name: test_v09_rejects_v08_begin_rendering_action
-  description: Tests that v0.9 MessageProcessor ignores v0.8 beginRendering action when protocolVersion is v0.9.
+  description: Tests that v0.9 MessageProcessor rejects v0.8 beginRendering action when protocolVersion is v0.9.
   action: process_messages
   protocolVersion: "v0.9"
   messages:
@@ -949,10 +949,8 @@
       beginRendering:
         surfaceId: "s_v09_invalid"
         catalogId: "v09-cat"
-  expect:
-    surfaces:
-      s_v09_invalid:
-        exists: false
+  expectError:
+    category: "ValidationError"
 
 - name: test_v09_non_string_surface_id_error
   description: Tests that a v0.9 action with a non-string surfaceId raises a ValidationError.

--- a/conformance/core/message_processor_v0_9.yaml
+++ b/conformance/core/message_processor_v0_9.yaml
@@ -951,6 +951,7 @@
         catalogId: "v09-cat"
   expectError:
     category: "ValidationError"
+    message: "action 'beginRendering' is not supported in protocol version v0.9"
 
 - name: test_v09_non_string_surface_id_error
   description: Tests that a v0.9 action with a non-string surfaceId raises a ValidationError.

--- a/conformance/core/message_processor_v1_0.yaml
+++ b/conformance/core/message_processor_v1_0.yaml
@@ -213,6 +213,7 @@
         catalogId: "test-catalog-v10"
   expectError:
     category: "ValidationError"
+    message: "action 'beginRendering' is not supported in protocol version v1.0"
 
 - name: test_v10_non_string_surface_id_error
   description: Tests that a v1.0 action with a non-string surfaceId raises a ValidationError.

--- a/conformance/core/message_processor_v1_0.yaml
+++ b/conformance/core/message_processor_v1_0.yaml
@@ -203,7 +203,7 @@
         exists: true
 
 - name: test_v10_rejects_v08_begin_rendering_action
-  description: Tests that v1.0 MessageProcessor ignores v0.8 beginRendering action when protocolVersion is v1.0.
+  description: Tests that v1.0 MessageProcessor rejects v0.8 beginRendering action when protocolVersion is v1.0.
   action: process_messages
   protocolVersion: "v1.0"
   messages:
@@ -211,10 +211,8 @@
       beginRendering:
         surfaceId: "s_v10_invalid"
         catalogId: "test-catalog-v10"
-  expect:
-    surfaces:
-      s_v10_invalid:
-        exists: false
+  expectError:
+    category: "ValidationError"
 
 - name: test_v10_non_string_surface_id_error
   description: Tests that a v1.0 action with a non-string surfaceId raises a ValidationError.

--- a/eval/a2ui_eval/scorers.py
+++ b/eval/a2ui_eval/scorers.py
@@ -30,7 +30,7 @@ from inspect_ai.model._model import sample_model_usage
 from a2ui.inference_formats.direct_json.format import DirectJsonFormat
 from a2ui.schema.catalog import CatalogConfig
 from a2ui.parser.parser import parse_response
-from a2ui.core.processing import MessageProcessor
+from a2ui.core.processing import MessageProcessor, MessageProcessorOptions
 from a2ui.core.validation import STRICT_VALIDATION
 from .shared.utils import GIT_ROOT
 
@@ -97,7 +97,8 @@ def a2ui_scorer(version: str) -> Scorer:
 
             answer_text = json.dumps(all_messages, indent=2)
             MessageProcessor(
-                [catalog.core_catalog], validation_config=STRICT_VALIDATION
+                [catalog.core_catalog],
+                options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
             ).process_messages(all_messages)
             return Score(
                 value=1.0, answer=answer_text, explanation="Valid A2UI payload"

--- a/eval/a2ui_eval/strategies/format.py
+++ b/eval/a2ui_eval/strategies/format.py
@@ -23,7 +23,7 @@ from inspect_ai.model import (
     ChatCompletionChoice,
     ChatMessageAssistant,
 )
-from a2ui.core.processing import MessageProcessor
+from a2ui.core.processing import MessageProcessor, MessageProcessorOptions
 from a2ui.core.validation import STRICT_VALIDATION
 from a2ui.schema.catalog import CatalogConfig
 from a2ui.inference_formats.direct_json import DirectJsonFormat
@@ -158,7 +158,8 @@ def _parse_and_validate_in_process(
         )
 
     MessageProcessor(
-        [catalog.core_catalog], validation_config=STRICT_VALIDATION
+        [catalog.core_catalog],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     ).process_messages(compiled_jsons)
     return {"compiled_jsons": compiled_jsons, "parts": serialized_parts}
 

--- a/python/a2ui_agent/pack_specs_hook.py
+++ b/python/a2ui_agent/pack_specs_hook.py
@@ -30,6 +30,10 @@ def load_module(project_root, rel_path, filename, module_name):
     if src_path not in sys.path:
         sys.path.insert(0, src_path)
 
+    core_src = os.path.abspath(os.path.join(project_root, "..", "a2ui_core", "src"))
+    if os.path.exists(core_src) and core_src not in sys.path:
+        sys.path.insert(0, core_src)
+
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec and spec.loader:
         module = importlib.util.module_from_spec(spec)

--- a/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -222,11 +222,12 @@ class A2uiCatalog:
 
     def validate(self, messages: Any) -> None:
         """Validates payload messages using MessageProcessor."""
-        from a2ui.core.processing import MessageProcessor
+        from a2ui.core.processing import MessageProcessor, MessageProcessorOptions
 
         msg_list = messages if isinstance(messages, list) else [messages]
         MessageProcessor(
-            [self.core_catalog], validation_config=STRICT_VALIDATION
+            [self.core_catalog],
+            options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
         ).process_messages(msg_list)
 
     def _with_pruned_components(self, allowed_components: Sequence[str]) -> A2uiCatalog:

--- a/python/a2ui_agent/src/a2ui/schema/utils.py
+++ b/python/a2ui_agent/src/a2ui/schema/utils.py
@@ -24,8 +24,6 @@ import os
 import importlib.resources
 from typing import Any, cast
 
-from a2ui.core import A2uiCatalogError
-from a2ui.core.common.semver import normalize_version_string, parse_semver
 from .constants import (
     A2UI_ASSET_PACKAGE,
     SPECIFICATION_DIR,
@@ -77,6 +75,8 @@ def get_spec_dir(version: str = "v1_0", start_path: str | None = None) -> str:
         raise FileNotFoundError(
             "Could not find repository root containing 'specification'"
         )
+
+    from a2ui.core.common.semver import normalize_version_string, parse_semver
 
     # The on-disk 'specification/' hierarchy is organized strictly by base protocol
     # versions (e.g. 'v1_0', 'v0_9_1', 'v0_8'). Pre-release tags ('-alpha') and build
@@ -251,6 +251,8 @@ def wrap_as_json_array(a2ui_schema: dict[str, Any]) -> dict[str, Any]:
         A2uiCatalogError: If a2ui_schema is empty.
     """
     if not a2ui_schema:
+        from a2ui.core import A2uiCatalogError
+
         raise A2uiCatalogError("A2UI schema is empty")
     return {"type": "array", "items": a2ui_schema}
 

--- a/python/a2ui_agent/src/a2ui/schema/utils.py
+++ b/python/a2ui_agent/src/a2ui/schema/utils.py
@@ -200,12 +200,11 @@ def load_from_bundled_resource(
     # This handles cases where assets might be present in src but not installed
     try:
         # The assets are located at a2ui/assets/<version_dir>/<filename>
-        # This file is at a2ui/inference/schema/manager.py
-        # So, we need to go up 3 directories to 'a2ui', then down to 'assets'
+        # This file is at a2ui/schema/utils.py
+        # So, we need to go up 1 directory to 'a2ui', then down to 'assets'
         potential_path = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),
-                "..",
                 "..",
                 "assets",
                 version_dir,

--- a/python/a2ui_agent/src/a2ui/schema/utils.py
+++ b/python/a2ui_agent/src/a2ui/schema/utils.py
@@ -24,6 +24,8 @@ import os
 import importlib.resources
 from typing import Any, cast
 
+from a2ui.core import A2uiCatalogError
+from a2ui.core.common.semver import normalize_version_string, parse_semver
 from .constants import (
     A2UI_ASSET_PACKAGE,
     SPECIFICATION_DIR,
@@ -75,7 +77,6 @@ def get_spec_dir(version: str = "v1_0", start_path: str | None = None) -> str:
         raise FileNotFoundError(
             "Could not find repository root containing 'specification'"
         )
-    from a2ui.core.common.semver import normalize_version_string, parse_semver
 
     # The on-disk 'specification/' hierarchy is organized strictly by base protocol
     # versions (e.g. 'v1_0', 'v0_9_1', 'v0_8'). Pre-release tags ('-alpha') and build
@@ -250,8 +251,6 @@ def wrap_as_json_array(a2ui_schema: dict[str, Any]) -> dict[str, Any]:
         A2uiCatalogError: If a2ui_schema is empty.
     """
     if not a2ui_schema:
-        from a2ui.core import A2uiCatalogError
-
         raise A2uiCatalogError("A2UI schema is empty")
     return {"type": "array", "items": a2ui_schema}
 

--- a/python/a2ui_agent/src/a2ui/schema/utils.py
+++ b/python/a2ui_agent/src/a2ui/schema/utils.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Utilities for A2UI Schema manipulation."""
+"""Utilities for A2UI schema resolution, loading, and manipulation.
+
+Provides helper functions for locating specification directories, loading
+bundled or repository schema assets, and performing schema transformations.
+"""
 
 import json
 import logging
@@ -20,12 +24,25 @@ import os
 import importlib.resources
 from typing import Any, cast
 
-from .constants import A2UI_ASSET_PACKAGE, SPECIFICATION_DIR, ENCODING, COMMON_TYPES_SCHEMA_KEY
+from .constants import (
+    A2UI_ASSET_PACKAGE,
+    SPECIFICATION_DIR,
+    ENCODING,
+    COMMON_TYPES_SCHEMA_KEY,
+)
 from .catalog_provider import FileSystemCatalogProvider
 
 
 def find_repo_root(start_path: str | None = None) -> str | None:
-    """Finds the repository root by looking for the 'specification' directory."""
+    """Finds the repository root by looking for the 'specification' directory.
+
+    Args:
+        start_path: Optional starting directory to search upwards from. Defaults to
+            the directory of this file.
+
+    Returns:
+        The absolute path to the repository root directory, or None if not found.
+    """
     if start_path is None:
         start_path = os.path.dirname(__file__)
     current = os.path.abspath(start_path)
@@ -39,27 +56,84 @@ def find_repo_root(start_path: str | None = None) -> str | None:
 
 
 def get_spec_dir(version: str = "v1_0", start_path: str | None = None) -> str:
-    """Returns the path to the specification directory for a given version."""
+    """Returns the path to the specification directory for a given version.
+
+    Args:
+        version: The protocol version string (e.g. 'v1_0', '1.0', 'v0_9_1',
+            '1.0.0-alpha.1'). Defaults to 'v1_0'.
+        start_path: Optional starting directory to search for the repository root.
+
+    Returns:
+        The absolute path to the specification directory for the resolved version.
+
+    Raises:
+        FileNotFoundError: If the repository root containing 'specification'
+            cannot be found.
+    """
     root = find_repo_root(start_path)
     if not root:
         raise FileNotFoundError(
             "Could not find repository root containing 'specification'"
         )
-    norm_version = version.replace(".", "_")
-    if not norm_version.startswith("v"):
-        norm_version = f"v{norm_version}"
+    from a2ui.core.common.semver import normalize_version_string, parse_semver
+
+    # The on-disk 'specification/' hierarchy is organized strictly by base protocol
+    # versions (e.g. 'v1_0', 'v0_9_1', 'v0_8'). Pre-release tags ('-alpha') and build
+    # metadata ('+build') are stripped so that requests for pre-release or development
+    # versions consistently map to the corresponding base specification directory.
+    clean_version = version.split("-")[0].split("+")[0]
+
+    # Format canonical specification directory names: versions with patch > 0
+    # use 'vMAJOR_MINOR_PATCH' (e.g. 'v0_9_1'), while zero-patch versions use
+    # 'vMAJOR_MINOR' (e.g. 'v1_0').
+    parsed = parse_semver(normalize_version_string(clean_version))
+    if parsed:
+        if parsed.patch > 0:
+            norm_version = f"v{parsed.major}_{parsed.minor}_{parsed.patch}"
+        else:
+            norm_version = f"v{parsed.major}_{parsed.minor}"
+    else:
+        norm_version = clean_version.replace(".", "_")
+        if norm_version.startswith(("v", "V")):
+            norm_version = f"v{norm_version[1:]}"
+        else:
+            norm_version = f"v{norm_version}"
     return os.path.join(root, SPECIFICATION_DIR, norm_version)
 
 
 def get_basic_catalog_path(version: str = "v1_0", start_path: str | None = None) -> str:
-    """Returns the path to the basic catalog.json file for a given version."""
+    """Returns the path to the basic catalog.json file for a given version.
+
+    Args:
+        version: The protocol version string. Defaults to 'v1_0'.
+        start_path: Optional starting directory to search for the repository root.
+
+    Returns:
+        The absolute path to the basic catalog.json file.
+
+    Raises:
+        FileNotFoundError: If the repository root containing 'specification'
+            cannot be found.
+    """
     return os.path.join(
         get_spec_dir(version, start_path), "catalogs", "basic", "catalog.json"
     )
 
 
 def get_basic_examples_dir(version: str = "v1_0", start_path: str | None = None) -> str:
-    """Returns the path to the basic examples directory for a given version."""
+    """Returns the path to the basic examples directory for a given version.
+
+    Args:
+        version: The protocol version string. Defaults to 'v1_0'.
+        start_path: Optional starting directory to search for the repository root.
+
+    Returns:
+        The absolute path to the basic examples directory.
+
+    Raises:
+        FileNotFoundError: If the repository root containing 'specification'
+            cannot be found.
+    """
     return os.path.join(
         get_spec_dir(version, start_path), "catalogs", "basic", "examples"
     )
@@ -70,8 +144,29 @@ def load_from_bundled_resource(
     resource_key: str,
     spec_map: dict[str, dict[str, str]],
 ) -> dict[str, Any]:
-    """Loads a schema resource from bundled package resources."""
-    version_spec_map = spec_map.get(version)
+    """Loads a schema resource from bundled package resources or local fallbacks.
+
+    Attempts to load the schema from bundled package resources first, falling back
+    to local asset directories, and finally to the source repository.
+
+    Args:
+        version: The protocol version string (e.g. 'v1_0', 'v0_9').
+        resource_key: Key identifying the resource in spec_map.
+        spec_map: Mapping of version names to dictionaries of resource keys and
+            relative file paths.
+
+    Returns:
+        The parsed schema JSON content as a dictionary.
+
+    Raises:
+        A2uiCatalogError: If the version is not found in spec_map, or if resource_key
+            is not found in the specification map for the version.
+        IOError: If the schema resource file cannot be located or loaded from any source.
+    """
+    stripped = version[1:] if version.startswith(("v", "V")) else version
+    version_spec_map = (
+        spec_map.get(version) or spec_map.get(stripped) or spec_map.get(f"v{stripped}")
+    )
     if not version_spec_map:
         from a2ui.core import A2uiCatalogError
 
@@ -139,18 +234,20 @@ def load_from_bundled_resource(
     raise IOError(f"Could not load schema {filename} for version {version}")
 
 
-# LLM is instructed to generate a list of messages, so we wrap the bundled schema in an array.
 def wrap_as_json_array(a2ui_schema: dict[str, Any]) -> dict[str, Any]:
-    """Wraps the A2UI schema in an array object to support multiple parts.
+    """Wraps an A2UI schema in a JSON array schema to support message sequences.
+
+    Used when prompting language models to generate a sequence of messages rather
+    than a single message object.
 
     Args:
-        a2ui_schema: The A2UI schema to wrap.
+        a2ui_schema: The base A2UI JSON schema dictionary to wrap.
 
     Returns:
-        The wrapped A2UI schema object.
+        The wrapped JSON schema specifying an array of the given schema items.
 
     Raises:
-        ValueError: If the A2UI schema is empty.
+        A2uiCatalogError: If a2ui_schema is empty.
     """
     if not a2ui_schema:
         from a2ui.core import A2uiCatalogError
@@ -159,11 +256,19 @@ def wrap_as_json_array(a2ui_schema: dict[str, Any]) -> dict[str, Any]:
     return {"type": "array", "items": a2ui_schema}
 
 
-def deep_update(d: dict[str, Any], u: dict[str, Any]) -> dict[str, Any]:
-    """Recursively update a dict with another dict."""
-    for k, v in u.items():
-        if isinstance(v, dict):
-            d[k] = deep_update(d.get(k, {}), v)
+def deep_update(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Recursively updates a dictionary with another dictionary.
+
+    Args:
+        base: The base dictionary to be updated in-place.
+        updates: The dictionary containing updates to recursively merge into the base dictionary.
+
+    Returns:
+        The updated base dictionary.
+    """
+    for key, value in updates.items():
+        if isinstance(value, dict):
+            base[key] = deep_update(base.get(key, {}), value)
         else:
-            d[k] = v
-    return d
+            base[key] = value
+    return base

--- a/python/a2ui_agent/src/a2ui/schema/utils.py
+++ b/python/a2ui_agent/src/a2ui/schema/utils.py
@@ -164,10 +164,10 @@ def load_from_bundled_resource(
             is not found in the specification map for the version.
         IOError: If the schema resource file cannot be located or loaded from any source.
     """
-    stripped = version[1:] if version.startswith(("v", "V")) else version
-    version_spec_map = (
-        spec_map.get(version) or spec_map.get(stripped) or spec_map.get(f"v{stripped}")
-    )
+    from a2ui.core.common.semver import to_canonical_version
+
+    canonical = to_canonical_version(version)
+    version_spec_map = spec_map.get(canonical or version)
     if not version_spec_map:
         from a2ui.core import A2uiCatalogError
 
@@ -185,11 +185,12 @@ def load_from_bundled_resource(
 
     rel_path = version_spec_map[resource_key]
     filename = os.path.basename(rel_path)
+    version_dir = canonical or version
 
     # 1. Try to load from the bundled package resources.
     try:
         traversable = importlib.resources.files(A2UI_ASSET_PACKAGE)
-        traversable = traversable.joinpath(version).joinpath(filename)
+        traversable = traversable.joinpath(version_dir).joinpath(filename)
         with traversable.open("r", encoding=ENCODING) as f:
             return cast(dict[str, Any], json.load(f))
     except Exception as e:
@@ -198,7 +199,7 @@ def load_from_bundled_resource(
     # 2. Fallback to local assets
     # This handles cases where assets might be present in src but not installed
     try:
-        # The assets are located at a2ui/assets/<version>/<filename>
+        # The assets are located at a2ui/assets/<version_dir>/<filename>
         # This file is at a2ui/inference/schema/manager.py
         # So, we need to go up 3 directories to 'a2ui', then down to 'assets'
         potential_path = os.path.abspath(
@@ -207,7 +208,7 @@ def load_from_bundled_resource(
                 "..",
                 "..",
                 "assets",
-                version,
+                version_dir,
                 filename,
             )
         )

--- a/python/a2ui_agent/src/a2ui/schema/utils.py
+++ b/python/a2ui_agent/src/a2ui/schema/utils.py
@@ -262,7 +262,8 @@ def deep_update(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]
 
     Args:
         base: The base dictionary to be updated in-place.
-        updates: The dictionary containing updates to recursively merge into the base dictionary.
+        updates: The dictionary containing updates to recursively merge into
+            the base dictionary.
 
     Returns:
         The updated base dictionary.

--- a/python/a2ui_agent/tests/schema/test_utils.py
+++ b/python/a2ui_agent/tests/schema/test_utils.py
@@ -21,6 +21,7 @@ from a2ui.schema.catalog_provider import A2uiCatalogProvider, FileSystemCatalogP
 from a2ui.schema.common_modifiers import remove_strict_validation
 from a2ui.schema.utils import (
     find_repo_root,
+    get_spec_dir,
     load_from_bundled_resource,
     wrap_as_json_array,
     deep_update,
@@ -178,6 +179,24 @@ class TestSchemaUtils(unittest.TestCase):
         # Unsupported type should raise TypeError
         with self.assertRaises(TypeError):
             CatalogSchemaHelper("invalid_catalog_type")
+
+    def test_get_spec_dir_standard_versions(self):
+        """Verifies get_spec_dir maps standard version formats to their spec directories."""
+        self.assertTrue(get_spec_dir("v1_0").endswith("specification/v1_0"))
+        self.assertTrue(get_spec_dir("1.0").endswith("specification/v1_0"))
+        self.assertTrue(get_spec_dir("v0_9_1").endswith("specification/v0_9_1"))
+        self.assertTrue(get_spec_dir("0.9.1").endswith("specification/v0_9_1"))
+        self.assertTrue(get_spec_dir("v1_0_0-alpha.1").endswith("specification/v1_0"))
+
+    def test_get_spec_dir_prerelease_versions(self):
+        """Verifies get_spec_dir consistently maps pre-release versions to their base spec directory."""
+        self.assertTrue(
+            get_spec_dir("1.0.0-dev_release").endswith("specification/v1_0")
+        )
+        self.assertTrue(
+            get_spec_dir("v1_0_0-dev_release").endswith("specification/v1_0")
+        )
+        self.assertTrue(get_spec_dir("1.0.0-alpha.1").endswith("specification/v1_0"))
 
 
 if __name__ == "__main__":

--- a/python/a2ui_agent/tests/schema/test_utils.py
+++ b/python/a2ui_agent/tests/schema/test_utils.py
@@ -85,6 +85,22 @@ class TestSchemaUtils(unittest.TestCase):
             self.assertIsInstance(schema, dict)
             self.assertIn("title", schema)
 
+    @patch(
+        "importlib.resources.files",
+        side_effect=Exception("Simulated package resource failure"),
+    )
+    def test_load_from_bundled_resource_local_assets_fallback(self, _mock_files):
+        """Verifies load_from_bundled_resource resolves schemas from local a2ui/assets when package resources fail."""
+        from a2ui.schema.constants import PROTOCOL_VERSION_MAP, SERVER_TO_CLIENT_SCHEMA_KEY
+
+        schema = load_from_bundled_resource(
+            version="v1.0",
+            resource_key=SERVER_TO_CLIENT_SCHEMA_KEY,
+            spec_map=PROTOCOL_VERSION_MAP,
+        )
+        self.assertIsInstance(schema, dict)
+        self.assertIn("title", schema)
+
     def test_wrap_as_json_array_empty_schema(self):
         """Verifies wrap_as_json_array raises A2uiCatalogError for empty schema."""
         with self.assertRaises(A2uiCatalogError) as ctx:

--- a/python/a2ui_agent/tests/schema/test_utils.py
+++ b/python/a2ui_agent/tests/schema/test_utils.py
@@ -48,7 +48,7 @@ class TestSchemaUtils(unittest.TestCase):
 
     def test_load_from_bundled_resource_missing_key(self):
         """Verifies load_from_bundled_resource raises A2uiCatalogError for missing resource key."""
-        spec_map = {"v1.0": {"s2c": "s2c_path.json"}}
+        spec_map = {"1.0": {"s2c": "s2c_path.json"}}
         with self.assertRaises(A2uiCatalogError) as ctx:
             load_from_bundled_resource(
                 version="v1.0", resource_key="missing_key", spec_map=spec_map
@@ -57,11 +57,33 @@ class TestSchemaUtils(unittest.TestCase):
 
     def test_load_from_bundled_resource_common_types_fallback(self):
         """Verifies load_from_bundled_resource fallback for common_types key."""
-        spec_map = {"v1.0": {"s2c": "s2c_path.json"}}
+        spec_map = {"1.0": {"s2c": "s2c_path.json"}}
         res = load_from_bundled_resource(
             version="v1.0", resource_key="common_types", spec_map=spec_map
         )
         self.assertEqual(res, {})
+
+    def test_load_from_bundled_resource_semver_normalization(self):
+        """Verifies load_from_bundled_resource normalizes various version formats to canonical keys."""
+        spec_map = {"1.0": {"s2c": "s2c_path.json"}}
+        for ver in ["v1_0", "1.0.0", "v1.0", "1.0", "V1.0"]:
+            res = load_from_bundled_resource(
+                version=ver, resource_key="common_types", spec_map=spec_map
+            )
+            self.assertEqual(res, {})
+
+    def test_load_from_bundled_resource_real_schema(self):
+        """Verifies load_from_bundled_resource successfully loads a real schema with version normalization."""
+        from a2ui.schema.constants import PROTOCOL_VERSION_MAP, SERVER_TO_CLIENT_SCHEMA_KEY
+
+        for ver in ["v1_0", "1.0.0", "v1.0", "1.0"]:
+            schema = load_from_bundled_resource(
+                version=ver,
+                resource_key=SERVER_TO_CLIENT_SCHEMA_KEY,
+                spec_map=PROTOCOL_VERSION_MAP,
+            )
+            self.assertIsInstance(schema, dict)
+            self.assertIn("title", schema)
 
     def test_wrap_as_json_array_empty_schema(self):
         """Verifies wrap_as_json_array raises A2uiCatalogError for empty schema."""

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -124,7 +124,7 @@ def _extract_module_type_refs(modname: str, excluded: set[str]) -> set[str]:
 
 
 def load_preserved_type_refs() -> set[str]:
-    """Dynamically loads all common type names defined in schema/common_types.py and versioned submodules."""
+    """Dynamically loads common type names from schema modules."""
     import a2ui.core.schema as schema_pkg
 
     excluded = {

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -98,6 +98,11 @@ def is_valid_uax31_identifier(name: str) -> bool:
     return test_name.isidentifier()
 
 
+def _is_version_at_least_1_0(protocol_version: Any) -> bool:
+    """Returns True if the protocol version is 1.0 or higher."""
+    return is_at_least_version(protocol_version, "1.0")
+
+
 def _extract_module_type_refs(modname: str, excluded: set[str]) -> set[str]:
     """Extracts non-private exported attribute names from a module.
 
@@ -625,7 +630,7 @@ class Catalog(Generic[TComponent, TFunction]):
                 if isinstance(ref, str) and ref.startswith("#/components/"):
                     permitted_names.add(ref.split("/")[-1])
 
-        validate_identifiers = _is_version_at_least_1_0(p_ver)
+        validate_identifiers = is_at_least_version(p_ver, "1.0")
 
         components = []
         for name, schema in components_map.items():

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -24,6 +24,8 @@ else:
     from typing_extensions import TypeVar
 from pydantic import BaseModel, TypeAdapter
 
+from ..common.semver import is_at_least_version, parse_semver
+
 
 def _generate_dynamic_type_def(type_cls: Any) -> dict[str, Any]:
     raw_schema = TypeAdapter(type_cls).json_schema()
@@ -96,20 +98,33 @@ def is_valid_uax31_identifier(name: str) -> bool:
     return test_name.isidentifier()
 
 
-def _is_version_at_least_1_0(protocol_version: str | Any) -> bool:
-    """Returns True if the protocol version is 1.0 or higher (e.g. v1.0, v1.1, v2.0)."""
-    ver_str = str(protocol_version).strip().lstrip("vV").replace("_", ".")
-    parts = ver_str.split(".")
+def _extract_module_type_refs(modname: str, excluded: set[str]) -> set[str]:
+    """Extracts non-private exported attribute names from a module.
+
+    Args:
+        modname: The fully qualified module name to import.
+        excluded: Set of attribute names to exclude from extraction.
+
+    Returns:
+        A set of public attribute names extracted from the module, or an empty
+        set if the module could not be imported.
+    """
+    import importlib
+
+    type_refs: set[str] = set()
     try:
-        major = int(parts[0])
-        return major >= 1
-    except (ValueError, IndexError):
-        return False
+        mod = importlib.import_module(modname)
+    except ImportError:
+        return type_refs
+
+    for attr in dir(mod):
+        if not attr.startswith("_") and attr not in excluded:
+            type_refs.add(attr)
+    return type_refs
 
 
 def load_preserved_type_refs() -> set[str]:
     """Dynamically loads all common type names defined in schema/common_types.py and versioned submodules."""
-    import importlib
     import a2ui.core.schema as schema_pkg
 
     excluded = {
@@ -145,21 +160,16 @@ def load_preserved_type_refs() -> set[str]:
     )
     if protocol_version_enum:
         for ver_enum in protocol_version_enum:
-            raw_ver = str(ver_enum.value).lstrip("vV")
-            major_minor = "_".join(raw_ver.split(".")[:2])
-            mod_name = f"{schema_pkg.__name__}.v{major_minor}.common_types"
-            if mod_name not in modules_to_check:
-                modules_to_check.append(mod_name)
+            parsed = parse_semver(ver_enum.value)
+            if parsed:
+                major_minor = f"{parsed.major}_{parsed.minor}"
+                mod_name = f"{schema_pkg.__name__}.v{major_minor}.common_types"
+                if mod_name not in modules_to_check:
+                    modules_to_check.append(mod_name)
 
     type_refs: set[str] = set()
     for modname in modules_to_check:
-        try:
-            mod = importlib.import_module(modname)
-            for attr in dir(mod):
-                if not attr.startswith("_") and attr not in excluded:
-                    type_refs.add(attr)
-        except ImportError:
-            pass
+        type_refs.update(_extract_module_type_refs(modname, excluded))
 
     return type_refs
 
@@ -393,7 +403,7 @@ class Catalog(Generic[TComponent, TFunction]):
         self.protocol_version = protocol_version
         self.instructions = instructions
 
-        validate_identifiers = _is_version_at_least_1_0(protocol_version)
+        validate_identifiers = is_at_least_version(protocol_version, "1.0")
 
         self.components: dict[str, TComponent] = {}
         for c in components or []:

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -98,11 +98,6 @@ def is_valid_uax31_identifier(name: str) -> bool:
     return test_name.isidentifier()
 
 
-def _is_version_at_least_1_0(protocol_version: Any) -> bool:
-    """Returns True if the protocol version is 1.0 or higher."""
-    return is_at_least_version(protocol_version, "1.0")
-
-
 def _extract_module_type_refs(modname: str, excluded: set[str]) -> set[str]:
     """Extracts non-private exported attribute names from a module.
 

--- a/python/a2ui_core/src/a2ui/core/common/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/common/__init__.py
@@ -18,9 +18,9 @@ from .semver import (
     SemVer,
     compare_semver,
     is_at_least_version,
-    is_catalog_version_compatible,
     normalize_version_string,
     parse_semver,
+    to_canonical_version,
 )
 
 __all__ = [
@@ -31,7 +31,7 @@ __all__ = [
     "SemVer",
     "normalize_version_string",
     "parse_semver",
+    "to_canonical_version",
     "compare_semver",
     "is_at_least_version",
-    "is_catalog_version_compatible",
 ]

--- a/python/a2ui_core/src/a2ui/core/common/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/common/__init__.py
@@ -21,6 +21,7 @@ from .semver import (
     normalize_version_string,
     parse_semver,
     to_canonical_version,
+    to_semver,
 )
 
 __all__ = [
@@ -32,6 +33,7 @@ __all__ = [
     "normalize_version_string",
     "parse_semver",
     "to_canonical_version",
+    "to_semver",
     "compare_semver",
     "is_at_least_version",
 ]

--- a/python/a2ui_core/src/a2ui/core/common/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/common/__init__.py
@@ -11,12 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Common utilities for A2UI core, including event handling and SemVer parsing."""
 
 from .events import Subscription, EventSource, Signal, AbortSignal
+from .semver import (
+    SemVer,
+    compare_semver,
+    is_at_least_version,
+    is_catalog_version_compatible,
+    normalize_version_string,
+    parse_semver,
+)
 
 __all__ = [
     "Subscription",
     "EventSource",
     "Signal",
     "AbortSignal",
+    "SemVer",
+    "normalize_version_string",
+    "parse_semver",
+    "compare_semver",
+    "is_at_least_version",
+    "is_catalog_version_compatible",
 ]

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -108,11 +108,39 @@ def parse_semver(version_str: Any) -> Optional[SemVer]:
     )
 
 
-def _to_semver(v: Any) -> Optional[SemVer]:
+def _to_semver(v: str | bytes | SemVer | None) -> Optional[SemVer]:
     """Converts a version string or SemVer instance into a SemVer object."""
     if isinstance(v, SemVer):
         return v
-    return parse_semver(v)
+    if v is None:
+        return None
+    return parse_semver(normalize_version_string(v))
+
+
+def to_canonical_version(version: str | bytes | SemVer | None) -> str | None:
+    """Formats a semantic version into a canonical string representation.
+
+    For standard versions with zero patch and no pre-release or build metadata,
+    returns f"{major}.{minor}" (e.g. '0.8', '0.9', '1.0').
+    For versions with non-zero patch, pre-release identifiers, or build metadata,
+    returns the full SemVer string (e.g. '0.9.1', '1.0.0-beta.1').
+
+    Args:
+        version: The version string, bytes, or SemVer object to canonicalize.
+
+    Returns:
+        The canonical version string, or None if the input cannot be parsed.
+    """
+    if not version:
+        return None
+    parsed = _to_semver(version)
+    if not parsed:
+        return None
+    if parsed.patch == 0 and not parsed.prerelease and not parsed.build:
+        return f"{parsed.major}.{parsed.minor}"
+    pre = f"-{'.'.join(parsed.prerelease)}" if parsed.prerelease else ""
+    bld = f"+{'.'.join(parsed.build)}" if parsed.build else ""
+    return f"{parsed.major}.{parsed.minor}.{parsed.patch}{pre}{bld}"
 
 
 def _compare_prerelease_id(id_a: str, id_b: str) -> int:
@@ -149,7 +177,10 @@ def _compare_prerelease_lists(pre_a: Sequence[str], pre_b: Sequence[str]) -> int
     return len(pre_a) - len(pre_b)
 
 
-def compare_semver(a: Any, b: Any) -> int:
+def compare_semver(
+    a: str | bytes | SemVer | None,
+    b: str | bytes | SemVer | None,
+) -> int:
     """Compares two semantic version strings or SemVer objects per SemVer 2.0.0 precedence (Section 11).
 
     Args:
@@ -178,7 +209,10 @@ def compare_semver(a: Any, b: Any) -> int:
     return _compare_prerelease_lists(v_a.prerelease, v_b.prerelease)
 
 
-def is_at_least_version(version: Any, min_version: str) -> bool:
+def is_at_least_version(
+    version: str | bytes | SemVer | None,
+    min_version: str | bytes | SemVer,
+) -> bool:
     """Checks if a given version string is at least the target minimum version.
 
     Args:
@@ -195,32 +229,3 @@ def is_at_least_version(version: Any, min_version: str) -> bool:
     if not parsed or not min_parsed:
         return False
     return compare_semver(parsed, min_parsed) >= 0
-
-
-def is_catalog_version_compatible(cat_ver: Any, msg_ver: Any) -> bool:
-    """Evaluates whether a catalog protocol version is compatible with an incoming message version.
-
-    For protocol versions >= 1.0, forward compatibility is supported (a catalog
-    at version 1.0 can process messages at version 1.1). For pre-1.0 versions,
-    exact version matching is required.
-
-    Args:
-        cat_ver: The catalog's declared protocol version.
-        msg_ver: The incoming message's declared protocol version.
-
-    Returns:
-        True if the catalog version is compatible with the message version, False otherwise.
-    """
-    if not cat_ver or not msg_ver:
-        return False
-    cat_semver = _to_semver(cat_ver)
-    msg_semver = _to_semver(msg_ver)
-    if cat_semver and msg_semver:
-        if compare_semver(cat_semver, "1.0") >= 0:
-            return compare_semver(cat_semver, msg_semver) <= 0
-        return compare_semver(cat_semver, msg_semver) == 0
-    cat_str = str(cat_ver)
-    msg_str = str(msg_ver)
-    norm_cat_ver = cat_str[1:] if cat_str.startswith(("v", "V")) else cat_str
-    norm_msg_ver = msg_str[1:] if msg_str.startswith(("v", "V")) else msg_str
-    return norm_cat_ver == norm_msg_ver

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -1,0 +1,226 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Semantic Versioning 2.0.0 parsing and comparison utilities."""
+
+from dataclasses import dataclass
+import re
+from typing import Any, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class SemVer:
+    """Structured representation of a semantic version per SemVer 2.0.0.
+
+    Attributes:
+        major: Major version number indicating breaking API changes.
+        minor: Minor version number indicating backwards-compatible features.
+        patch: Patch version number indicating backwards-compatible bug fixes.
+        prerelease: Sequence of dot-separated pre-release identifiers.
+        build: Sequence of dot-separated build metadata identifiers.
+    """
+
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+    build: tuple[str, ...] = ()
+
+
+# Official SemVer 2.0.0 regular expression from https://semver.org/,
+# extended with optional leading 'v'/'V' and optional patch component for protocol compatibility.
+_SEMVER_PATTERN = re.compile(
+    r"^[vV]?(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+
+def normalize_version_string(version: Any) -> str:
+    """Normalizes a version string by stripping any leading 'v'/'V' and replacing underscores with dots in the core release segment.
+
+    Preserves pre-release ('-') and build metadata ('+') suffixes intact.
+
+    Args:
+        version: The raw version string or bytes to normalize (e.g. 'v1_0', 'v0_9_1').
+
+    Returns:
+        The normalized version string, or an empty string if version is falsy or invalid.
+
+    Examples:
+        'v1_0' -> '1.0'
+        'V1_0' -> '1.0'
+        'v0_9_1' -> '0.9.1'
+        '1_0_0-dev_release' -> '1.0.0-dev_release'
+    """
+    if isinstance(version, bytes):
+        version = version.decode("utf-8", errors="replace")
+    if not version or not isinstance(version, str):
+        return ""
+    text = version.strip()
+    if text.startswith(("v", "V")):
+        text = text[1:]
+    delims = [i for i in (text.find("-"), text.find("+")) if i != -1]
+    split_idx = min(delims) if delims else len(text)
+    core = text[:split_idx].replace("_", ".")
+    return f"{core}{text[split_idx:]}"
+
+
+def parse_semver(version_str: Any) -> Optional[SemVer]:
+    """Parses a semantic version string according to SemVer 2.0.0.
+
+    Args:
+        version_str: The version string to parse.
+
+    Returns:
+        A SemVer object if valid, or None if the string cannot be parsed.
+    """
+    if isinstance(version_str, bytes):
+        version_str = version_str.decode("utf-8", errors="replace")
+    if not version_str or not isinstance(version_str, str):
+        return None
+    text = version_str.strip()
+    match = _SEMVER_PATTERN.match(text)
+    if not match:
+        return None
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    patch = int(match.group(3)) if match.group(3) is not None else 0
+    prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+    build = tuple(match.group(5).split(".")) if match.group(5) else ()
+    return SemVer(
+        major=major,
+        minor=minor,
+        patch=patch,
+        prerelease=prerelease,
+        build=build,
+    )
+
+
+def _to_semver(v: Any) -> Optional[SemVer]:
+    """Converts a version string or SemVer instance into a SemVer object."""
+    if isinstance(v, SemVer):
+        return v
+    return parse_semver(v)
+
+
+def _compare_prerelease_id(id_a: str, id_b: str) -> int:
+    """Compares two dot-separated pre-release identifiers per SemVer 2.0.0 Rule 11.4."""
+    is_num_a = id_a.isdigit()
+    is_num_b = id_b.isdigit()
+    if is_num_a and is_num_b:
+        return int(id_a) - int(id_b)
+    if is_num_a:
+        return -1  # Numeric identifiers have lower precedence than non-numeric
+    if is_num_b:
+        return 1
+    if id_a < id_b:
+        return -1
+    if id_a > id_b:
+        return 1
+    return 0
+
+
+def _compare_prerelease_lists(pre_a: Sequence[str], pre_b: Sequence[str]) -> int:
+    """Compares pre-release identifier lists per SemVer 2.0.0 Rules 11.3 and 11.4."""
+    if not pre_a and not pre_b:
+        return 0
+    if not pre_a:
+        return 1  # Normal version has higher precedence than pre-release version
+    if not pre_b:
+        return -1
+
+    for id_a, id_b in zip(pre_a, pre_b):
+        diff = _compare_prerelease_id(id_a, id_b)
+        if diff != 0:
+            return diff
+
+    return len(pre_a) - len(pre_b)
+
+
+def compare_semver(a: Any, b: Any) -> int:
+    """Compares two semantic version strings or SemVer objects per SemVer 2.0.0 precedence (Section 11).
+
+    Args:
+        a: First version string or SemVer object.
+        b: Second version string or SemVer object.
+
+    Returns:
+        Negative integer if a < b, 0 if a == b, positive integer if a > b.
+    """
+    v_a = _to_semver(a)
+    v_b = _to_semver(b)
+    if not v_a and not v_b:
+        return 0
+    if not v_a:
+        return -1
+    if not v_b:
+        return 1
+
+    if v_a.major != v_b.major:
+        return v_a.major - v_b.major
+    if v_a.minor != v_b.minor:
+        return v_a.minor - v_b.minor
+    if v_a.patch != v_b.patch:
+        return v_a.patch - v_b.patch
+
+    return _compare_prerelease_lists(v_a.prerelease, v_b.prerelease)
+
+
+def is_at_least_version(version: Any, min_version: str) -> bool:
+    """Checks if a given version string is at least the target minimum version.
+
+    Args:
+        version: The version string to check (e.g. 'v1.0', '1.1.0').
+        min_version: The minimum version requirement (e.g. 'v1.0', '1.0.0').
+
+    Returns:
+        True if version is valid and >= min_version, False otherwise.
+    """
+    if not version:
+        return False
+    parsed = _to_semver(version)
+    min_parsed = _to_semver(min_version)
+    if not parsed or not min_parsed:
+        return False
+    return compare_semver(parsed, min_parsed) >= 0
+
+
+def is_catalog_version_compatible(cat_ver: Any, msg_ver: Any) -> bool:
+    """Evaluates whether a catalog protocol version is compatible with an incoming message version.
+
+    For protocol versions >= 1.0, forward compatibility is supported (a catalog
+    at version 1.0 can process messages at version 1.1). For pre-1.0 versions,
+    exact version matching is required.
+
+    Args:
+        cat_ver: The catalog's declared protocol version.
+        msg_ver: The incoming message's declared protocol version.
+
+    Returns:
+        True if the catalog version is compatible with the message version, False otherwise.
+    """
+    if not cat_ver or not msg_ver:
+        return False
+    cat_semver = _to_semver(cat_ver)
+    msg_semver = _to_semver(msg_ver)
+    if cat_semver and msg_semver:
+        if compare_semver(cat_semver, "1.0") >= 0:
+            return compare_semver(cat_semver, msg_semver) <= 0
+        return compare_semver(cat_semver, msg_semver) == 0
+    cat_str = str(cat_ver)
+    msg_str = str(msg_ver)
+    norm_cat_ver = cat_str[1:] if cat_str.startswith(("v", "V")) else cat_str
+    norm_msg_ver = msg_str[1:] if msg_str.startswith(("v", "V")) else msg_str
+    return norm_cat_ver == norm_msg_ver

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -112,13 +112,16 @@ def parse_semver(version: ProtocolVersion | str | None) -> Optional[SemVer]:
     )
 
 
-def _to_semver(v: ProtocolVersion | str | SemVer | None) -> Optional[SemVer]:
-    """Converts a version string or SemVer instance into a SemVer object."""
+def to_semver(v: ProtocolVersion | str | SemVer | None) -> Optional[SemVer]:
+    """Converts a version string, ProtocolVersion enum, or SemVer instance into a SemVer object."""
     if isinstance(v, SemVer):
         return v
     if v is None:
         return None
     return parse_semver(normalize_version_string(v))
+
+
+_to_semver = to_semver
 
 
 def to_canonical_version(

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -14,9 +14,14 @@
 
 """Semantic Versioning 2.0.0 parsing and comparison utilities."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 import re
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
+
+if TYPE_CHECKING:
+    from ..schema import ProtocolVersion
 
 
 @dataclass(frozen=True)
@@ -48,7 +53,7 @@ _SEMVER_PATTERN = re.compile(
 )
 
 
-def normalize_version_string(version: Any) -> str:
+def normalize_version_string(version: ProtocolVersion | str | None) -> str:
     """Normalizes a version string for semantic version processing.
 
     Strips any leading 'v'/'V' and replaces underscores with dots in the core
@@ -56,7 +61,7 @@ def normalize_version_string(version: Any) -> str:
     suffixes intact.
 
     Args:
-        version: The raw version string or bytes to normalize (e.g. 'v1_0', 'v0_9_1').
+        version: The raw version string or ProtocolVersion enum to normalize (e.g. 'v1_0', 'v0_9_1').
 
     Returns:
         The normalized version string, or an empty string if version is falsy or invalid.
@@ -67,8 +72,6 @@ def normalize_version_string(version: Any) -> str:
         'v0_9_1' -> '0.9.1'
         '1_0_0-dev_release' -> '1.0.0-dev_release'
     """
-    if isinstance(version, bytes):
-        version = version.decode("utf-8", errors="replace")
     if not version or not isinstance(version, str):
         return ""
     text = version.strip()
@@ -80,20 +83,18 @@ def normalize_version_string(version: Any) -> str:
     return f"{core}{text[split_idx:]}"
 
 
-def parse_semver(version_str: Any) -> Optional[SemVer]:
+def parse_semver(version: ProtocolVersion | str | None) -> Optional[SemVer]:
     """Parses a semantic version string according to SemVer 2.0.0.
 
     Args:
-        version_str: The version string to parse.
+        version: The version string or ProtocolVersion enum to parse.
 
     Returns:
-        A SemVer object if valid, or None if the string cannot be parsed.
+        A SemVer object if valid, or None if the version cannot be parsed.
     """
-    if isinstance(version_str, bytes):
-        version_str = version_str.decode("utf-8", errors="replace")
-    if not version_str or not isinstance(version_str, str):
+    if not version or not isinstance(version, str):
         return None
-    text = version_str.strip()
+    text = version.strip()
     match = _SEMVER_PATTERN.match(text)
     if not match:
         return None
@@ -111,7 +112,7 @@ def parse_semver(version_str: Any) -> Optional[SemVer]:
     )
 
 
-def _to_semver(v: str | bytes | SemVer | None) -> Optional[SemVer]:
+def _to_semver(v: ProtocolVersion | str | SemVer | None) -> Optional[SemVer]:
     """Converts a version string or SemVer instance into a SemVer object."""
     if isinstance(v, SemVer):
         return v
@@ -120,7 +121,9 @@ def _to_semver(v: str | bytes | SemVer | None) -> Optional[SemVer]:
     return parse_semver(normalize_version_string(v))
 
 
-def to_canonical_version(version: str | bytes | SemVer | None) -> str | None:
+def to_canonical_version(
+    version: ProtocolVersion | str | SemVer | None,
+) -> str | None:
     """Formats a semantic version into a canonical string representation.
 
     For standard versions with zero patch and no pre-release or build metadata,
@@ -129,7 +132,7 @@ def to_canonical_version(version: str | bytes | SemVer | None) -> str | None:
     returns the full SemVer string (e.g. '0.9.1', '1.0.0-beta.1').
 
     Args:
-        version: The version string, bytes, or SemVer object to canonicalize.
+        version: The version string, ProtocolVersion enum, or SemVer object to canonicalize.
 
     Returns:
         The canonical version string, or None if the input cannot be parsed.
@@ -181,17 +184,17 @@ def _compare_prerelease_lists(pre_a: Sequence[str], pre_b: Sequence[str]) -> int
 
 
 def compare_semver(
-    a: str | bytes | SemVer | None,
-    b: str | bytes | SemVer | None,
+    a: ProtocolVersion | str | SemVer | None,
+    b: ProtocolVersion | str | SemVer | None,
 ) -> int:
     """Compares two semantic versions per SemVer 2.0.0 precedence.
 
-    Evaluates precedence between version strings or SemVer objects per
+    Evaluates precedence between version strings, ProtocolVersion enums, or SemVer objects per
     SemVer 2.0.0 Section 11 rules.
 
     Args:
-        a: First version string or SemVer object.
-        b: Second version string or SemVer object.
+        a: First version string, ProtocolVersion enum, or SemVer object.
+        b: Second version string, ProtocolVersion enum, or SemVer object.
 
     Returns:
         Negative integer if a < b, 0 if a == b, positive integer if a > b.
@@ -216,14 +219,14 @@ def compare_semver(
 
 
 def is_at_least_version(
-    version: str | bytes | SemVer | None,
-    min_version: str | bytes | SemVer,
+    version: ProtocolVersion | str | SemVer | None,
+    min_version: ProtocolVersion | str | SemVer,
 ) -> bool:
     """Determines whether a version string meets a minimum version requirement.
 
     Args:
-        version: The version string to check (e.g. 'v1.0', '1.1.0').
-        min_version: The minimum version requirement (e.g. 'v1.0', '1.0.0').
+        version: The version to check (e.g. 'v1.0', ProtocolVersion.V1_0, '1.1.0').
+        min_version: The minimum version requirement (e.g. 'v1.0', ProtocolVersion.V1_0, '1.0.0').
 
     Returns:
         Whether version is valid and at least min_version.

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -190,23 +190,23 @@ def compare_semver(
     Returns:
         Negative integer if a < b, 0 if a == b, positive integer if a > b.
     """
-    v_a = _to_semver(a)
-    v_b = _to_semver(b)
-    if not v_a and not v_b:
+    version_a = _to_semver(a)
+    version_b = _to_semver(b)
+    if not version_a and not version_b:
         return 0
-    if not v_a:
+    if not version_a:
         return -1
-    if not v_b:
+    if not version_b:
         return 1
 
-    if v_a.major != v_b.major:
-        return v_a.major - v_b.major
-    if v_a.minor != v_b.minor:
-        return v_a.minor - v_b.minor
-    if v_a.patch != v_b.patch:
-        return v_a.patch - v_b.patch
+    if version_a.major != version_b.major:
+        return version_a.major - version_b.major
+    if version_a.minor != version_b.minor:
+        return version_a.minor - version_b.minor
+    if version_a.patch != version_b.patch:
+        return version_a.patch - version_b.patch
 
-    return _compare_prerelease_lists(v_a.prerelease, v_b.prerelease)
+    return _compare_prerelease_lists(version_a.prerelease, version_b.prerelease)
 
 
 def is_at_least_version(

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -49,9 +49,11 @@ _SEMVER_PATTERN = re.compile(
 
 
 def normalize_version_string(version: Any) -> str:
-    """Normalizes a version string by stripping any leading 'v'/'V' and replacing underscores with dots in the core release segment.
+    """Normalizes a version string for semantic version processing.
 
-    Preserves pre-release ('-') and build metadata ('+') suffixes intact.
+    Strips any leading 'v'/'V' and replaces underscores with dots in the core
+    release segment, while preserving pre-release ('-') and build metadata ('+')
+    suffixes intact.
 
     Args:
         version: The raw version string or bytes to normalize (e.g. 'v1_0', 'v0_9_1').
@@ -182,7 +184,10 @@ def compare_semver(
     a: str | bytes | SemVer | None,
     b: str | bytes | SemVer | None,
 ) -> int:
-    """Compares two semantic version strings or SemVer objects per SemVer 2.0.0 precedence (Section 11).
+    """Compares two semantic versions per SemVer 2.0.0 precedence.
+
+    Evaluates precedence between version strings or SemVer objects per
+    SemVer 2.0.0 Section 11 rules.
 
     Args:
         a: First version string or SemVer object.
@@ -214,14 +219,14 @@ def is_at_least_version(
     version: str | bytes | SemVer | None,
     min_version: str | bytes | SemVer,
 ) -> bool:
-    """Checks if a given version string is at least the target minimum version.
+    """Determines whether a version string meets a minimum version requirement.
 
     Args:
         version: The version string to check (e.g. 'v1.0', '1.1.0').
         min_version: The minimum version requirement (e.g. 'v1.0', '1.0.0').
 
     Returns:
-        True if version is valid and >= min_version, False otherwise.
+        Whether version is valid and at least min_version.
     """
     if not version:
         return False

--- a/python/a2ui_core/src/a2ui/core/common/semver.py
+++ b/python/a2ui_core/src/a2ui/core/common/semver.py
@@ -43,7 +43,8 @@ class SemVer:
 _SEMVER_PATTERN = re.compile(
     r"^[vV]?(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?"
     r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+    re.ASCII,
 )
 
 
@@ -145,8 +146,8 @@ def to_canonical_version(version: str | bytes | SemVer | None) -> str | None:
 
 def _compare_prerelease_id(id_a: str, id_b: str) -> int:
     """Compares two dot-separated pre-release identifiers per SemVer 2.0.0 Rule 11.4."""
-    is_num_a = id_a.isdigit()
-    is_num_b = id_b.isdigit()
+    is_num_a = id_a.isascii() and id_a.isdigit()
+    is_num_b = id_b.isascii() and id_b.isdigit()
     if is_num_a and is_num_b:
         return int(id_a) - int(id_b)
     if is_num_a:

--- a/python/a2ui_core/src/a2ui/core/processing/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/processing/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .execution_context import ExecutionContext
-from .message_processor import MessageProcessor
+from .message_processor import MessageProcessor, MessageProcessorOptions
 from .operations import (
     InternalCreateSurfaceOp,
     InternalDeleteSurfaceOp,
@@ -26,6 +26,7 @@ from .adapters import VersionAdapter, VersionAdapterFactory
 __all__ = [
     "ExecutionContext",
     "MessageProcessor",
+    "MessageProcessorOptions",
     "InternalOperation",
     "InternalCreateSurfaceOp",
     "InternalUpdateComponentsOp",

--- a/python/a2ui_core/src/a2ui/core/processing/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/processing/__init__.py
@@ -24,6 +24,11 @@ from .operations import (
     InternalUpdateDataModelOp,
 )
 from .adapters import VersionAdapter, VersionAdapterFactory
+from .format_pydantic_error import (
+    format_pydantic_issue,
+    format_validation_error,
+    format_validation_error_summary,
+)
 
 __all__ = [
     "ExecutionContext",
@@ -36,4 +41,7 @@ __all__ = [
     "InternalDeleteSurfaceOp",
     "VersionAdapter",
     "VersionAdapterFactory",
+    "format_pydantic_issue",
+    "format_validation_error",
+    "format_validation_error_summary",
 ]

--- a/python/a2ui_core/src/a2ui/core/processing/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/processing/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Message processing engine, execution contexts, and internal operation definitions."""
+
 from .execution_context import ExecutionContext
 from .message_processor import MessageProcessor, MessageProcessorOptions
 from .operations import (

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Version adapters and compatibility helpers for A2UI protocol processing."""
+
 from .base import (
     DEFAULT_CATALOG_COMPATIBILITY,
     SUPPORTED_PROTOCOL_VERSIONS,

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/__init__.py
@@ -12,17 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import VersionAdapter
+from .base import (
+    DEFAULT_CATALOG_COMPATIBILITY,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    VersionAdapter,
+    is_catalog_version_compatible,
+)
 from .v0_8 import V0Point8Adapter
 from .v0_9 import V0Point9Adapter
 from .v1_0 import V1Point0Adapter
 from .factory import DEFAULT_PROTOCOL_VERSION, VersionAdapterFactory
 
 __all__ = [
+    "DEFAULT_CATALOG_COMPATIBILITY",
     "DEFAULT_PROTOCOL_VERSION",
+    "SUPPORTED_PROTOCOL_VERSIONS",
     "VersionAdapter",
     "V0Point8Adapter",
     "V0Point9Adapter",
     "V1Point0Adapter",
     "VersionAdapterFactory",
+    "is_catalog_version_compatible",
 ]

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -27,6 +27,7 @@ from ...schema import AgentToRendererMessage, ProtocolVersion
 from ...common.semver import (
     SemVer,
     normalize_version_string,
+    parse_semver,
     to_canonical_version,
 )
 
@@ -79,9 +80,27 @@ def is_catalog_version_compatible(
             else DEFAULT_CATALOG_COMPATIBILITY
         )
         compatible = mapping.get(msg_canonical)
-        return bool(compatible and cat_canonical in compatible)
+        if compatible and cat_canonical in compatible:
+            return True
+
+        # For SemVer >= 1.0.0, patch releases within the same major.minor are compatible
+        cat_sv = parse_semver(catalog_version)
+        msg_sv = parse_semver(message_version)
+        if (
+            cat_sv
+            and msg_sv
+            and cat_sv.major >= 1
+            and cat_sv.major == msg_sv.major
+            and cat_sv.minor == msg_sv.minor
+            and not cat_sv.prerelease
+            and not msg_sv.prerelease
+        ):
+            return True
+        return False
 
     # Fallback for non-semver custom identifiers (e.g. 'custom' vs 'Vcustom')
+    if not isinstance(catalog_version, str) or not isinstance(message_version, str):
+        return False
     norm_cat = normalize_version_string(catalog_version)
     norm_msg = normalize_version_string(message_version)
     return bool(norm_cat and norm_cat == norm_msg)
@@ -221,10 +240,11 @@ class BaseVersionAdapter(VersionAdapter, ABC):
 
     def _extract_single_action(self, message: dict[str, Any]) -> str:
         """Validates presence of exactly one action key from valid_actions."""
-        update_types = [k for k in self.valid_actions if k in message]
+        update_types = sorted([k for k in self.valid_actions if k in message])
         if len(update_types) > 1:
             raise A2uiValidationError(
-                f"Message contains multiple conflicting update actions: {update_types}"
+                "Message contains multiple conflicting update actions:"
+                f" {', '.join(update_types)}."
             )
         if not update_types:
             ver_str = (

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -96,6 +96,19 @@ def _clean_loc_part(x: str) -> str:
     return x
 
 
+ALL_KNOWN_ACTION_KEYS: frozenset[str] = frozenset({
+    "beginRendering",
+    "surfaceUpdate",
+    "dataModelUpdate",
+    "createSurface",
+    "updateComponents",
+    "updateDataModel",
+    "deleteSurface",
+    "callRendererFunction",
+    "agentFunctionResponse",
+})
+
+
 class VersionAdapter(ABC):
     """Abstract base class for protocol version adapters."""
 
@@ -161,11 +174,6 @@ class BaseVersionAdapter(VersionAdapter, ABC):
     def valid_actions(self) -> set[str]:
         """The set of valid message action keys supported by this protocol version."""
         pass
-
-    @property
-    def raise_on_empty_actions(self) -> bool:
-        """Whether to raise an error if no valid action keys are found."""
-        return False
 
     @property
     @abstractmethod
@@ -235,12 +243,21 @@ class BaseVersionAdapter(VersionAdapter, ABC):
                 f"Message contains multiple conflicting update actions: {update_types}"
             )
         if not update_types:
-            if self.raise_on_empty_actions:
-                raise A2uiValidationError(
-                    "A2UI Protocol message must contain exactly one update action: "
-                    f"{', '.join(sorted(self.valid_actions))}."
-                )
-            return None
+            if any(
+                k in message
+                for k in ALL_KNOWN_ACTION_KEYS
+                if k not in self.valid_actions
+            ):
+                return None
+            ver_str = (
+                self.version.value
+                if hasattr(self.version, "value")
+                else str(self.version)
+            )
+            raise A2uiValidationError(
+                f"Invalid {ver_str} message: message must contain exactly one update"
+                f" action: {', '.join(sorted(self.valid_actions))}."
+            )
         action = update_types[0]
         if isinstance(message.get(action), dict):
             self._get_surface_id(message[action])
@@ -266,7 +283,9 @@ class BaseVersionAdapter(VersionAdapter, ABC):
         context: ExecutionContext | None = None,
     ) -> list[InternalOperation]:
         """Unwraps payloads and delegates validated action messages to action handlers."""
-        if not payload:
+        if payload is None:
+            return []
+        if isinstance(payload, list) and not payload:
             return []
 
         raw_payload: Any = payload

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -96,19 +96,6 @@ def _clean_loc_part(x: str) -> str:
     return x
 
 
-ALL_KNOWN_ACTION_KEYS: frozenset[str] = frozenset({
-    "beginRendering",
-    "surfaceUpdate",
-    "dataModelUpdate",
-    "createSurface",
-    "updateComponents",
-    "updateDataModel",
-    "deleteSurface",
-    "callRendererFunction",
-    "agentFunctionResponse",
-})
-
-
 class VersionAdapter(ABC):
     """Abstract base class for protocol version adapters."""
 
@@ -117,6 +104,11 @@ class VersionAdapter(ABC):
     def version(self) -> ProtocolVersion:
         """The protocol version handled by this adapter (e.g. ProtocolVersion.V1_0)."""
         pass
+
+    @property
+    def valid_actions(self) -> set[str]:
+        """Set of action keys supported by this version adapter."""
+        return set()
 
     @property
     def compatible_catalog_versions(self) -> frozenset[str]:
@@ -227,7 +219,7 @@ class BaseVersionAdapter(VersionAdapter, ABC):
             details.append(A2uiErrorDetail(path_str, code, msg))
         return details
 
-    def _extract_single_action(self, message: dict[str, Any]) -> str | None:
+    def _extract_single_action(self, message: dict[str, Any]) -> str:
         """Validates presence of exactly one action key from valid_actions."""
         update_types = [k for k in self.valid_actions if k in message]
         if len(update_types) > 1:
@@ -235,17 +227,21 @@ class BaseVersionAdapter(VersionAdapter, ABC):
                 f"Message contains multiple conflicting update actions: {update_types}"
             )
         if not update_types:
-            if any(
-                k in message
-                for k in ALL_KNOWN_ACTION_KEYS
-                if k not in self.valid_actions
-            ):
-                return None
             ver_str = (
                 self.version.value
                 if hasattr(self.version, "value")
                 else str(self.version)
             )
+            from .factory import VersionAdapterFactory
+
+            all_known = VersionAdapterFactory.all_known_actions()
+            other_actions = [k for k in message if k in all_known]
+            if other_actions:
+                raise A2uiValidationError(
+                    f"Invalid {ver_str} message: action '{other_actions[0]}' is not"
+                    f" supported in protocol version {ver_str}. Allowed actions:"
+                    f" {', '.join(sorted(self.valid_actions))}."
+                )
             raise A2uiValidationError(
                 f"Invalid {ver_str} message: message must contain exactly one update"
                 f" action: {', '.join(sorted(self.valid_actions))}."
@@ -303,8 +299,6 @@ class BaseVersionAdapter(VersionAdapter, ABC):
                 )
 
             action = self._extract_single_action(raw_payload)
-            if not action:
-                return []
 
             if not isinstance(raw_payload[action], dict):
                 raise A2uiValidationError(

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -15,15 +15,12 @@
 """Base classes, interfaces, and protocol compatibility helpers for version adapters."""
 
 from collections.abc import Mapping, Sequence
-import re
 from abc import ABC, abstractmethod
 from typing import Any
 from pydantic import ValidationError
 from ..operations import InternalOperation
-from ...exceptions import (
-    A2uiErrorDetail,
-    A2uiValidationError,
-)
+from ..format_pydantic_error import format_validation_error_summary
+from ...exceptions import A2uiValidationError
 from ...state.validation_helpers import validate_recursion_and_paths
 from ...schema import AgentToRendererMessage, ProtocolVersion
 from ...common.semver import (
@@ -112,15 +109,6 @@ def is_catalog_version_compatible(
     return bool(normalized_catalog and normalized_catalog == normalized_message)
 
 
-def _clean_loc_part(x: str) -> str:
-    """Extracts base message class names from Pydantic validator wrapper strings."""
-    if x.startswith("function-after[") or x.startswith("function-before["):
-        match = re.search(r"([A-Za-z0-9_]+Message)\]", x)
-        if match:
-            return match.group(1)
-    return x
-
-
 class VersionAdapter(ABC):
     """Abstract base class for protocol version adapters."""
 
@@ -192,56 +180,6 @@ class BaseVersionAdapter(VersionAdapter, ABC):
     def prepare_payload_for_validation(self, msg_obj: dict[str, Any]) -> dict[str, Any]:
         """Normalizes the message object before running schema validation."""
         return msg_obj
-
-    def _format_validation_errors(
-        self, error: ValidationError, messages: list[dict[str, Any]]
-    ) -> list[A2uiErrorDetail]:
-        """Formats Pydantic validation errors while filtering out irrelevant union branches."""
-        details = []
-        branch_to_action = {}
-        action_to_branch = {}
-        for action in self.valid_actions:
-            branch = action[0].upper() + action[1:] + "Message"
-            branch_to_action[branch] = action
-            action_to_branch[action] = branch
-
-        all_branch_names = set(branch_to_action.keys())
-
-        for err in error.errors():
-            loc = err.get("loc", [])
-            loc_parts = [_clean_loc_part(str(x)) for x in loc]
-            if len(loc) >= 3 and loc[0] == "messages" and isinstance(loc[1], int):
-                msg_idx = loc[1]
-                if msg_idx < len(messages) and isinstance(messages[msg_idx], dict):
-                    m = messages[msg_idx]
-                    present_actions = [k for k in self.valid_actions if k in m]
-                    if present_actions:
-                        branch = loc_parts[2]
-                        if branch in all_branch_names:
-                            expected_branches = {
-                                action_to_branch[act] for act in present_actions
-                            }
-                            if branch not in expected_branches:
-                                continue
-
-            clean_loc_parts = [x for x in loc_parts if x not in all_branch_names]
-            path_str = ".".join(clean_loc_parts)
-            msg = err.get("msg", "Validation failed")
-            err_type = err.get("type", "")
-            if err_type == "missing":
-                code = "missing_field"
-            elif err_type == "extra_forbidden":
-                code = "extra_field"
-            elif (
-                err_type.endswith("_type")
-                or err_type.endswith("_parsing")
-                or "type" in err_type
-            ):
-                code = "type_mismatch"
-            else:
-                code = "invalid_value"
-            details.append(A2uiErrorDetail(path_str, code, msg))
-        return details
 
     def _extract_single_action(self, message: dict[str, Any]) -> str:
         """Validates presence of exactly one action key from valid_actions."""
@@ -338,7 +276,7 @@ class BaseVersionAdapter(VersionAdapter, ABC):
             if ver_str != "v0.8":
                 if "version" not in raw_payload:
                     raise A2uiValidationError(
-                        f"Invalid {self.version} message: messages.0.version: 'version'"
+                        f"Invalid {self.version} message: version: 'version'"
                         " is a required property"
                     )
                 raw_ver = raw_payload["version"]
@@ -360,7 +298,7 @@ class BaseVersionAdapter(VersionAdapter, ABC):
                         )
                     )
                     raise A2uiValidationError(
-                        f"Invalid {self.version} message: messages.0.version: Input"
+                        f"Invalid {self.version} message: version: Input"
                         f" should be {expected}"
                     )
 
@@ -368,8 +306,12 @@ class BaseVersionAdapter(VersionAdapter, ABC):
             try:
                 self.schema.model_validate({"messages": [prepared_msg]})
             except ValidationError as e:
-                details = self._format_validation_errors(e, [raw_payload])
-                summary = "; ".join(f"{d.path}: {d.message}" for d in details)
+                summary = format_validation_error_summary(
+                    e,
+                    messages=[raw_payload],
+                    valid_actions=self.valid_actions,
+                    strip_messages_prefix=True,
+                )
                 raise A2uiValidationError(f"Invalid {self.version} message: {summary}")
 
             return self._extract_operations_for_action(

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -34,14 +34,12 @@ from ...common.semver import (
 from ..execution_context import ExecutionContext
 
 # Canonical protocol versions supported by the A2UI runtime.
-SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset(
-    {
-        "0.8",
-        "0.9",
-        "0.9.1",
-        "1.0",
-    }
-)
+SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset({
+    "0.8",
+    "0.9",
+    "0.9.1",
+    "1.0",
+})
 
 # Maps an incoming message or surface protocol version to the set of catalog
 # protocol specification versions that it can accommodate.

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -119,14 +119,6 @@ class VersionAdapter(ABC):
         pass
 
     @property
-    def supported_versions(self) -> set[str]:
-        """Set of version string literals accepted by this adapter."""
-        ver_str = (
-            self.version.value if hasattr(self.version, "value") else str(self.version)
-        )
-        return {ver_str}
-
-    @property
     def compatible_catalog_versions(self) -> frozenset[str]:
         """Set of canonical catalog protocol versions compatible with this adapter."""
         ver_str = (
@@ -330,11 +322,23 @@ class BaseVersionAdapter(VersionAdapter, ABC):
                         f"Invalid {self.version} message: messages.0.version: 'version'"
                         " is a required property"
                     )
-                if raw_payload["version"] not in self.supported_versions:
+                raw_ver = raw_payload["version"]
+                canonical_ver = (
+                    to_canonical_version(raw_ver)
+                    if isinstance(raw_ver, (str, bytes, SemVer))
+                    else None
+                )
+                if (
+                    not canonical_ver
+                    or canonical_ver not in self.compatible_catalog_versions
+                ):
                     expected = (
                         f"'{ver_str}'"
-                        if len(self.supported_versions) == 1
-                        else f"one of {sorted(self.supported_versions)}"
+                        if len(self.compatible_catalog_versions) == 1
+                        else (
+                            "one of"
+                            f" {sorted(f'v{v}' for v in self.compatible_catalog_versions)}"
+                        )
                     )
                     raise A2uiValidationError(
                         f"Invalid {self.version} message: messages.0.version: Input"

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -55,8 +55,8 @@ DEFAULT_CATALOG_COMPATIBILITY: dict[str, frozenset[str]] = {
 
 
 def is_catalog_version_compatible(
-    catalog_version: str | bytes | SemVer | None,
-    message_version: str | bytes | SemVer | None,
+    catalog_version: ProtocolVersion | str | SemVer | None,
+    message_version: ProtocolVersion | str | SemVer | None,
     compatibility_map: dict[str, frozenset[str]] | None = None,
 ) -> bool:
     """Evaluates catalog protocol compatibility against a message version.
@@ -90,8 +90,16 @@ def is_catalog_version_compatible(
             return True
 
         # For SemVer >= 1.0.0, releases within the same major version are compatible
-        cat_sv = parse_semver(catalog_version)
-        msg_sv = parse_semver(message_version)
+        cat_sv = (
+            catalog_version
+            if isinstance(catalog_version, SemVer)
+            else parse_semver(catalog_version)
+        )
+        msg_sv = (
+            message_version
+            if isinstance(message_version, SemVer)
+            else parse_semver(message_version)
+        )
         if (
             cat_sv
             and msg_sv
@@ -144,7 +152,7 @@ class VersionAdapter(ABC):
         return frozenset({canonical}) if canonical else frozenset()
 
     def is_catalog_compatible(
-        self, catalog_version: str | bytes | SemVer | None
+        self, catalog_version: ProtocolVersion | str | SemVer | None
     ) -> bool:
         """Checks if a catalog protocol version is compatible with this adapter.
 
@@ -343,7 +351,7 @@ class BaseVersionAdapter(VersionAdapter, ABC):
                 raw_ver = raw_payload["version"]
                 canonical_ver = (
                     to_canonical_version(raw_ver)
-                    if isinstance(raw_ver, (str, bytes, SemVer))
+                    if isinstance(raw_ver, (str, ProtocolVersion, SemVer))
                     else None
                 )
                 if (

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -29,20 +29,22 @@ from ...schema import AgentToRendererMessage, ProtocolVersion
 from ...common.semver import (
     SemVer,
     normalize_version_string,
-    parse_semver,
     to_canonical_version,
+    to_semver,
 )
 
 
 from ..execution_context import ExecutionContext
 
 # Canonical protocol versions supported by the A2UI runtime.
-SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset({
-    "0.8",
-    "0.9",
-    "0.9.1",
-    "1.0",
-})
+SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset(
+    {
+        "0.8",
+        "0.9",
+        "0.9.1",
+        "1.0",
+    }
+)
 
 # Maps an incoming message or surface protocol version to the set of catalog
 # protocol specification versions that it can accommodate.
@@ -75,38 +77,29 @@ def is_catalog_version_compatible(
     """
     if not catalog_version or not message_version:
         return False
-    cat_canonical = to_canonical_version(catalog_version)
-    msg_canonical = to_canonical_version(message_version)
-    if cat_canonical and msg_canonical:
-        if cat_canonical == msg_canonical:
+    catalog_canonical = to_canonical_version(catalog_version)
+    message_canonical = to_canonical_version(message_version)
+    if catalog_canonical and message_canonical:
+        if catalog_canonical == message_canonical:
             return True
         mapping = (
             compatibility_map
             if compatibility_map is not None
             else DEFAULT_CATALOG_COMPATIBILITY
         )
-        compatible = mapping.get(msg_canonical)
-        if compatible and cat_canonical in compatible:
+        compatible = mapping.get(message_canonical)
+        if compatible and catalog_canonical in compatible:
             return True
 
-        # For SemVer >= 1.0.0, releases within the same major version are compatible
-        cat_sv = (
-            catalog_version
-            if isinstance(catalog_version, SemVer)
-            else parse_semver(catalog_version)
-        )
-        msg_sv = (
-            message_version
-            if isinstance(message_version, SemVer)
-            else parse_semver(message_version)
-        )
+        # For SemVer >= 1.0.0, releases within the same major version are compatible,
+        # ignoring pre-release identifiers.
+        catalog_semver = to_semver(catalog_version)
+        message_semver = to_semver(message_version)
         if (
-            cat_sv
-            and msg_sv
-            and cat_sv.major >= 1
-            and cat_sv.major == msg_sv.major
-            and not cat_sv.prerelease
-            and not msg_sv.prerelease
+            catalog_semver
+            and message_semver
+            and catalog_semver.major >= 1
+            and catalog_semver.major == message_semver.major
         ):
             return True
         return False
@@ -114,9 +107,9 @@ def is_catalog_version_compatible(
     # Fallback for non-semver custom identifiers (e.g. 'custom' vs 'Vcustom')
     if not isinstance(catalog_version, str) or not isinstance(message_version, str):
         return False
-    norm_cat = normalize_version_string(catalog_version)
-    norm_msg = normalize_version_string(message_version)
-    return bool(norm_cat and norm_cat == norm_msg)
+    normalized_catalog = normalize_version_string(catalog_version)
+    normalized_message = normalize_version_string(message_version)
+    return bool(normalized_catalog and normalized_catalog == normalized_message)
 
 
 def _clean_loc_part(x: str) -> str:

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Base classes, interfaces, and protocol compatibility helpers for version adapters."""
+
 from collections.abc import Mapping, Sequence
 import re
 from abc import ABC, abstractmethod
@@ -34,6 +36,7 @@ from ...common.semver import (
 
 from ..execution_context import ExecutionContext
 
+# Canonical protocol versions supported by the A2UI runtime.
 SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset({
     "0.8",
     "0.9",
@@ -41,6 +44,8 @@ SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset({
     "1.0",
 })
 
+# Maps an incoming message or surface protocol version to the set of catalog
+# protocol specification versions that it can accommodate.
 DEFAULT_CATALOG_COMPATIBILITY: dict[str, frozenset[str]] = {
     "0.8": frozenset({"0.8"}),
     "0.9": frozenset({"0.9", "0.9.1"}),
@@ -54,10 +59,11 @@ def is_catalog_version_compatible(
     message_version: str | bytes | SemVer | None,
     compatibility_map: dict[str, frozenset[str]] | None = None,
 ) -> bool:
-    """Evaluates whether a catalog protocol version is compatible with an incoming message or surface version.
+    """Evaluates catalog protocol compatibility against a message version.
 
     Compatibility is verified against explicit supported version sets.
-    Minor formatting differences ('v1.0', '1.0', '1.0.0', 'v1_0') normalize to the same canonical version.
+    Minor formatting differences ('v1.0', '1.0', '1.0.0', 'v1_0') normalize
+    to the same canonical version.
 
     Args:
         catalog_version: The catalog's declared protocol version.
@@ -65,7 +71,7 @@ def is_catalog_version_compatible(
         compatibility_map: Optional explicit compatibility mapping. Defaults to DEFAULT_CATALOG_COMPATIBILITY.
 
     Returns:
-        True if the catalog version is compatible with the message version, False otherwise.
+        Whether the catalog version is compatible with the message version.
     """
     if not catalog_version or not message_version:
         return False
@@ -140,7 +146,14 @@ class VersionAdapter(ABC):
     def is_catalog_compatible(
         self, catalog_version: str | bytes | SemVer | None
     ) -> bool:
-        """Checks if a catalog protocol version is compatible with this adapter."""
+        """Checks if a catalog protocol version is compatible with this adapter.
+
+        Args:
+            catalog_version: The catalog's declared protocol version.
+
+        Returns:
+            Whether the catalog version is compatible with this adapter.
+        """
         if not catalog_version:
             return False
         return is_catalog_version_compatible(catalog_version, self.version)

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -19,16 +19,72 @@ from typing import Any
 from pydantic import ValidationError
 from ..operations import InternalOperation
 from ...exceptions import (
-    A2uiCatalogError,
     A2uiErrorDetail,
-    A2uiIntegrityError,
     A2uiValidationError,
 )
 from ...state.validation_helpers import validate_recursion_and_paths
 from ...schema import AgentToRendererMessage, ProtocolVersion
+from ...common.semver import (
+    SemVer,
+    normalize_version_string,
+    to_canonical_version,
+)
 
 
 from ..execution_context import ExecutionContext
+
+SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset({
+    "0.8",
+    "0.9",
+    "0.9.1",
+    "1.0",
+})
+
+DEFAULT_CATALOG_COMPATIBILITY: dict[str, frozenset[str]] = {
+    "0.8": frozenset({"0.8"}),
+    "0.9": frozenset({"0.9", "0.9.1"}),
+    "0.9.1": frozenset({"0.9.1", "0.9"}),
+    "1.0": frozenset({"1.0"}),
+}
+
+
+def is_catalog_version_compatible(
+    catalog_version: str | bytes | SemVer | None,
+    message_version: str | bytes | SemVer | None,
+    compatibility_map: dict[str, frozenset[str]] | None = None,
+) -> bool:
+    """Evaluates whether a catalog protocol version is compatible with an incoming message or surface version.
+
+    Compatibility is verified against explicit supported version sets.
+    Minor formatting differences ('v1.0', '1.0', '1.0.0', 'v1_0') normalize to the same canonical version.
+
+    Args:
+        catalog_version: The catalog's declared protocol version.
+        message_version: The incoming message or surface declared protocol version.
+        compatibility_map: Optional explicit compatibility mapping. Defaults to DEFAULT_CATALOG_COMPATIBILITY.
+
+    Returns:
+        True if the catalog version is compatible with the message version, False otherwise.
+    """
+    if not catalog_version or not message_version:
+        return False
+    cat_canonical = to_canonical_version(catalog_version)
+    msg_canonical = to_canonical_version(message_version)
+    if cat_canonical and msg_canonical:
+        if cat_canonical == msg_canonical:
+            return True
+        mapping = (
+            compatibility_map
+            if compatibility_map is not None
+            else DEFAULT_CATALOG_COMPATIBILITY
+        )
+        compatible = mapping.get(msg_canonical)
+        return bool(compatible and cat_canonical in compatible)
+
+    # Fallback for non-semver custom identifiers (e.g. 'custom' vs 'Vcustom')
+    norm_cat = normalize_version_string(catalog_version)
+    norm_msg = normalize_version_string(message_version)
+    return bool(norm_cat and norm_cat == norm_msg)
 
 
 def _clean_loc_part(x: str) -> str:
@@ -56,6 +112,31 @@ class VersionAdapter(ABC):
             self.version.value if hasattr(self.version, "value") else str(self.version)
         )
         return {ver_str}
+
+    @property
+    def compatible_catalog_versions(self) -> frozenset[str]:
+        """Set of canonical catalog protocol versions compatible with this adapter."""
+        ver_str = (
+            self.version.value if hasattr(self.version, "value") else str(self.version)
+        )
+        canonical = to_canonical_version(ver_str)
+        return frozenset({canonical}) if canonical else frozenset()
+
+    def is_catalog_compatible(
+        self, catalog_version: str | bytes | SemVer | None
+    ) -> bool:
+        """Checks if a catalog protocol version is compatible with this adapter."""
+        if not catalog_version:
+            return False
+        cat_canonical = to_canonical_version(catalog_version)
+        if cat_canonical:
+            return cat_canonical in self.compatible_catalog_versions
+        norm_cat = normalize_version_string(catalog_version)
+        ver_str = (
+            self.version.value if hasattr(self.version, "value") else str(self.version)
+        )
+        norm_self = normalize_version_string(ver_str)
+        return bool(norm_cat and norm_cat == norm_self)
 
     @abstractmethod
     def extract_operations(

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/base.py
@@ -83,7 +83,7 @@ def is_catalog_version_compatible(
         if compatible and cat_canonical in compatible:
             return True
 
-        # For SemVer >= 1.0.0, patch releases within the same major.minor are compatible
+        # For SemVer >= 1.0.0, releases within the same major version are compatible
         cat_sv = parse_semver(catalog_version)
         msg_sv = parse_semver(message_version)
         if (
@@ -91,7 +91,6 @@ def is_catalog_version_compatible(
             and msg_sv
             and cat_sv.major >= 1
             and cat_sv.major == msg_sv.major
-            and cat_sv.minor == msg_sv.minor
             and not cat_sv.prerelease
             and not msg_sv.prerelease
         ):
@@ -144,15 +143,7 @@ class VersionAdapter(ABC):
         """Checks if a catalog protocol version is compatible with this adapter."""
         if not catalog_version:
             return False
-        cat_canonical = to_canonical_version(catalog_version)
-        if cat_canonical:
-            return cat_canonical in self.compatible_catalog_versions
-        norm_cat = normalize_version_string(catalog_version)
-        ver_str = (
-            self.version.value if hasattr(self.version, "value") else str(self.version)
-        )
-        norm_self = normalize_version_string(ver_str)
-        return bool(norm_cat and norm_cat == norm_self)
+        return is_catalog_version_compatible(catalog_version, self.version)
 
     @abstractmethod
     def extract_operations(

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -140,10 +140,33 @@ class VersionAdapterFactory:
 
     @classmethod
     def _parse_version(cls, version_str: str) -> ProtocolVersion | None:
-        """Parses a version string into an ProtocolVersion enum."""
-        if not version_str.startswith("v"):
-            version_str = f"v{version_str}"
+        """Parses a version string into a ProtocolVersion enum.
+
+        Args:
+            version_str: The version string to parse.
+
+        Returns:
+            The matched ProtocolVersion enum member, or None if unrecognized.
+        """
+        from ...common.semver import parse_semver
+
+        clean = (
+            f"v{version_str[1:]}"
+            if version_str.startswith(("v", "V"))
+            else f"v{version_str}"
+        )
         try:
-            return ProtocolVersion(version_str)
+            return ProtocolVersion(clean)
         except ValueError:
-            return None
+            pass
+
+        parsed = parse_semver(version_str)
+        if parsed:
+            if parsed.major == 0 and parsed.minor == 9 and parsed.patch == 1:
+                return ProtocolVersion.V0_9_1
+            canonical = f"v{parsed.major}.{parsed.minor}"
+            try:
+                return ProtocolVersion(canonical)
+            except ValueError:
+                return None
+        return None

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -37,7 +37,22 @@ class VersionAdapterFactory:
     @classmethod
     def register_adapter(cls, adapter: VersionAdapter) -> None:
         """Dynamically registers a version adapter."""
+        from ...common.semver import normalize_version_string, to_canonical_version
+
         cls._adapters[adapter.version] = adapter
+        ver_str = (
+            adapter.version.value
+            if hasattr(adapter.version, "value")
+            else str(adapter.version)
+        )
+        canonical = to_canonical_version(ver_str)
+        if canonical:
+            cls._adapters[canonical] = adapter
+            cls._adapters[f"v{canonical}"] = adapter
+        normalized = normalize_version_string(ver_str)
+        if normalized:
+            cls._adapters[normalized] = adapter
+            cls._adapters[f"v{normalized}"] = adapter
 
     @classmethod
     def all_known_actions(cls) -> frozenset[str]:
@@ -51,20 +66,48 @@ class VersionAdapterFactory:
     @classmethod
     def get_adapter(cls, version: ProtocolVersion | str) -> VersionAdapter:
         """Resolves the version adapter for the specified protocol version enum or string."""
-        adapter = None
-        if isinstance(version, str):
-            parsed_ver = cls._parse_version(version)
-            if parsed_ver:
-                adapter = cls._adapters.get(parsed_ver)
-            if not adapter:
-                adapter = cls._adapters.get(version)
-        elif isinstance(version, ProtocolVersion):
-            adapter = cls._adapters.get(version)
+        from ...common.semver import normalize_version_string, to_canonical_version
+
+        adapter = cls._adapters.get(version)
+        if not adapter:
+            if isinstance(version, str):
+                parsed_ver = cls._parse_version(version)
+                if parsed_ver:
+                    adapter = cls._adapters.get(parsed_ver)
+                if not adapter:
+                    canonical = to_canonical_version(version)
+                    if canonical:
+                        adapter = cls._adapters.get(canonical) or cls._adapters.get(
+                            f"v{canonical}"
+                        )
+                    if not adapter:
+                        norm = normalize_version_string(version)
+                        if norm:
+                            adapter = cls._adapters.get(norm) or cls._adapters.get(
+                                f"v{norm}"
+                            )
+            elif isinstance(version, ProtocolVersion):
+                canonical = to_canonical_version(version.value)
+                if canonical:
+                    adapter = cls._adapters.get(canonical) or cls._adapters.get(
+                        f"v{canonical}"
+                    )
 
         if not adapter:
-            supported = ", ".join(
-                v.value for v in cls._adapters.keys() if hasattr(v, "value")
-            )
+            seen: set[str] = set()
+            supported_list: list[str] = []
+            for k in cls._adapters.keys():
+                val = k.value if hasattr(k, "value") else str(k)
+                canon = to_canonical_version(val)
+                v_str = (
+                    f"v{canon}"
+                    if canon
+                    else (val if val.startswith("v") else f"v{val}")
+                )
+                if v_str not in seen:
+                    seen.add(v_str)
+                    supported_list.append(v_str)
+            supported = ", ".join(sorted(supported_list))
             raise A2uiValidationError(
                 f"[VersionAdapterFactory] Unsupported protocol version '{version}'."
                 f" Supported versions: {supported}."

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -27,7 +27,7 @@ DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion.V0_9
 class VersionAdapterFactory:
     """Resolves version adapters for protocol specification versions."""
 
-    _adapters: dict[ProtocolVersion, VersionAdapter] = {
+    _adapters: dict[ProtocolVersion | str, VersionAdapter] = {
         ProtocolVersion.V0_8: V0Point8Adapter(),
         ProtocolVersion.V0_9: V0Point9Adapter(),
         ProtocolVersion.V0_9_1: V0Point9Adapter(),
@@ -47,11 +47,15 @@ class VersionAdapterFactory:
             parsed_ver = cls._parse_version(version)
             if parsed_ver:
                 adapter = cls._adapters.get(parsed_ver)
+            if not adapter:
+                adapter = cls._adapters.get(version)
         elif isinstance(version, ProtocolVersion):
             adapter = cls._adapters.get(version)
 
         if not adapter:
-            supported = ", ".join(v.value for v in cls._adapters.keys())
+            supported = ", ".join(
+                v.value for v in cls._adapters.keys() if hasattr(v, "value")
+            )
             raise A2uiValidationError(
                 f"[VersionAdapterFactory] Unsupported protocol version '{version}'."
                 f" Supported versions: {supported}."
@@ -69,18 +73,43 @@ class VersionAdapterFactory:
         ),
     ) -> VersionAdapter:
         """Resolves the version adapter directly from an incoming message payload."""
+        if payload is None or isinstance(payload, (int, float, str)):
+            raise A2uiValidationError(
+                "[VersionAdapterFactory] Message payload is missing a valid 'version'"
+                " string.",
+                details=[
+                    A2uiErrorDetail(
+                        path="messages.0.version",
+                        code="missing_field",
+                        message="Missing required version field",
+                    )
+                ],
+            )
+
         raw_payload: Any = payload
         if hasattr(raw_payload, "model_dump"):
             raw_payload = raw_payload.model_dump(by_alias=True, exclude_none=True)
 
         if isinstance(raw_payload, list):
+            if not raw_payload:
+                raise A2uiValidationError(
+                    "[VersionAdapterFactory] Message payload is missing a valid"
+                    " 'version' string.",
+                    details=[
+                        A2uiErrorDetail(
+                            path="messages.0.version",
+                            code="missing_field",
+                            message="Missing required version field",
+                        )
+                    ],
+                )
             for idx, item in enumerate(raw_payload):
                 raw_item: Any = item
                 if hasattr(raw_item, "model_dump"):
                     raw_item = raw_item.model_dump(by_alias=True, exclude_none=True)
                 if isinstance(raw_item, dict):
                     v = raw_item.get("version")
-                    if not v:
+                    if not v or not isinstance(v, str):
                         if not any(
                             k in raw_item
                             for k in (
@@ -91,7 +120,8 @@ class VersionAdapterFactory:
                             )
                         ):
                             raise A2uiValidationError(
-                                "Missing required version field",
+                                "[VersionAdapterFactory] Message payload is missing a"
+                                " valid 'version' string.",
                                 details=[
                                     A2uiErrorDetail(
                                         path=f"messages.{idx}.version",
@@ -105,10 +135,33 @@ class VersionAdapterFactory:
         if isinstance(raw_payload, dict):
             if "messages" in raw_payload and isinstance(raw_payload["messages"], list):
                 return cls.resolve_from_payload(raw_payload["messages"])
+            v = raw_payload.get("version")
+            if not v or not isinstance(v, str):
+                if not any(
+                    k in raw_payload
+                    for k in (
+                        "beginRendering",
+                        "surfaceUpdate",
+                        "dataModelUpdate",
+                        "deleteSurface",
+                    )
+                ):
+                    raise A2uiValidationError(
+                        "[VersionAdapterFactory] Message payload is missing a valid"
+                        " 'version' string.",
+                        details=[
+                            A2uiErrorDetail(
+                                path="messages.0.version",
+                                code="missing_field",
+                                message="Missing required version field",
+                            )
+                        ],
+                    )
             return cls._resolve_from_single_action(raw_payload)
 
         raise A2uiValidationError(
-            "Missing required version field",
+            "[VersionAdapterFactory] Message payload is missing a valid 'version'"
+            " string.",
             details=[
                 A2uiErrorDetail(
                     path="messages.0.version",
@@ -125,7 +178,9 @@ class VersionAdapterFactory:
             ver_str = item["version"]
             ver_enum = cls._parse_version(ver_str)
             if not ver_enum:
-                supported = ", ".join(v.value for v in cls._adapters.keys())
+                supported = ", ".join(
+                    v.value for v in cls._adapters.keys() if hasattr(v, "value")
+                )
                 raise A2uiValidationError(
                     f"[VersionAdapterFactory] Unsupported protocol version '{ver_str}'."
                     f" Supported versions: {supported}."
@@ -141,7 +196,17 @@ class VersionAdapterFactory:
             )
         ):
             return cls.get_adapter(ProtocolVersion.V0_8)
-        return cls.get_adapter(DEFAULT_PROTOCOL_VERSION)
+        raise A2uiValidationError(
+            "[VersionAdapterFactory] Message payload is missing a valid 'version'"
+            " string.",
+            details=[
+                A2uiErrorDetail(
+                    path="messages.0.version",
+                    code="missing_field",
+                    message="Missing required version field",
+                )
+            ],
+        )
 
     @classmethod
     def _parse_version(cls, version_str: str) -> ProtocolVersion | None:

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Factory and resolver for protocol version adapters."""
+
 from collections.abc import Mapping, Sequence
 from typing import Any
 from .base import VersionAdapter
@@ -21,6 +23,7 @@ from .v1_0 import V1Point0Adapter
 from ...exceptions import A2uiErrorDetail, A2uiValidationError
 from ...schema import AgentToRendererMessage, ProtocolVersion
 
+# Default fallback protocol version when no version header is present.
 DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion.V0_9
 
 
@@ -36,7 +39,11 @@ class VersionAdapterFactory:
 
     @classmethod
     def register_adapter(cls, adapter: VersionAdapter) -> None:
-        """Dynamically registers a version adapter."""
+        """Dynamically registers a version adapter.
+
+        Args:
+            adapter: The version adapter instance to register.
+        """
         from ...common.semver import normalize_version_string, to_canonical_version
 
         cls._adapters[adapter.version] = adapter
@@ -56,7 +63,11 @@ class VersionAdapterFactory:
 
     @classmethod
     def all_known_actions(cls) -> frozenset[str]:
-        """Returns the aggregated set of all action keys supported by all registered adapters."""
+        """Returns all action keys supported across registered adapters.
+
+        Returns:
+            A frozenset of action keys supported across all registered adapters.
+        """
         actions: set[str] = set()
         for adapter in cls._adapters.values():
             if hasattr(adapter, "valid_actions"):
@@ -65,7 +76,17 @@ class VersionAdapterFactory:
 
     @classmethod
     def get_adapter(cls, version: ProtocolVersion | str) -> VersionAdapter:
-        """Resolves the version adapter for the specified protocol version enum or string."""
+        """Resolves the version adapter for a protocol version.
+
+        Args:
+            version: Protocol version enum or version string.
+
+        Returns:
+            The resolved version adapter instance.
+
+        Raises:
+            A2uiValidationError: If the protocol version is not supported.
+        """
         from ...common.semver import normalize_version_string, to_canonical_version
 
         adapter = cls._adapters.get(version)
@@ -124,7 +145,17 @@ class VersionAdapterFactory:
             | Sequence[Mapping[str, Any]]
         ),
     ) -> VersionAdapter:
-        """Resolves the version adapter directly from an incoming message payload."""
+        """Resolves the version adapter directly from a message payload.
+
+        Args:
+            payload: Raw message dictionary, message object, or message sequence.
+
+        Returns:
+            The resolved version adapter instance.
+
+        Raises:
+            A2uiValidationError: If payload is invalid or no adapter can be resolved.
+        """
         raw: Any = payload
         if hasattr(raw, "model_dump"):
             raw = raw.model_dump(by_alias=True, exclude_none=True)

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -42,9 +42,14 @@ class VersionAdapterFactory:
     @classmethod
     def get_adapter(cls, version: ProtocolVersion | str) -> VersionAdapter:
         """Resolves the version adapter for the specified protocol version enum or string."""
+        adapter = None
         if isinstance(version, str):
-            version = cls._parse_version(version) or DEFAULT_PROTOCOL_VERSION
-        adapter = cls._adapters.get(version)
+            parsed_ver = cls._parse_version(version)
+            if parsed_ver:
+                adapter = cls._adapters.get(parsed_ver)
+        elif isinstance(version, ProtocolVersion):
+            adapter = cls._adapters.get(version)
+
         if not adapter:
             supported = ", ".join(v.value for v in cls._adapters.keys())
             raise A2uiValidationError(
@@ -148,7 +153,18 @@ class VersionAdapterFactory:
         Returns:
             The matched ProtocolVersion enum member, or None if unrecognized.
         """
-        from ...common.semver import parse_semver
+        from ...common.semver import to_canonical_version
+
+        canonical = to_canonical_version(version_str)
+        if canonical:
+            canonical_map = {
+                "0.8": ProtocolVersion.V0_8,
+                "0.9": ProtocolVersion.V0_9,
+                "0.9.1": ProtocolVersion.V0_9_1,
+                "1.0": ProtocolVersion.V1_0,
+            }
+            if canonical in canonical_map:
+                return canonical_map[canonical]
 
         clean = (
             f"v{version_str[1:]}"
@@ -158,15 +174,4 @@ class VersionAdapterFactory:
         try:
             return ProtocolVersion(clean)
         except ValueError:
-            pass
-
-        parsed = parse_semver(version_str)
-        if parsed:
-            if parsed.major == 0 and parsed.minor == 9 and parsed.patch == 1:
-                return ProtocolVersion.V0_9_1
-            canonical = f"v{parsed.major}.{parsed.minor}"
-            try:
-                return ProtocolVersion(canonical)
-            except ValueError:
-                return None
-        return None
+            return None

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -73,119 +73,87 @@ class VersionAdapterFactory:
         ),
     ) -> VersionAdapter:
         """Resolves the version adapter directly from an incoming message payload."""
-        if payload is None or isinstance(payload, (int, float, str)):
+        raw: Any = payload
+        if hasattr(raw, "model_dump"):
+            raw = raw.model_dump(by_alias=True, exclude_none=True)
+
+        # 1. Reject non-collection types (None, int, str, etc.)
+        if not isinstance(raw, (list, dict)):
             raise A2uiValidationError(
                 "[VersionAdapterFactory] Message payload is missing a valid 'version'"
-                " string.",
+                f" string: expected object or list, got {type(payload).__name__}.",
                 details=[
                     A2uiErrorDetail(
                         path="messages.0.version",
-                        code="missing_field",
-                        message="Missing required version field",
+                        code="invalid_payload_type",
+                        message=(
+                            f"Expected object or list, got {type(payload).__name__}"
+                        ),
                     )
                 ],
             )
 
-        raw_payload: Any = payload
-        if hasattr(raw_payload, "model_dump"):
-            raw_payload = raw_payload.model_dump(by_alias=True, exclude_none=True)
-
-        if isinstance(raw_payload, list):
-            if not raw_payload:
+        # 2. Extract first item from list or unwrap {'messages': [...]}
+        item: Any
+        idx: int = 0
+        if isinstance(raw, list):
+            if not raw:
                 raise A2uiValidationError(
                     "[VersionAdapterFactory] Message payload is missing a valid"
-                    " 'version' string.",
+                    " 'version' string: message list is empty.",
                     details=[
                         A2uiErrorDetail(
                             path="messages.0.version",
-                            code="missing_field",
-                            message="Missing required version field",
+                            code="empty_payload",
+                            message="Message list is empty",
                         )
                     ],
                 )
-            for idx, item in enumerate(raw_payload):
-                raw_item: Any = item
-                if hasattr(raw_item, "model_dump"):
-                    raw_item = raw_item.model_dump(by_alias=True, exclude_none=True)
-                if isinstance(raw_item, dict):
-                    v = raw_item.get("version")
-                    if not v or not isinstance(v, str):
-                        if not any(
-                            k in raw_item
-                            for k in (
-                                "beginRendering",
-                                "surfaceUpdate",
-                                "dataModelUpdate",
-                                "deleteSurface",
-                            )
-                        ):
-                            raise A2uiValidationError(
-                                "[VersionAdapterFactory] Message payload is missing a"
-                                " valid 'version' string.",
-                                details=[
-                                    A2uiErrorDetail(
-                                        path=f"messages.{idx}.version",
-                                        code="missing_field",
-                                        message="Missing required version field",
-                                    )
-                                ],
-                            )
-                    return cls._resolve_from_single_action(raw_item)
+            item = raw[0]
+        elif "messages" in raw and isinstance(raw["messages"], list):
+            return cls.resolve_from_payload(raw["messages"])
+        else:
+            item = raw
 
-        if isinstance(raw_payload, dict):
-            if "messages" in raw_payload and isinstance(raw_payload["messages"], list):
-                return cls.resolve_from_payload(raw_payload["messages"])
-            v = raw_payload.get("version")
-            if not v or not isinstance(v, str):
-                if not any(
-                    k in raw_payload
-                    for k in (
-                        "beginRendering",
-                        "surfaceUpdate",
-                        "dataModelUpdate",
-                        "deleteSurface",
+        if hasattr(item, "model_dump"):
+            item = item.model_dump(by_alias=True, exclude_none=True)
+
+        # 3. Ensure candidate item is a dictionary
+        if not isinstance(item, dict):
+            raise A2uiValidationError(
+                "[VersionAdapterFactory] Message payload is missing a valid 'version'"
+                f" string: message item at index {idx} is not an object.",
+                details=[
+                    A2uiErrorDetail(
+                        path=f"messages.{idx}.version",
+                        code="invalid_payload_type",
+                        message="Message item is not an object",
                     )
-                ):
-                    raise A2uiValidationError(
-                        "[VersionAdapterFactory] Message payload is missing a valid"
-                        " 'version' string.",
-                        details=[
-                            A2uiErrorDetail(
-                                path="messages.0.version",
-                                code="missing_field",
-                                message="Missing required version field",
-                            )
-                        ],
-                    )
-            return cls._resolve_from_single_action(raw_payload)
+                ],
+            )
 
-        raise A2uiValidationError(
-            "[VersionAdapterFactory] Message payload is missing a valid 'version'"
-            " string.",
-            details=[
-                A2uiErrorDetail(
-                    path="messages.0.version",
-                    code="missing_field",
-                    message="Missing required version field",
-                )
-            ],
-        )
-
-    @classmethod
-    def _resolve_from_single_action(cls, item: dict[str, Any]) -> VersionAdapter:
-        """Resolves version adapter from a single message dictionary if explicit version or action keys match."""
-        if "version" in item and isinstance(item["version"], str):
-            ver_str = item["version"]
-            ver_enum = cls._parse_version(ver_str)
-            if not ver_enum:
-                supported = ", ".join(
-                    v.value for v in cls._adapters.keys() if hasattr(v, "value")
-                )
+        # 4. Check explicit version property
+        if "version" in item:
+            ver = item["version"]
+            if not isinstance(ver, str):
                 raise A2uiValidationError(
-                    f"[VersionAdapterFactory] Unsupported protocol version '{ver_str}'."
-                    f" Supported versions: {supported}."
+                    "[VersionAdapterFactory] Message payload is missing a valid"
+                    " 'version' string: 'version' property must be a string, got"
+                    f" {type(ver).__name__}.",
+                    details=[
+                        A2uiErrorDetail(
+                            path=f"messages.{idx}.version",
+                            code="type_mismatch",
+                            message=(
+                                "Expected string for 'version', got"
+                                f" {type(ver).__name__}"
+                            ),
+                        )
+                    ],
                 )
-            return cls.get_adapter(ver_enum)
+            return cls.get_adapter(ver)
+
+        # 5. Check v0.8 legacy action keys
         if any(
             k in item
             for k in (
@@ -196,12 +164,14 @@ class VersionAdapterFactory:
             )
         ):
             return cls.get_adapter(ProtocolVersion.V0_8)
+
+        # 6. Missing version and no legacy action key
         raise A2uiValidationError(
             "[VersionAdapterFactory] Message payload is missing a valid 'version'"
-            " string.",
+            " string: no version header or legacy v0.8 action found.",
             details=[
                 A2uiErrorDetail(
-                    path="messages.0.version",
+                    path=f"messages.{idx}.version",
                     code="missing_field",
                     message="Missing required version field",
                 )

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/factory.py
@@ -40,6 +40,15 @@ class VersionAdapterFactory:
         cls._adapters[adapter.version] = adapter
 
     @classmethod
+    def all_known_actions(cls) -> frozenset[str]:
+        """Returns the aggregated set of all action keys supported by all registered adapters."""
+        actions: set[str] = set()
+        for adapter in cls._adapters.values():
+            if hasattr(adapter, "valid_actions"):
+                actions.update(adapter.valid_actions)
+        return frozenset(actions)
+
+    @classmethod
     def get_adapter(cls, version: ProtocolVersion | str) -> VersionAdapter:
         """Resolves the version adapter for the specified protocol version enum or string."""
         adapter = None

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v0_8.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v0_8.py
@@ -54,10 +54,6 @@ class V0Point8Adapter(BaseVersionAdapter):
             MSG_TYPE_DELETE_SURFACE,
         }
 
-    @property
-    def raise_on_empty_actions(self) -> bool:
-        return False
-
     def _extract_operations_for_action(
         self,
         action: str,

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v0_8.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v0_8.py
@@ -72,6 +72,12 @@ class V0Point8Adapter(BaseVersionAdapter):
                     components=br.get("components"),
                     data_model=br.get("dataModel"),
                     root=br.get("root"),
+                    version=message.get("version")
+                    or (
+                        self.version.value
+                        if hasattr(self.version, "value")
+                        else str(self.version)
+                    ),
                 )
             )
         elif action == MSG_TYPE_SURFACE_UPDATE:

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v0_9.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v0_9.py
@@ -41,10 +41,6 @@ class V0Point9Adapter(BaseVersionAdapter):
         return ProtocolVersion.V0_9
 
     @property
-    def supported_versions(self) -> set[str]:
-        return {"v0.9", "v0.9.1"}
-
-    @property
     def compatible_catalog_versions(self) -> frozenset[str]:
         return frozenset({"0.9", "0.9.1"})
 

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v0_9.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v0_9.py
@@ -80,6 +80,12 @@ class V0Point9Adapter(BaseVersionAdapter):
                     send_data_model=bool(cs.get("sendDataModel", False)),
                     components=cs.get("components"),
                     data_model=cs.get("dataModel"),
+                    version=message.get("version")
+                    or (
+                        self.version.value
+                        if hasattr(self.version, "value")
+                        else str(self.version)
+                    ),
                 )
             )
         elif action == MSG_TYPE_UPDATE_COMPONENTS:

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v0_9.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v0_9.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import Any, cast
+from typing import Any
 from .base import BaseVersionAdapter
 from ...schema import ProtocolVersion
 from ...schema.v0_9 import (
@@ -43,6 +43,10 @@ class V0Point9Adapter(BaseVersionAdapter):
     @property
     def supported_versions(self) -> set[str]:
         return {"v0.9", "v0.9.1"}
+
+    @property
+    def compatible_catalog_versions(self) -> frozenset[str]:
+        return frozenset({"0.9", "0.9.1"})
 
     def prepare_payload_for_validation(self, message: dict[str, Any]) -> dict[str, Any]:
         payload = copy.deepcopy(message)

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
@@ -68,9 +68,7 @@ class V1Point0Adapter(BaseVersionAdapter):
         message: dict[str, Any],
         context: ExecutionContext | None = None,
     ) -> list[InternalOperation]:
-        user_activation = (
-            context.user_activation_present if context is not None else False
-        )
+        user_activation = context.is_user_activated if context is not None else False
         res: list[InternalOperation] = []
         if action == MSG_TYPE_CREATE_SURFACE:
             cs = message[MSG_TYPE_CREATE_SURFACE]
@@ -140,7 +138,7 @@ class V1Point0Adapter(BaseVersionAdapter):
                     version=ver_str,
                     catalog_id=cf.catalog_id,
                     args=cf.args or {},
-                    user_activation_present=user_activation,
+                    is_user_activated=user_activation,
                 )
             )
         elif action == MSG_TYPE_AGENT_FUNCTION_RESPONSE:
@@ -149,6 +147,7 @@ class V1Point0Adapter(BaseVersionAdapter):
             res.append(
                 InternalAgentFunctionResponseOp(
                     function_call_id=resp_data.function_call_id,
+                    version=str(getattr(af_resp, "version", "v1.0")),
                     value=resp_data.value,
                     error=resp_data.error.model_dump(by_alias=True)
                     if resp_data.error

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
@@ -78,6 +78,12 @@ class V1Point0Adapter(BaseVersionAdapter):
                     catalog_id=cs.get("catalogId"),
                     theme=cs.get("theme"),
                     send_data_model=bool(cs.get("sendDataModel", False)),
+                    version=message.get("version")
+                    or (
+                        self.version.value
+                        if hasattr(self.version, "value")
+                        else str(self.version)
+                    ),
                 )
             )
             comps = cs.get("components")

--- a/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
+++ b/python/a2ui_core/src/a2ui/core/processing/adapters/v1_0.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Any
-from ...exceptions import A2uiValidationError
 from .base import BaseVersionAdapter
 from ...schema import ProtocolVersion
 from ...schema.v1_0 import (

--- a/python/a2ui_core/src/a2ui/core/processing/execution_context.py
+++ b/python/a2ui_core/src/a2ui/core/processing/execution_context.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Execution context tracking user activation and message processing state."""
+
 from dataclasses import dataclass
 
 
 @dataclass
 class ExecutionContext:
-    """Execution context passed through message processing and operation extraction."""
+    """Execution context passed through message processing and operation extraction.
+
+    Attributes:
+        is_user_activated: Whether user activation is present in the context.
+    """
 
     is_user_activated: bool = False
 
@@ -26,6 +32,13 @@ class ExecutionContext:
         is_user_activated: bool = False,
         user_activation_present: bool | None = None,
     ) -> None:
+        """Initializes an ExecutionContext.
+
+        Args:
+            is_user_activated: Whether user activation is present in the context.
+            user_activation_present: Optional backward-compatibility alias for
+                is_user_activated.
+        """
         if user_activation_present is not None:
             self.is_user_activated = user_activation_present
         else:
@@ -33,7 +46,7 @@ class ExecutionContext:
 
     @property
     def user_activation_present(self) -> bool:
-        """Backward compatibility alias for is_user_activated."""
+        """Whether user activation is present (backward compatibility alias)."""
         return self.is_user_activated
 
     @user_activation_present.setter

--- a/python/a2ui_core/src/a2ui/core/processing/execution_context.py
+++ b/python/a2ui_core/src/a2ui/core/processing/execution_context.py
@@ -26,29 +26,3 @@ class ExecutionContext:
     """
 
     is_user_activated: bool = False
-
-    def __init__(
-        self,
-        is_user_activated: bool = False,
-        user_activation_present: bool | None = None,
-    ) -> None:
-        """Initializes an ExecutionContext.
-
-        Args:
-            is_user_activated: Whether user activation is present in the context.
-            user_activation_present: Optional backward-compatibility alias for
-                is_user_activated.
-        """
-        if user_activation_present is not None:
-            self.is_user_activated = user_activation_present
-        else:
-            self.is_user_activated = is_user_activated
-
-    @property
-    def user_activation_present(self) -> bool:
-        """Whether user activation is present (backward compatibility alias)."""
-        return self.is_user_activated
-
-    @user_activation_present.setter
-    def user_activation_present(self, value: bool) -> None:
-        self.is_user_activated = value

--- a/python/a2ui_core/src/a2ui/core/processing/execution_context.py
+++ b/python/a2ui_core/src/a2ui/core/processing/execution_context.py
@@ -19,4 +19,23 @@ from dataclasses import dataclass
 class ExecutionContext:
     """Execution context passed through message processing and operation extraction."""
 
-    user_activation_present: bool = False
+    is_user_activated: bool = False
+
+    def __init__(
+        self,
+        is_user_activated: bool = False,
+        user_activation_present: bool | None = None,
+    ) -> None:
+        if user_activation_present is not None:
+            self.is_user_activated = user_activation_present
+        else:
+            self.is_user_activated = is_user_activated
+
+    @property
+    def user_activation_present(self) -> bool:
+        """Backward compatibility alias for is_user_activated."""
+        return self.is_user_activated
+
+    @user_activation_present.setter
+    def user_activation_present(self, value: bool) -> None:
+        self.is_user_activated = value

--- a/python/a2ui_core/src/a2ui/core/processing/format_pydantic_error.py
+++ b/python/a2ui_core/src/a2ui/core/processing/format_pydantic_error.py
@@ -1,0 +1,330 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic validation error formatting utilities.
+
+Provides functions to format Pydantic validation issues into human-readable diagnostic
+messages and structured A2UI error details, congruent with A2UI's cross-language standards.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from pydantic import ValidationError
+from ..exceptions import A2uiErrorDetail
+
+
+def _clean_loc_part(x: str) -> str:
+    """Extracts base message class names from Pydantic validator wrapper strings."""
+    if x.startswith("function-after[") or x.startswith("function-before["):
+        match = re.search(r"([A-Za-z0-9_]+Message)\]", x)
+        if match:
+            return match.group(1)
+    return x
+
+
+def _format_type_name(val: Any) -> str:
+    """Formats a Python value into canonical schema type vocabulary."""
+    if val is None:
+        return "null"
+    if isinstance(val, bool):
+        return "boolean"
+    if isinstance(val, (int, float)):
+        return "number"
+    if isinstance(val, str):
+        return "string"
+    if isinstance(val, dict):
+        return "object"
+    if isinstance(val, (list, tuple, set)):
+        return "array"
+    return type(val).__name__
+
+
+_PYDANTIC_TYPE_MAP: dict[str, str] = {
+    "string_type": "string",
+    "int_type": "integer",
+    "int_parsing": "integer",
+    "float_type": "number",
+    "float_parsing": "number",
+    "bool_type": "boolean",
+    "bool_parsing": "boolean",
+    "dict_type": "object",
+    "list_type": "array",
+}
+
+
+def _get_expected_type(err_type: str, msg: str) -> str:
+    """Extracts a canonical expected type name from Pydantic error type and message."""
+    if err_type in _PYDANTIC_TYPE_MAP:
+        return _PYDANTIC_TYPE_MAP[err_type]
+    match = re.search(r"Input should be a valid ([a-zA-Z0-9_ ]+)", msg)
+    if match:
+        raw_target = match.group(1).split(",")[0].strip()
+        type_aliases = {
+            "string": "string",
+            "integer": "integer",
+            "int": "integer",
+            "boolean": "boolean",
+            "dictionary": "object",
+            "list": "array",
+        }
+        return type_aliases.get(raw_target, raw_target)
+    cleaned = err_type.replace("_type", "").replace("_parsing", "").strip()
+    return cleaned or "valid value"
+
+
+def map_pydantic_error_code(err_type: str) -> str:
+    """Maps a Pydantic error type to a canonical A2UI error code.
+
+    Args:
+        err_type: Pydantic error type string (e.g. 'missing', 'extra_forbidden').
+
+    Returns:
+        Canonical A2UI error code ('missing_field', 'extra_field', 'type_mismatch', or 'invalid_value').
+    """
+    if err_type == "missing":
+        return "missing_field"
+    if err_type == "extra_forbidden":
+        return "extra_field"
+    if (
+        err_type.endswith("_type")
+        or err_type.endswith("_parsing")
+        or "type" in err_type
+    ):
+        return "type_mismatch"
+    return "invalid_value"
+
+
+def format_pydantic_message(
+    err: dict[str, Any],
+    path_str: str = "",
+    match_jsonschema_missing: bool = False,
+) -> str:
+    """Formats a diagnostic error message string for a single Pydantic error.
+
+    Ensures the message contains informative, congruent diagnostic details matching
+    cross-language conventions.
+
+    Args:
+        err: Pydantic error dictionary from ValidationError.errors().
+        path_str: Property path string associated with the error.
+        match_jsonschema_missing: If True, uses JSON Schema-style missing field message.
+
+    Returns:
+        Human-readable diagnostic error message.
+    """
+    err_type = err.get("type", "")
+    ctx = err.get("ctx") or {}
+
+    if err_type == "extra_forbidden":
+        extra_key = ctx.get("extra")
+        if not extra_key and err.get("loc"):
+            extra_key = str(err["loc"][-1])
+        key_str = f": '{extra_key}'" if extra_key else ""
+        return (
+            f"Additional properties are not allowed: unrecognized key(s) in object{key_str}"
+            f" (extra inputs are not permitted)"
+        )
+
+    if err_type == "missing":
+        if match_jsonschema_missing:
+            return (
+                f"'{path_str}' is a required property"
+                if path_str
+                else "Missing required field"
+            )
+        return err.get("msg", "Field required")
+
+    if err_type == "literal_error":
+        expected = ctx.get("expected")
+        received = err.get("input")
+        if expected is not None:
+            return f"Invalid enum value. Expected {expected}, received '{received}'"
+        return err.get("msg", "Invalid value")
+
+    if (
+        err_type.endswith("_type")
+        or err_type.endswith("_parsing")
+        or "type" in err_type
+    ):
+        return err.get("msg", "Type mismatch")
+        raw_msg = err.get("msg", "Type mismatch")
+        expected = _get_expected_type(err_type, raw_msg)
+        pydantic_hint = raw_msg[0].lower() + raw_msg[1:] if raw_msg else ""
+        hint_str = f" ({pydantic_hint})" if pydantic_hint else ""
+        if "input" in err:
+            received = _format_type_name(err["input"])
+            return f"Expected {expected}, received {received}{hint_str}"
+        return f"Expected {expected}{hint_str}"
+
+    return err.get("msg", "Validation failed")
+
+
+def format_pydantic_issue(err: dict[str, Any], path: str | None = None) -> str:
+    """Formats a single Pydantic issue into a human-readable diagnostic message.
+
+    Extracts issue details into a diagnostic string containing the target path and
+    violation details, mirroring TypeScript's formatZodIssue.
+
+    Args:
+        err: Pydantic error dictionary from ValidationError.errors().
+        path: Optional pre-computed path string. If omitted, constructed from err['loc'].
+
+    Returns:
+        Human-readable formatted error message with path prefix.
+    """
+    if path is None:
+        loc = err.get("loc", ())
+        clean_parts = [_clean_loc_part(str(x)) for x in loc]
+        path = ".".join(clean_parts) or "root"
+
+    msg = format_pydantic_message(err, path)
+    return f"{path}: {msg}"
+
+
+def format_validation_error(
+    error: ValidationError,
+    messages: list[dict[str, Any]] | None = None,
+    valid_actions: set[str] | None = None,
+    path_prefix: str = "",
+    allow_unknown_extra: bool = False,
+    match_jsonschema_missing_path: bool = False,
+    strip_messages_prefix: bool = False,
+) -> list[A2uiErrorDetail]:
+    """Formats a Pydantic ValidationError into structured A2uiErrorDetail instances.
+
+    Filters out irrelevant union branches when validating message envelopes with multiple
+    discriminated union branches.
+
+    Args:
+        error: Pydantic ValidationError to format.
+        messages: Optional list of raw message payloads being validated (used for union pruning).
+        valid_actions: Optional set of valid action names supported by the adapter.
+        path_prefix: Optional prefix to prepend to error paths.
+        allow_unknown_extra: If True, extra_field errors are ignored.
+        match_jsonschema_missing_path: If True, sets path to empty string for missing root fields
+            to maintain parity with JSON Schema component validation behavior.
+        strip_messages_prefix: If True, strips leading 'messages.<index>' from error paths.
+
+    Returns:
+        List of structured A2uiErrorDetail objects.
+    """
+    details: list[A2uiErrorDetail] = []
+    branch_to_action: dict[str, str] = {}
+    action_to_branch: dict[str, str] = {}
+    action_to_branches: dict[str, set[str]] = {}
+    if valid_actions:
+        for action in valid_actions:
+            branch = action[0].upper() + action[1:] + "Message"
+            short_branch = action[0].upper() + action[1:]
+            branch_to_action[branch] = action
+            action_to_branch[action] = branch
+            branch_to_action[short_branch] = action
+            action_to_branches[action] = {branch, short_branch}
+
+    all_branch_names = set(branch_to_action.keys())
+
+    for err in error.errors():
+        loc = err.get("loc", ())
+        loc_parts = [_clean_loc_part(str(x)) for x in loc]
+        if (
+            messages is not None
+            and all_branch_names
+            and len(loc) >= 3
+            and loc[0] == "messages"
+            and isinstance(loc[1], int)
+        ):
+            msg_idx = loc[1]
+            if msg_idx < len(messages) and isinstance(messages[msg_idx], dict):
+                m = messages[msg_idx]
+                present_actions = [k for k in (valid_actions or ()) if k in m]
+                if present_actions:
+                    branch = loc_parts[2]
+                    if branch in all_branch_names:
+                        expected_branches = {
+                            action_to_branch[act] for act in present_actions
+                        }
+                        expected_branches = set().union(
+                            *(
+                                action_to_branches.get(act, set())
+                                for act in present_actions
+                            )
+                        )
+                        if branch not in expected_branches:
+                            continue
+
+        clean_loc_parts = [x for x in loc_parts if x not in all_branch_names]
+        if strip_messages_prefix:
+            if (
+                len(clean_loc_parts) >= 2
+                and clean_loc_parts[0] == "messages"
+                and clean_loc_parts[1].isdigit()
+            ):
+                clean_loc_parts = clean_loc_parts[2:]
+        path_str = ".".join(clean_loc_parts)
+        err_type = err.get("type", "")
+        code = map_pydantic_error_code(err_type)
+
+        if allow_unknown_extra and code == "extra_field":
+            continue
+
+        msg = format_pydantic_message(
+            err,
+            path_str,
+            match_jsonschema_missing=match_jsonschema_missing_path,
+        )
+
+        if match_jsonschema_missing_path and code == "missing_field":
+            path_str = ""
+
+        if path_prefix:
+            full_path = f"{path_prefix}.{path_str}" if path_str else path_prefix
+        else:
+            full_path = path_str
+
+        details.append(A2uiErrorDetail(path=full_path, code=code, message=msg))
+
+    return details
+
+
+def format_validation_error_summary(
+    error: ValidationError,
+    messages: list[dict[str, Any]] | None = None,
+    valid_actions: set[str] | None = None,
+    path_prefix: str = "",
+    separator: str = "; ",
+    strip_messages_prefix: bool = False,
+) -> str:
+    """Formats a ValidationError into a joined summary diagnostic string.
+
+    Args:
+        error: Pydantic ValidationError to format.
+        messages: Optional list of raw message payloads being validated.
+        valid_actions: Optional set of valid action names supported by the adapter.
+        path_prefix: Optional prefix to prepend to error paths.
+        separator: Separator string between error diagnostics. Defaults to '; '.
+        strip_messages_prefix: If True, strips leading 'messages.<index>' from error paths.
+
+    Returns:
+        Formatted summary string (e.g. 'path1: msg1; path2: msg2').
+    """
+    details = format_validation_error(
+        error,
+        messages=messages,
+        valid_actions=valid_actions,
+        path_prefix=path_prefix,
+        strip_messages_prefix=strip_messages_prefix,
+    )
+    return separator.join(f"{d.path}: {d.message}" for d in details)

--- a/python/a2ui_core/src/a2ui/core/processing/format_pydantic_error.py
+++ b/python/a2ui_core/src/a2ui/core/processing/format_pydantic_error.py
@@ -20,6 +20,7 @@ messages and structured A2UI error details, congruent with A2UI's cross-language
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import re
 from typing import Any
 from pydantic import ValidationError
@@ -108,7 +109,7 @@ def map_pydantic_error_code(err_type: str) -> str:
 
 
 def format_pydantic_message(
-    err: dict[str, Any],
+    err: Mapping[str, Any],
     path_str: str = "",
     match_jsonschema_missing: bool = False,
 ) -> str:
@@ -134,8 +135,8 @@ def format_pydantic_message(
             extra_key = str(err["loc"][-1])
         key_str = f": '{extra_key}'" if extra_key else ""
         return (
-            f"Additional properties are not allowed: unrecognized key(s) in object{key_str}"
-            f" (extra inputs are not permitted)"
+            "Additional properties are not allowed: unrecognized key(s) in"
+            f" object{key_str} (extra inputs are not permitted)"
         )
 
     if err_type == "missing":
@@ -145,22 +146,21 @@ def format_pydantic_message(
                 if path_str
                 else "Missing required field"
             )
-        return err.get("msg", "Field required")
+        return str(err.get("msg", "Field required"))
 
     if err_type == "literal_error":
         expected = ctx.get("expected")
         received = err.get("input")
         if expected is not None:
             return f"Invalid enum value. Expected {expected}, received '{received}'"
-        return err.get("msg", "Invalid value")
+        return str(err.get("msg", "Invalid value"))
 
     if (
         err_type.endswith("_type")
         or err_type.endswith("_parsing")
         or "type" in err_type
     ):
-        return err.get("msg", "Type mismatch")
-        raw_msg = err.get("msg", "Type mismatch")
+        raw_msg = str(err.get("msg", "Type mismatch"))
         expected = _get_expected_type(err_type, raw_msg)
         pydantic_hint = raw_msg[0].lower() + raw_msg[1:] if raw_msg else ""
         hint_str = f" ({pydantic_hint})" if pydantic_hint else ""
@@ -169,10 +169,10 @@ def format_pydantic_message(
             return f"Expected {expected}, received {received}{hint_str}"
         return f"Expected {expected}{hint_str}"
 
-    return err.get("msg", "Validation failed")
+    return str(err.get("msg", "Validation failed"))
 
 
-def format_pydantic_issue(err: dict[str, Any], path: str | None = None) -> str:
+def format_pydantic_issue(err: Mapping[str, Any], path: str | None = None) -> str:
     """Formats a single Pydantic issue into a human-readable diagnostic message.
 
     Extracts issue details into a diagnostic string containing the target path and
@@ -249,19 +249,17 @@ def format_validation_error(
             msg_idx = loc[1]
             if msg_idx < len(messages) and isinstance(messages[msg_idx], dict):
                 m = messages[msg_idx]
-                present_actions = [k for k in (valid_actions or ()) if k in m]
+                present_actions = [k for k in valid_actions or () if k in m]
                 if present_actions:
                     branch = loc_parts[2]
                     if branch in all_branch_names:
                         expected_branches = {
                             action_to_branch[act] for act in present_actions
                         }
-                        expected_branches = set().union(
-                            *(
-                                action_to_branches.get(act, set())
-                                for act in present_actions
-                            )
-                        )
+                        expected_branches = set().union(*(
+                            action_to_branches.get(act, set())
+                            for act in present_actions
+                        ))
                         if branch not in expected_branches:
                             continue
 

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 from ..common.events import EventSource
+from ..common.semver import is_catalog_version_compatible
 from ..state import SurfaceGroupModel, SurfaceModel, ComponentModel
 from ..validation import (
     PayloadValidator,
@@ -416,6 +417,7 @@ class MessageProcessor:
             )
 
     def _process_create_surface_op(self, op: InternalCreateSurfaceOp) -> None:
+        """Processes a createSurface operation, validating catalog and theme compatibility."""
         surface_id = op.surface_id
         catalog_id = op.catalog_id
         theme = op.theme or {}
@@ -441,11 +443,14 @@ class MessageProcessor:
                     f"Validation failed for theme on surface '{surface_id}': {e}"
                 ) from e
 
+        surface_proto_ver = getattr(surface_catalog, "protocol_version", None)
         matching_available_catalogs = {
             getattr(cat, "catalog_id", f"cat_{i}"): cat
             for i, cat in enumerate(self.catalogs)
-            if getattr(cat, "protocol_version", None)
-            == getattr(surface_catalog, "protocol_version", None)
+            if is_catalog_version_compatible(
+                getattr(cat, "protocol_version", None),
+                surface_proto_ver,
+            )
         }
         new_surface = SurfaceModel(
             surface_id=surface_id,
@@ -473,6 +478,7 @@ class MessageProcessor:
             )
 
     def _process_update_components_op(self, op: InternalUpdateComponentsOp) -> None:
+        """Processes an updateComponents operation, validating catalog and component consistency."""
         surface_id = op.surface_id
         surface = self.model.get_surface(surface_id)
         if not surface:
@@ -516,7 +522,11 @@ class MessageProcessor:
                     raise A2uiCatalogError(f"Catalog not found: {comp_cat_id}")
                 comp_ver = getattr(comp_catalog, "protocol_version", None)
                 surface_ver = getattr(surface.default_catalog, "protocol_version", None)
-                if comp_ver and surface_ver and comp_ver != surface_ver:
+                if (
+                    comp_ver
+                    and surface_ver
+                    and not is_catalog_version_compatible(comp_ver, surface_ver)
+                ):
                     raise A2uiCatalogError(
                         f"Component {c_id} catalog '{comp_cat_id}' has different"
                         f" protocol version {comp_ver} than default catalog"

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -72,7 +72,12 @@ PendingAgentCallCallback = Callable[[Any, Optional[dict[str, Any]]], None]
 
 @dataclass
 class MessageProcessorOptions:
-    """Options for configuring a MessageProcessor instance."""
+    """Options for configuring a MessageProcessor instance.
+
+    Attributes:
+        validation_config: Validation configuration to enforce on messages, or None.
+        default_timeout_ms: Default timeout in milliseconds for async RPC calls.
+    """
 
     validation_config: ValidationConfig | None = None
     default_timeout_ms: float = 30000.0
@@ -87,6 +92,16 @@ class MessageProcessor:
         action_handler: Callable[[dict[str, Any]], None] | None = None,
         options: MessageProcessorOptions | None = None,
     ) -> None:
+        """Initializes a MessageProcessor with component catalogs and options.
+
+        Args:
+            catalogs: Sequence of component and function catalogs for resolution.
+            action_handler: Optional callback invoked when UI actions trigger.
+            options: Optional configuration options including validation rules.
+
+        Raises:
+            ValueError: If catalogs is empty or None.
+        """
         if not catalogs:
             raise ValueError("At least one catalog must be provided.")
         self.catalogs = catalogs

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 from ..common.events import EventSource
-from ..common.semver import is_catalog_version_compatible
+from .adapters import is_catalog_version_compatible
 from ..state import SurfaceGroupModel, SurfaceModel, ComponentModel
 from ..validation import (
     PayloadValidator,

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -15,6 +15,7 @@
 import asyncio
 import concurrent.futures
 import copy
+from dataclasses import dataclass
 import inspect
 import logging
 from collections.abc import Mapping, Sequence
@@ -55,6 +56,7 @@ from ..schema.v1_0 import (
 )
 from ..schema.v1_0.common_types import FunctionCall
 from .adapters import VersionAdapterFactory
+from .execution_context import ExecutionContext
 from .operations import (
     InternalAgentFunctionResponseOp,
     InternalCallRendererFunctionOp,
@@ -68,7 +70,12 @@ from .operations import (
 PendingAgentCallCallback = Callable[[Any, Optional[dict[str, Any]]], None]
 
 
-from .execution_context import ExecutionContext
+@dataclass
+class MessageProcessorOptions:
+    """Options for configuring a MessageProcessor instance."""
+
+    validation_config: ValidationConfig | None = None
+    default_timeout_ms: float = 30000.0
 
 
 class MessageProcessor:
@@ -77,14 +84,15 @@ class MessageProcessor:
     def __init__(
         self,
         catalogs: Sequence[Catalog[TComponent, TFunction]] | None = None,
-        validation_config: ValidationConfig | None = None,
         action_handler: Callable[[dict[str, Any]], None] | None = None,
+        options: MessageProcessorOptions | None = None,
     ) -> None:
         if not catalogs:
             raise ValueError("At least one catalog must be provided.")
         self.catalogs = catalogs
         self.model = SurfaceGroupModel()
-        self.validation_config = validation_config
+        opts = options or MessageProcessorOptions()
+        self.validation_config = opts.validation_config
         self.on_agent_function_response = EventSource()
         self._pending_agent_calls: dict[str, PendingAgentCallCallback] = {}
         if action_handler:
@@ -380,7 +388,7 @@ class MessageProcessor:
             )
 
         requires_user_activation = getattr(fn, "requires_user_activation", False)
-        if requires_user_activation and not op.user_activation_present:
+        if requires_user_activation and not op.is_user_activated:
             return make_error(
                 RpcErrorCode.INVALID_FUNCTION_CALL,
                 f"Function '{op.call}' requires user activation context to execute.",

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -478,6 +478,19 @@ class MessageProcessor:
                 ) from e
 
         surface_proto_ver = getattr(surface_catalog, "protocol_version", None)
+        msg_version = op.version or getattr(self, "version", None)
+        if (
+            surface_proto_ver
+            and msg_version
+            and not is_catalog_version_compatible(surface_proto_ver, msg_version)
+        ):
+            cat_name = catalog_id or getattr(surface_catalog, "catalog_id", "unknown")
+            raise A2uiValidationError(
+                f"Surface '{surface_id}' catalog '{cat_name}' specification version"
+                f" ({surface_proto_ver}) does not match message protocol version"
+                f" ({msg_version})."
+            )
+
         matching_available_catalogs = {
             getattr(cat, "catalog_id", f"cat_{i}"): cat
             for i, cat in enumerate(self.catalogs)

--- a/python/a2ui_core/src/a2ui/core/processing/message_processor.py
+++ b/python/a2ui_core/src/a2ui/core/processing/message_processor.py
@@ -349,6 +349,17 @@ class MessageProcessor:
                 f"Catalog not found: {op.catalog_id}",
             )
 
+        cat_ver = getattr(matched_catalog, "protocol_version", None)
+        if cat_ver and version and not is_catalog_version_compatible(cat_ver, version):
+            cat_name = op.catalog_id or getattr(
+                matched_catalog, "catalog_id", "unknown"
+            )
+            return make_error(
+                RpcErrorCode.INVALID_FUNCTION_CALL,
+                f"Catalog '{cat_name}' specification version ({cat_ver}) does not"
+                f" match message protocol version ({version}).",
+            )
+
         fn = (
             matched_catalog.get_function(op.call)
             if hasattr(matched_catalog, "get_function")

--- a/python/a2ui_core/src/a2ui/core/processing/operations.py
+++ b/python/a2ui_core/src/a2ui/core/processing/operations.py
@@ -65,13 +65,14 @@ class InternalCallRendererFunctionOp:
     version: str
     catalog_id: str | None = None
     args: dict[str, Any] = field(default_factory=dict)
-    user_activation_present: bool = False
+    is_user_activated: bool = False
     type: str = MSG_TYPE_CALL_RENDERER_FUNCTION
 
 
 @dataclass
 class InternalAgentFunctionResponseOp:
     function_call_id: str
+    version: str = "v1.0"
     value: Any | None = None
     error: dict[str, Any] | None = None
     type: str = MSG_TYPE_AGENT_FUNCTION_RESPONSE

--- a/python/a2ui_core/src/a2ui/core/processing/operations.py
+++ b/python/a2ui_core/src/a2ui/core/processing/operations.py
@@ -34,6 +34,7 @@ class InternalCreateSurfaceOp:
     components: list[dict[str, Any]] | None = None
     data_model: dict[str, Any] | None = None
     root: str | None = None
+    version: str | None = None
     type: str = MSG_TYPE_CREATE_SURFACE
 
 

--- a/python/a2ui_core/src/a2ui/core/processing/operations.py
+++ b/python/a2ui_core/src/a2ui/core/processing/operations.py
@@ -60,6 +60,8 @@ class InternalDeleteSurfaceOp:
 
 @dataclass
 class InternalCallRendererFunctionOp:
+    """Internal operation representing an agent-to-renderer function call."""
+
     function_call_id: str
     call: str
     version: str
@@ -71,6 +73,8 @@ class InternalCallRendererFunctionOp:
 
 @dataclass
 class InternalAgentFunctionResponseOp:
+    """Internal operation representing a response to a renderer-to-agent function call."""
+
     function_call_id: str
     version: str = "v1.0"
     value: Any | None = None

--- a/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
+++ b/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
@@ -12,27 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from typing import (
     Any,
-    Dict,
     Generic,
-    List,
-    Optional,
-    Set,
-    Tuple,
     Type,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-    TYPE_CHECKING,
 )
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 from jsonschema import Draft202012Validator
 from ..exceptions import A2uiValidationError, A2uiErrorDetail, A2uiCatalogError
 from ..catalog.catalog import Catalog, TComponent, TFunction
+from ..processing.format_pydantic_error import format_validation_error
 
 
 class A2uiValidatorError(A2uiValidationError):
@@ -226,41 +216,13 @@ class PayloadValidator(Generic[TComponent, TFunction]):
         try:
             model_cls.model_validate(comp)
         except ValidationError as e:
-            for err in e.errors():
-                loc_parts = [str(x) for x in err.get("loc", [])]
-                path_str = ".".join(loc_parts)
-                err_type = err.get("type", "")
-                if err_type == "missing":
-                    code = "missing_field"
-                    msg = (
-                        f"'{path_str}' is a required property"
-                        if path_str
-                        else "Missing required field"
-                    )
-                    # Match jsonschema error path behavior for missing property
-                    path_str = ""
-                elif err_type == "extra_forbidden":
-                    code = "extra_field"
-                    msg = "Additional properties are not allowed"
-                elif "type" in err_type or "parsing" in err_type:
-                    code = "type_mismatch"
-                    msg = err.get("msg", "Type mismatch")
-                else:
-                    code = "invalid_value"
-                    msg = err.get("msg", "Validation failed")
-
-                if allow_unknown and code == "extra_field":
-                    continue
-
-                errors.append(
-                    A2uiErrorDetail(
-                        path=f"components.{comp_id or 'unknown'}.{path_str}"
-                        if path_str
-                        else f"components.{comp_id or 'unknown'}",
-                        code=code,
-                        message=msg,
-                    )
-                )
+            component_errors = format_validation_error(
+                e,
+                path_prefix=f"components.{comp_id or 'unknown'}",
+                allow_unknown_extra=allow_unknown,
+                match_jsonschema_missing_path=True,
+            )
+            errors.extend(component_errors)
 
     def _validate_dict_component(
         self,

--- a/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
+++ b/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
@@ -461,10 +461,10 @@ class PayloadValidator(Generic[TComponent, TFunction]):
                 fn_schema = funcs_schema[name]
                 base_schema = cat_schema
         if fn_def is None and name.startswith("@"):
-            from ..catalog.catalog import _is_version_at_least_1_0
+            from ..common.semver import is_at_least_version
 
             ver = getattr(self.catalog, "protocol_version", None)
-            if name == "@index" and ver and _is_version_at_least_1_0(ver):
+            if name == "@index" and ver and is_at_least_version(ver, "1.0"):
                 from ..basic_catalog.v1_0.function_impls import IndexImplementation
 
                 fn_def = IndexImplementation

--- a/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
+++ b/python/a2ui_core/src/a2ui/core/validation/payload_validator.py
@@ -138,12 +138,13 @@ class PayloadValidator(Generic[TComponent, TFunction]):
         comp_type = comp.get("component") or comp.get("type")
 
         if comp_id and isinstance(comp_id, str):
-            from ..catalog.catalog import is_valid_uax31_identifier, _is_version_at_least_1_0
+            from ..catalog.catalog import is_valid_uax31_identifier
+            from ..common.semver import is_at_least_version
 
             ver = getattr(self.catalog, "protocol_version", None)
             if (
                 ver
-                and _is_version_at_least_1_0(ver)
+                and is_at_least_version(ver, "1.0")
                 and not is_valid_uax31_identifier(comp_id)
             ):
                 errors.append(
@@ -372,10 +373,11 @@ class PayloadValidator(Generic[TComponent, TFunction]):
         active_config = self.config
         allow_unknown = active_config.allow_unknown_elements if active_config else False
 
-        from ..catalog.catalog import is_valid_uax31_identifier, _is_version_at_least_1_0
+        from ..catalog.catalog import is_valid_uax31_identifier
+        from ..common.semver import is_at_least_version
 
         ver = getattr(self.catalog, "protocol_version", None)
-        if ver and _is_version_at_least_1_0(ver):
+        if ver and is_at_least_version(ver, "1.0"):
             if not is_valid_uax31_identifier(name):
                 raise A2uiValidationError(
                     f"Function name '{name}' must be a valid UAX #31 identifier",

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -14,6 +14,18 @@
 
 """Unit tests for VersionAdapter, VersionAdapterFactory, and catalog compatibility."""
 
+import pytest
+
+from a2ui.core.common.semver import SemVer
+from a2ui.core.exceptions import A2uiValidationError
+from a2ui.core.processing.operations import (
+    InternalCreateSurfaceOp,
+    InternalDeleteSurfaceOp,
+    InternalOperation,
+    InternalUpdateComponentsOp,
+    InternalUpdateDataModelOp,
+)
+from a2ui.core.schema import ProtocolVersion
 from a2ui.core.processing.adapters import (
     DEFAULT_CATALOG_COMPATIBILITY,
     DEFAULT_PROTOCOL_VERSION,
@@ -21,6 +33,7 @@ from a2ui.core.processing.adapters import (
     V0Point8Adapter,
     V0Point9Adapter,
     V1Point0Adapter,
+    VersionAdapter,
     VersionAdapterFactory,
     is_catalog_version_compatible,
 )
@@ -75,11 +88,31 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible("custom", "Vcustom") is True
     assert is_catalog_version_compatible("custom", "other") is False
 
+    # v0.8 matches
+    assert is_catalog_version_compatible("v0.8", "v0.8") is True
+    assert is_catalog_version_compatible("0.8", "v0.8") is True
+    assert is_catalog_version_compatible("v0.8", "0.8.0") is True
+    assert is_catalog_version_compatible("v0.8", "v0.9") is False
+
+    # ProtocolVersion enum, SemVer object, and bytes inputs
+    assert is_catalog_version_compatible(ProtocolVersion.V1_0, "1.0") is True
+    assert (
+        is_catalog_version_compatible(ProtocolVersion.V0_9, ProtocolVersion.V0_9_1)
+        is True
+    )
+    assert is_catalog_version_compatible(SemVer(1, 0, 0), "1.0") is True
+    assert is_catalog_version_compatible("1.0", SemVer(1, 0, 0)) is True
+    assert is_catalog_version_compatible(SemVer(0, 9, 0), SemVer(0, 9, 1)) is True
+    assert is_catalog_version_compatible(b"v1.0", "v1.0") is True
+    assert is_catalog_version_compatible("v1.0", b"1.0") is True
+
     # Falsy / invalid inputs
     assert is_catalog_version_compatible(None, "v1.0") is False
     assert is_catalog_version_compatible("v1.0", None) is False
     assert is_catalog_version_compatible(None, None) is False
     assert is_catalog_version_compatible("", "") is False
+    assert is_catalog_version_compatible("", "v1.0") is False
+    assert is_catalog_version_compatible("v1.0", "") is False
     assert is_catalog_version_compatible(None, "None") is False
     assert is_catalog_version_compatible("None", None) is False
 
@@ -121,3 +154,307 @@ def test_version_adapter_factory_get_adapter():
     assert adapter_09.is_catalog_compatible("0.9.1") is True
 
     assert DEFAULT_PROTOCOL_VERSION.value == "v0.9"
+
+
+def test_resolve_v1_0_and_extract_operations():
+    """Verifies resolving v1.0 adapter and extracting operations with initial state and surface properties."""
+    payload = {
+        "version": "v1.0",
+        "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": "basic",
+            "sendDataModel": True,
+            "components": [{"id": "root", "component": "Column"}],
+            "dataModel": {
+                "key": "value",
+            },
+        },
+    }
+    adapter = VersionAdapterFactory.resolve_from_payload(payload)
+    assert adapter.version == ProtocolVersion.V1_0
+
+    ops = adapter.extract_operations(payload)
+    assert len(ops) == 3
+    op = ops[0]
+    assert isinstance(op, InternalCreateSurfaceOp)
+    assert op.surface_id == "s1"
+    assert op.theme is None
+    assert op.send_data_model is True
+
+    comp_op = ops[1]
+    assert isinstance(comp_op, InternalUpdateComponentsOp)
+    assert comp_op.surface_id == "s1"
+    assert comp_op.components == [{"id": "root", "component": "Column"}]
+
+    dm_op = ops[2]
+    assert isinstance(dm_op, InternalUpdateDataModelOp)
+    assert dm_op.surface_id == "s1"
+    assert dm_op.path == "/"
+    assert dm_op.value == {"key": "value"}
+
+
+def test_resolve_v0_9_and_extract_create_surface():
+    """Verifies resolving v0.9 adapter and extracting createSurface operations."""
+    payload = {
+        "version": "v0.9",
+        "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": "basic",
+            "theme": {"primaryColor": "#FF0000"},
+        },
+    }
+    adapter = VersionAdapterFactory.resolve_from_payload(payload)
+    assert adapter.version == ProtocolVersion.V0_9
+
+    ops = adapter.extract_operations(payload)
+    assert len(ops) == 1
+    op = ops[0]
+    assert isinstance(op, InternalCreateSurfaceOp)
+    assert op.surface_id == "s1"
+    assert op.theme == {"primaryColor": "#FF0000"}
+
+
+def test_resolve_v0_8_and_normalize_begin_rendering():
+    """Verifies resolving v0.8 adapter and normalizing beginRendering into createSurface operation."""
+    payload = {
+        "version": "v0.8",
+        "beginRendering": {
+            "surfaceId": "s1",
+            "root": "root",
+            "styles": {"primaryColor": "#FF0000"},
+        },
+    }
+    adapter = VersionAdapterFactory.resolve_from_payload(payload)
+    assert adapter.version == ProtocolVersion.V0_8
+
+    ops = adapter.extract_operations(payload)
+    assert len(ops) == 1
+    op = ops[0]
+    assert isinstance(op, InternalCreateSurfaceOp)
+    assert op.surface_id == "s1"
+    assert op.theme == {"primaryColor": "#FF0000"}
+
+
+def test_resolve_unversioned_v0_8_delete_surface():
+    """Verifies resolving unversioned deleteSurface to v0.8 adapter."""
+    payload = {
+        "deleteSurface": {
+            "surfaceId": "s1",
+        },
+    }
+    adapter = VersionAdapterFactory.resolve_from_payload(payload)
+    assert adapter.version == ProtocolVersion.V0_8
+
+    ops = adapter.extract_operations(payload)
+    assert len(ops) == 1
+    op = ops[0]
+    assert isinstance(op, InternalDeleteSurfaceOp)
+    assert op.surface_id == "s1"
+
+
+def test_extract_v0_8_surface_update_and_data_model_update():
+    """Verifies extracting surfaceUpdate and dataModelUpdate operations in v0.8 adapter."""
+    adapter = VersionAdapterFactory.get_adapter("v0.8")
+
+    surface_ops = adapter.extract_operations({
+        "surfaceUpdate": {
+            "surfaceId": "s1",
+            "components": [{
+                "id": "txt1",
+                "component": {"Text": {"text": {"literalString": "Click"}}},
+            }],
+        }
+    })
+    assert len(surface_ops) == 1
+    assert isinstance(surface_ops[0], InternalUpdateComponentsOp)
+    assert surface_ops[0].surface_id == "s1"
+
+    data_ops = adapter.extract_operations({
+        "dataModelUpdate": {
+            "surfaceId": "s1",
+            "path": "/count",
+            "contents": [{"key": "count", "valueNumber": 42}],
+        }
+    })
+    assert len(data_ops) == 1
+    assert isinstance(data_ops[0], InternalUpdateDataModelOp)
+    assert data_ops[0].surface_id == "s1"
+
+
+def test_extract_operations_no_update_action_raises_validation_error():
+    """Verifies that extract_operations raises A2uiValidationError when payload contains no update action."""
+    v08_adapter = VersionAdapterFactory.get_adapter("v0.8")
+    v09_adapter = VersionAdapterFactory.get_adapter("v0.9")
+
+    with pytest.raises(A2uiValidationError, match=r"Invalid v0\.8 message"):
+        v08_adapter.extract_operations({})
+    with pytest.raises(A2uiValidationError, match=r"Invalid v0\.9 message"):
+        v09_adapter.extract_operations({})
+
+
+def test_supports_dynamic_registration():
+    """Verifies dynamic registration of custom version adapters."""
+
+    class CustomAdapter(VersionAdapter):
+
+        @property
+        def version(self) -> str:
+            return "v2.0"
+
+        def extract_operations(
+            self,
+            payload,
+            context=None,
+        ) -> list[InternalOperation]:
+            return [
+                InternalCreateSurfaceOp(
+                    surface_id="s_custom",
+                    catalog_id="custom",
+                )
+            ]
+
+    VersionAdapterFactory.register_adapter(CustomAdapter())
+    resolved = VersionAdapterFactory.get_adapter("v2.0")
+    assert resolved.version == "v2.0"
+
+    ops = resolved.extract_operations({})
+    assert len(ops) == 1
+    assert isinstance(ops[0], InternalCreateSurfaceOp)
+    assert ops[0].surface_id == "s_custom"
+
+
+def test_unrecognized_or_missing_version_strings():
+    """Verifies that unrecognized or missing version strings raise A2uiValidationError."""
+    with pytest.raises(
+        A2uiValidationError, match=r"Unsupported protocol version 'v99\.0'"
+    ):
+        VersionAdapterFactory.get_adapter("v99.0")
+
+    with pytest.raises(A2uiValidationError, match=r"missing a valid 'version' string"):
+        VersionAdapterFactory.resolve_from_payload({})
+
+
+def test_resolves_v0_9_1_version_string_to_v0_9_adapter():
+    """Verifies resolving v0.9.1 version string to v0.9 adapter."""
+    adapter = VersionAdapterFactory.get_adapter("v0.9.1")
+    assert adapter.version == ProtocolVersion.V0_9
+
+    from_payload = VersionAdapterFactory.resolve_from_payload(
+        {"version": "v0.9.1", "createSurface": {"surfaceId": "s1"}}
+    )
+    assert from_payload.version == ProtocolVersion.V0_9
+
+
+def test_batch_payloads():
+    """Verifies resolving adapter and extracting operations from batch array payloads."""
+    payload = [
+        {"version": "v1.0", "createSurface": {"surfaceId": "s1", "catalogId": "basic"}},
+        {"version": "v1.0", "deleteSurface": {"surfaceId": "s1"}},
+    ]
+    adapter = VersionAdapterFactory.resolve_from_payload(payload)
+    assert adapter.version == ProtocolVersion.V1_0
+
+    ops = adapter.extract_operations(payload)
+    assert len(ops) == 2
+    assert isinstance(ops[0], InternalCreateSurfaceOp)
+    assert isinstance(ops[1], InternalDeleteSurfaceOp)
+
+
+def test_wrapped_messages_payload():
+    """Verifies resolving adapter and extracting operations from wrapped { messages: [...] } payload."""
+    payload = {
+        "messages": [
+            {"version": "v1.0", "createSurface": {"surfaceId": "s1"}},
+            {
+                "version": "v1.0",
+                "updateComponents": {
+                    "surfaceId": "s1",
+                    "components": [{"id": "root", "component": "Column"}],
+                },
+            },
+        ]
+    }
+    adapter = VersionAdapterFactory.resolve_from_payload(payload)
+    assert adapter.version == ProtocolVersion.V1_0
+
+    ops = adapter.extract_operations(payload)
+    assert len(ops) == 2
+    assert isinstance(ops[0], InternalCreateSurfaceOp)
+    assert isinstance(ops[1], InternalUpdateComponentsOp)
+
+
+def test_extract_operations_v1_0_actions():
+    """Verifies extracting updateComponents, updateDataModel, and deleteSurface operations."""
+    adapter = VersionAdapterFactory.get_adapter("v1.0")
+
+    uc_ops = adapter.extract_operations({
+        "version": "v1.0",
+        "updateComponents": {
+            "surfaceId": "s1",
+            "components": [{"id": "c1", "component": "Text", "text": "Hi"}],
+        },
+    })
+    assert len(uc_ops) == 1
+    assert isinstance(uc_ops[0], InternalUpdateComponentsOp)
+    assert uc_ops[0].surface_id == "s1"
+    assert uc_ops[0].components == [{"id": "c1", "component": "Text", "text": "Hi"}]
+
+    ud_ops = adapter.extract_operations({
+        "version": "v1.0",
+        "updateDataModel": {
+            "surfaceId": "s1",
+            "path": "/user/name",
+            "value": "Alice",
+        },
+    })
+    assert len(ud_ops) == 1
+    assert isinstance(ud_ops[0], InternalUpdateDataModelOp)
+    assert ud_ops[0].surface_id == "s1"
+    assert ud_ops[0].path == "/user/name"
+    assert ud_ops[0].value == "Alice"
+
+    ds_ops = adapter.extract_operations({
+        "version": "v1.0",
+        "deleteSurface": {
+            "surfaceId": "s1",
+        },
+    })
+    assert len(ds_ops) == 1
+    assert isinstance(ds_ops[0], InternalDeleteSurfaceOp)
+    assert ds_ops[0].surface_id == "s1"
+
+
+def test_resolve_from_payload_invalid_inputs():
+    """Verifies that null, primitive, or non-object payloads in resolve_from_payload raise A2uiValidationError."""
+    invalid_payloads = [None, 42, "v1.0", [], {"version": 123}, {"version": None}]
+    for invalid in invalid_payloads:
+        with pytest.raises(
+            A2uiValidationError, match=r"missing a valid 'version' string"
+        ):
+            VersionAdapterFactory.resolve_from_payload(invalid)
+
+
+def test_extract_operations_non_object():
+    """Verifies returning empty list when extract_operations is called with non-object/None values."""
+    adapter = VersionAdapterFactory.get_adapter("v1.0")
+    assert adapter.extract_operations(None) == []
+    assert adapter.extract_operations("not-an-object") == []
+    assert adapter.extract_operations(123) == []
+
+
+def test_version_adapter_factory_get_adapter_formatting_variants():
+    """Verifies resolving adapters by canonical and formatted version strings."""
+    assert VersionAdapterFactory.get_adapter("v1.0").version == ProtocolVersion.V1_0
+    assert VersionAdapterFactory.get_adapter("1.0").version == ProtocolVersion.V1_0
+    assert VersionAdapterFactory.get_adapter("1.0.0").version == ProtocolVersion.V1_0
+    assert VersionAdapterFactory.get_adapter("v1_0").version == ProtocolVersion.V1_0
+    assert VersionAdapterFactory.get_adapter("V1.0").version == ProtocolVersion.V1_0
+    assert VersionAdapterFactory.get_adapter("v0.9.1").version == ProtocolVersion.V0_9
+    assert VersionAdapterFactory.get_adapter("0.9.1").version == ProtocolVersion.V0_9
+    assert VersionAdapterFactory.get_adapter("v0.9").version == ProtocolVersion.V0_9
+    assert VersionAdapterFactory.get_adapter("0.9").version == ProtocolVersion.V0_9
+    assert VersionAdapterFactory.get_adapter("v0.8").version == ProtocolVersion.V0_8
+    assert VersionAdapterFactory.get_adapter("0.8").version == ProtocolVersion.V0_8
+
+    with pytest.raises(A2uiValidationError, match="Unsupported protocol version"):
+        VersionAdapterFactory.get_adapter("v1.1")

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -339,6 +339,11 @@ def test_supports_dynamic_registration():
     VersionAdapterFactory.register_adapter(CustomAdapter())
     resolved = VersionAdapterFactory.get_adapter("v2.0")
     assert resolved.version == "v2.0"
+    # Verify format-tolerant retrieval of dynamically registered adapters
+    assert VersionAdapterFactory.get_adapter("2.0").version == "v2.0"
+    assert VersionAdapterFactory.get_adapter("2.0.0").version == "v2.0"
+    assert VersionAdapterFactory.get_adapter("v2.0.0").version == "v2.0"
+    assert VersionAdapterFactory.get_adapter("V2.0").version == "v2.0"
 
     ops = resolved.extract_operations({})
     assert len(ops) == 1
@@ -349,7 +354,8 @@ def test_supports_dynamic_registration():
 def test_unrecognized_or_missing_version_strings():
     """Verifies that unrecognized or missing version strings raise A2uiValidationError."""
     with pytest.raises(
-        A2uiValidationError, match=r"Unsupported protocol version 'v99\.0'"
+        A2uiValidationError,
+        match=r"Unsupported protocol version 'v99\.0'.*Supported versions: .*v2\.0",
     ):
         VersionAdapterFactory.get_adapter("v99.0")
 

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -112,11 +112,14 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible("1.0", SemVer(1, 0, 0)) is True
     assert is_catalog_version_compatible(SemVer(0, 9, 0), SemVer(0, 9, 1)) is True
 
-    # Patch version compatibility for SemVer >= 1.0.0
+    # Patch and pre-release version compatibility for SemVer >= 1.0.0
     assert is_catalog_version_compatible("v1.0.1", "v1.0") is True
     assert is_catalog_version_compatible("v1.0", "v1.0.1") is True
     assert is_catalog_version_compatible("1.0.2", "1.0.1") is True
-    assert is_catalog_version_compatible("v1.0.1-alpha", "v1.0") is False
+    assert is_catalog_version_compatible("v1.0.1-alpha", "v1.0") is True
+    assert is_catalog_version_compatible("v1.0.0-beta.1", "v1.0.0-rc.2") is True
+    assert is_catalog_version_compatible("v1.2.0-beta", "v1.0.0") is True
+    assert is_catalog_version_compatible("v1.0.0-alpha", "v2.0.0-alpha") is False
     assert is_catalog_version_compatible("v1.1.0", "v1.0.0") is True
 
     # Falsy / invalid inputs
@@ -272,26 +275,32 @@ def test_extract_v0_8_surface_update_and_data_model_update():
     """Verifies extracting surfaceUpdate and dataModelUpdate operations in v0.8 adapter."""
     adapter = VersionAdapterFactory.get_adapter("v0.8")
 
-    surface_ops = adapter.extract_operations({
-        "surfaceUpdate": {
-            "surfaceId": "s1",
-            "components": [{
-                "id": "txt1",
-                "component": {"Text": {"text": {"literalString": "Click"}}},
-            }],
+    surface_ops = adapter.extract_operations(
+        {
+            "surfaceUpdate": {
+                "surfaceId": "s1",
+                "components": [
+                    {
+                        "id": "txt1",
+                        "component": {"Text": {"text": {"literalString": "Click"}}},
+                    }
+                ],
+            }
         }
-    })
+    )
     assert len(surface_ops) == 1
     assert isinstance(surface_ops[0], InternalUpdateComponentsOp)
     assert surface_ops[0].surface_id == "s1"
 
-    data_ops = adapter.extract_operations({
-        "dataModelUpdate": {
-            "surfaceId": "s1",
-            "path": "/count",
-            "contents": [{"key": "count", "valueNumber": 42}],
+    data_ops = adapter.extract_operations(
+        {
+            "dataModelUpdate": {
+                "surfaceId": "s1",
+                "path": "/count",
+                "contents": [{"key": "count", "valueNumber": 42}],
+            }
         }
-    })
+    )
     assert len(data_ops) == 1
     assert isinstance(data_ops[0], InternalUpdateDataModelOp)
     assert data_ops[0].surface_id == "s1"
@@ -315,27 +324,30 @@ def test_extract_operations_invalid_version_raises_validation_error():
         A2uiValidationError,
         match=r"messages\.0\.version: Input should be one of \['v0\.9', 'v0\.9\.1'\]",
     ):
-        v09_adapter.extract_operations({
-            "version": "v1.0",
-            "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
-        })
+        v09_adapter.extract_operations(
+            {
+                "version": "v1.0",
+                "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
+            }
+        )
 
     v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
     with pytest.raises(
         A2uiValidationError,
         match=r"messages\.0\.version: Input should be 'v1\.0'",
     ):
-        v10_adapter.extract_operations({
-            "version": "v0.9",
-            "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
-        })
+        v10_adapter.extract_operations(
+            {
+                "version": "v0.9",
+                "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
+            }
+        )
 
 
 def test_supports_dynamic_registration():
     """Verifies dynamic registration of custom version adapters."""
 
     class CustomAdapter(VersionAdapter):
-
         @property
         def version(self) -> str:
             return "v2.0"
@@ -435,38 +447,44 @@ def test_extract_operations_v1_0_actions():
     """Verifies extracting updateComponents, updateDataModel, and deleteSurface operations."""
     adapter = VersionAdapterFactory.get_adapter("v1.0")
 
-    uc_ops = adapter.extract_operations({
-        "version": "v1.0",
-        "updateComponents": {
-            "surfaceId": "s1",
-            "components": [{"id": "c1", "component": "Text", "text": "Hi"}],
-        },
-    })
+    uc_ops = adapter.extract_operations(
+        {
+            "version": "v1.0",
+            "updateComponents": {
+                "surfaceId": "s1",
+                "components": [{"id": "c1", "component": "Text", "text": "Hi"}],
+            },
+        }
+    )
     assert len(uc_ops) == 1
     assert isinstance(uc_ops[0], InternalUpdateComponentsOp)
     assert uc_ops[0].surface_id == "s1"
     assert uc_ops[0].components == [{"id": "c1", "component": "Text", "text": "Hi"}]
 
-    ud_ops = adapter.extract_operations({
-        "version": "v1.0",
-        "updateDataModel": {
-            "surfaceId": "s1",
-            "path": "/user/name",
-            "value": "Alice",
-        },
-    })
+    ud_ops = adapter.extract_operations(
+        {
+            "version": "v1.0",
+            "updateDataModel": {
+                "surfaceId": "s1",
+                "path": "/user/name",
+                "value": "Alice",
+            },
+        }
+    )
     assert len(ud_ops) == 1
     assert isinstance(ud_ops[0], InternalUpdateDataModelOp)
     assert ud_ops[0].surface_id == "s1"
     assert ud_ops[0].path == "/user/name"
     assert ud_ops[0].value == "Alice"
 
-    ds_ops = adapter.extract_operations({
-        "version": "v1.0",
-        "deleteSurface": {
-            "surfaceId": "s1",
-        },
-    })
+    ds_ops = adapter.extract_operations(
+        {
+            "version": "v1.0",
+            "deleteSurface": {
+                "surfaceId": "s1",
+            },
+        }
+    )
     assert len(ds_ops) == 1
     assert isinstance(ds_ops[0], InternalDeleteSurfaceOp)
     assert ds_ops[0].surface_id == "s1"
@@ -530,36 +548,44 @@ def test_extract_operations_cross_version_action_rejection():
         A2uiValidationError,
         match=r"action 'beginRendering' is not supported in protocol version v0.9",
     ):
-        v09_adapter.extract_operations({
-            "version": "v0.9",
-            "beginRendering": {"surfaceId": "s1"},
-        })
+        v09_adapter.extract_operations(
+            {
+                "version": "v0.9",
+                "beginRendering": {"surfaceId": "s1"},
+            }
+        )
 
     v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
     with pytest.raises(
         A2uiValidationError,
         match=r"action 'beginRendering' is not supported in protocol version v1.0",
     ):
-        v10_adapter.extract_operations({
-            "version": "v1.0",
-            "beginRendering": {"surfaceId": "s1"},
-        })
+        v10_adapter.extract_operations(
+            {
+                "version": "v1.0",
+                "beginRendering": {"surfaceId": "s1"},
+            }
+        )
 
     v08_adapter = VersionAdapterFactory.get_adapter("v0.8")
     with pytest.raises(
         A2uiValidationError,
         match=r"action 'createSurface' is not supported in protocol version v0.8",
     ):
-        v08_adapter.extract_operations({
-            "createSurface": {"surfaceId": "s1"},
-        })
+        v08_adapter.extract_operations(
+            {
+                "createSurface": {"surfaceId": "s1"},
+            }
+        )
 
     # Completely unknown action (not in any known adapter)
     with pytest.raises(
         A2uiValidationError,
         match=r"message must contain exactly one update action",
     ):
-        v09_adapter.extract_operations({
-            "version": "v0.9",
-            "completelyUnknownAction": {"surfaceId": "s1"},
-        })
+        v09_adapter.extract_operations(
+            {
+                "version": "v0.9",
+                "completelyUnknownAction": {"surfaceId": "s1"},
+            }
+        )

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -275,32 +275,26 @@ def test_extract_v0_8_surface_update_and_data_model_update():
     """Verifies extracting surfaceUpdate and dataModelUpdate operations in v0.8 adapter."""
     adapter = VersionAdapterFactory.get_adapter("v0.8")
 
-    surface_ops = adapter.extract_operations(
-        {
-            "surfaceUpdate": {
-                "surfaceId": "s1",
-                "components": [
-                    {
-                        "id": "txt1",
-                        "component": {"Text": {"text": {"literalString": "Click"}}},
-                    }
-                ],
-            }
+    surface_ops = adapter.extract_operations({
+        "surfaceUpdate": {
+            "surfaceId": "s1",
+            "components": [{
+                "id": "txt1",
+                "component": {"Text": {"text": {"literalString": "Click"}}},
+            }],
         }
-    )
+    })
     assert len(surface_ops) == 1
     assert isinstance(surface_ops[0], InternalUpdateComponentsOp)
     assert surface_ops[0].surface_id == "s1"
 
-    data_ops = adapter.extract_operations(
-        {
-            "dataModelUpdate": {
-                "surfaceId": "s1",
-                "path": "/count",
-                "contents": [{"key": "count", "valueNumber": 42}],
-            }
+    data_ops = adapter.extract_operations({
+        "dataModelUpdate": {
+            "surfaceId": "s1",
+            "path": "/count",
+            "contents": [{"key": "count", "valueNumber": 42}],
         }
-    )
+    })
     assert len(data_ops) == 1
     assert isinstance(data_ops[0], InternalUpdateDataModelOp)
     assert data_ops[0].surface_id == "s1"
@@ -324,30 +318,27 @@ def test_extract_operations_invalid_version_raises_validation_error():
         A2uiValidationError,
         match=r"version: Input should be one of \['v0\.9', 'v0\.9\.1'\]",
     ):
-        v09_adapter.extract_operations(
-            {
-                "version": "v1.0",
-                "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
-            }
-        )
+        v09_adapter.extract_operations({
+            "version": "v1.0",
+            "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
+        })
 
     v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
     with pytest.raises(
         A2uiValidationError,
         match=r"version: Input should be 'v1\.0'",
     ):
-        v10_adapter.extract_operations(
-            {
-                "version": "v0.9",
-                "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
-            }
-        )
+        v10_adapter.extract_operations({
+            "version": "v0.9",
+            "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
+        })
 
 
 def test_supports_dynamic_registration():
     """Verifies dynamic registration of custom version adapters."""
 
     class CustomAdapter(VersionAdapter):
+
         @property
         def version(self) -> str:
             return "v2.0"
@@ -447,44 +438,38 @@ def test_extract_operations_v1_0_actions():
     """Verifies extracting updateComponents, updateDataModel, and deleteSurface operations."""
     adapter = VersionAdapterFactory.get_adapter("v1.0")
 
-    uc_ops = adapter.extract_operations(
-        {
-            "version": "v1.0",
-            "updateComponents": {
-                "surfaceId": "s1",
-                "components": [{"id": "c1", "component": "Text", "text": "Hi"}],
-            },
-        }
-    )
+    uc_ops = adapter.extract_operations({
+        "version": "v1.0",
+        "updateComponents": {
+            "surfaceId": "s1",
+            "components": [{"id": "c1", "component": "Text", "text": "Hi"}],
+        },
+    })
     assert len(uc_ops) == 1
     assert isinstance(uc_ops[0], InternalUpdateComponentsOp)
     assert uc_ops[0].surface_id == "s1"
     assert uc_ops[0].components == [{"id": "c1", "component": "Text", "text": "Hi"}]
 
-    ud_ops = adapter.extract_operations(
-        {
-            "version": "v1.0",
-            "updateDataModel": {
-                "surfaceId": "s1",
-                "path": "/user/name",
-                "value": "Alice",
-            },
-        }
-    )
+    ud_ops = adapter.extract_operations({
+        "version": "v1.0",
+        "updateDataModel": {
+            "surfaceId": "s1",
+            "path": "/user/name",
+            "value": "Alice",
+        },
+    })
     assert len(ud_ops) == 1
     assert isinstance(ud_ops[0], InternalUpdateDataModelOp)
     assert ud_ops[0].surface_id == "s1"
     assert ud_ops[0].path == "/user/name"
     assert ud_ops[0].value == "Alice"
 
-    ds_ops = adapter.extract_operations(
-        {
-            "version": "v1.0",
-            "deleteSurface": {
-                "surfaceId": "s1",
-            },
-        }
-    )
+    ds_ops = adapter.extract_operations({
+        "version": "v1.0",
+        "deleteSurface": {
+            "surfaceId": "s1",
+        },
+    })
     assert len(ds_ops) == 1
     assert isinstance(ds_ops[0], InternalDeleteSurfaceOp)
     assert ds_ops[0].surface_id == "s1"
@@ -548,44 +533,36 @@ def test_extract_operations_cross_version_action_rejection():
         A2uiValidationError,
         match=r"action 'beginRendering' is not supported in protocol version v0.9",
     ):
-        v09_adapter.extract_operations(
-            {
-                "version": "v0.9",
-                "beginRendering": {"surfaceId": "s1"},
-            }
-        )
+        v09_adapter.extract_operations({
+            "version": "v0.9",
+            "beginRendering": {"surfaceId": "s1"},
+        })
 
     v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
     with pytest.raises(
         A2uiValidationError,
         match=r"action 'beginRendering' is not supported in protocol version v1.0",
     ):
-        v10_adapter.extract_operations(
-            {
-                "version": "v1.0",
-                "beginRendering": {"surfaceId": "s1"},
-            }
-        )
+        v10_adapter.extract_operations({
+            "version": "v1.0",
+            "beginRendering": {"surfaceId": "s1"},
+        })
 
     v08_adapter = VersionAdapterFactory.get_adapter("v0.8")
     with pytest.raises(
         A2uiValidationError,
         match=r"action 'createSurface' is not supported in protocol version v0.8",
     ):
-        v08_adapter.extract_operations(
-            {
-                "createSurface": {"surfaceId": "s1"},
-            }
-        )
+        v08_adapter.extract_operations({
+            "createSurface": {"surfaceId": "s1"},
+        })
 
     # Completely unknown action (not in any known adapter)
     with pytest.raises(
         A2uiValidationError,
         match=r"message must contain exactly one update action",
     ):
-        v09_adapter.extract_operations(
-            {
-                "version": "v0.9",
-                "completelyUnknownAction": {"surfaceId": "s1"},
-            }
-        )
+        v09_adapter.extract_operations({
+            "version": "v0.9",
+            "completelyUnknownAction": {"surfaceId": "s1"},
+        })

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -1,0 +1,123 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for VersionAdapter, VersionAdapterFactory, and catalog compatibility."""
+
+from a2ui.core.processing.adapters import (
+    DEFAULT_CATALOG_COMPATIBILITY,
+    DEFAULT_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    V0Point8Adapter,
+    V0Point9Adapter,
+    V1Point0Adapter,
+    VersionAdapterFactory,
+    is_catalog_version_compatible,
+)
+
+
+def test_supported_protocol_versions():
+    """Verifies membership of canonical protocol versions in SUPPORTED_PROTOCOL_VERSIONS."""
+    assert "1.0" in SUPPORTED_PROTOCOL_VERSIONS
+    assert "0.9.1" in SUPPORTED_PROTOCOL_VERSIONS
+    assert "0.9" in SUPPORTED_PROTOCOL_VERSIONS
+    assert "0.8" in SUPPORTED_PROTOCOL_VERSIONS
+    assert "1.1" not in SUPPORTED_PROTOCOL_VERSIONS
+    assert "0.9" in DEFAULT_CATALOG_COMPATIBILITY.get("0.9.1", frozenset())
+
+
+def test_is_catalog_version_compatible():
+    """Tests catalog version compatibility for equal, backward-compatible, and formatting variants."""
+    # Exact canonical matches across formatting variations
+    assert is_catalog_version_compatible("v1.0", "v1.0") is True
+    assert is_catalog_version_compatible("V1.0", "v1.0") is True
+    assert is_catalog_version_compatible("v1.0", "V1.0") is True
+    assert is_catalog_version_compatible("1.0", "v1.0") is True
+    assert is_catalog_version_compatible("v1.0.0", "1.0") is True
+    assert is_catalog_version_compatible("v1_0", "1.0.0") is True
+    assert is_catalog_version_compatible("v0.9", "v0.9") is True
+    assert is_catalog_version_compatible("V0.9", "0.9") is True
+    assert is_catalog_version_compatible("0.9", "V0.9") is True
+    assert is_catalog_version_compatible("v0_9", "0.9") is True
+    assert is_catalog_version_compatible("v0.9.1", "0.9.1") is True
+    assert is_catalog_version_compatible("v0_9_1", "0.9.1") is True
+
+    # Backward compatibility between 0.9 and 0.9.1
+    assert is_catalog_version_compatible("v0.9", "v0.9.1") is True
+    assert is_catalog_version_compatible("v0.9.1", "v0.9") is True
+
+    # Unsupported future or cross-major versions are rejected
+    assert is_catalog_version_compatible("v1.0", "v1.1") is False
+    assert is_catalog_version_compatible("v1.1", "v1.0") is False
+    assert is_catalog_version_compatible("v1.0", "v2.0") is False
+    assert is_catalog_version_compatible("v0.9", "v1.0") is False
+    assert is_catalog_version_compatible("v1.0", "v0.9") is False
+
+    # Custom compatibility map override
+    custom_map = {
+        "1.1": frozenset({"1.0", "1.1"}),
+    }
+    assert is_catalog_version_compatible("v1.0", "v1.1", custom_map) is True
+    assert is_catalog_version_compatible("v0.9", "v1.1", custom_map) is False
+
+    # Custom non-semver fallback
+    assert is_catalog_version_compatible("Vcustom", "vcustom") is True
+    assert is_catalog_version_compatible("custom", "Vcustom") is True
+    assert is_catalog_version_compatible("custom", "other") is False
+
+    # Falsy / invalid inputs
+    assert is_catalog_version_compatible(None, "v1.0") is False
+    assert is_catalog_version_compatible("v1.0", None) is False
+    assert is_catalog_version_compatible(None, None) is False
+    assert is_catalog_version_compatible("", "") is False
+    assert is_catalog_version_compatible(None, "None") is False
+    assert is_catalog_version_compatible("None", None) is False
+
+
+def test_adapter_catalog_compatibility_methods():
+    """Tests compatible_catalog_versions and is_catalog_compatible on adapter instances."""
+    v08 = V0Point8Adapter()
+    assert v08.compatible_catalog_versions == frozenset({"0.8"})
+    assert v08.is_catalog_compatible("v0.8") is True
+    assert v08.is_catalog_compatible("0.8") is True
+    assert v08.is_catalog_compatible("v0.9") is False
+
+    v09 = V0Point9Adapter()
+    assert v09.compatible_catalog_versions == frozenset({"0.9", "0.9.1"})
+    assert v09.is_catalog_compatible("v0.9") is True
+    assert v09.is_catalog_compatible("v0.9.1") is True
+    assert v09.is_catalog_compatible("0.9") is True
+    assert v09.is_catalog_compatible("0.9.1") is True
+    assert v09.is_catalog_compatible("v1.0") is False
+
+    v10 = V1Point0Adapter()
+    assert v10.compatible_catalog_versions == frozenset({"1.0"})
+    assert v10.is_catalog_compatible("v1.0") is True
+    assert v10.is_catalog_compatible("1.0.0") is True
+    assert v10.is_catalog_compatible("v1_0") is True
+    assert v10.is_catalog_compatible("v0.9") is False
+    assert v10.is_catalog_compatible("v1.1") is False
+    assert v10.is_catalog_compatible(None) is False
+
+
+def test_version_adapter_factory_get_adapter():
+    """Verifies that VersionAdapterFactory resolves adapters and checks compatibility."""
+    adapter = VersionAdapterFactory.get_adapter("v1.0")
+    assert adapter.version.value == "v1.0"
+    assert adapter.is_catalog_compatible("1.0") is True
+
+    adapter_09 = VersionAdapterFactory.get_adapter("v0.9.1")
+    assert adapter_09.is_catalog_compatible("0.9") is True
+    assert adapter_09.is_catalog_compatible("0.9.1") is True
+
+    assert DEFAULT_PROTOCOL_VERSION.value == "v0.9"

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -102,7 +102,7 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible("v0.8", "0.8.0") is True
     assert is_catalog_version_compatible("v0.8", "v0.9") is False
 
-    # ProtocolVersion enum, SemVer object, and bytes inputs
+    # ProtocolVersion enum and SemVer object inputs
     assert is_catalog_version_compatible(ProtocolVersion.V1_0, "1.0") is True
     assert (
         is_catalog_version_compatible(ProtocolVersion.V0_9, ProtocolVersion.V0_9_1)
@@ -111,8 +111,6 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible(SemVer(1, 0, 0), "1.0") is True
     assert is_catalog_version_compatible("1.0", SemVer(1, 0, 0)) is True
     assert is_catalog_version_compatible(SemVer(0, 9, 0), SemVer(0, 9, 1)) is True
-    assert is_catalog_version_compatible(b"v1.0", "v1.0") is True
-    assert is_catalog_version_compatible("v1.0", b"1.0") is True
 
     # Patch version compatibility for SemVer >= 1.0.0
     assert is_catalog_version_compatible("v1.0.1", "v1.0") is True

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -292,6 +292,29 @@ def test_extract_operations_no_update_action_raises_validation_error():
         v09_adapter.extract_operations({})
 
 
+def test_extract_operations_invalid_version_raises_validation_error():
+    """Verifies that extract_operations validates version against compatible_catalog_versions."""
+    v09_adapter = VersionAdapterFactory.get_adapter("v0.9")
+    with pytest.raises(
+        A2uiValidationError,
+        match=r"messages\.0\.version: Input should be one of \['v0\.9', 'v0\.9\.1'\]",
+    ):
+        v09_adapter.extract_operations({
+            "version": "v1.0",
+            "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
+        })
+
+    v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
+    with pytest.raises(
+        A2uiValidationError,
+        match=r"messages\.0\.version: Input should be 'v1\.0'",
+    ):
+        v10_adapter.extract_operations({
+            "version": "v0.9",
+            "createSurface": {"surfaceId": "s1", "catalogId": "c1"},
+        })
+
+
 def test_supports_dynamic_registration():
     """Verifies dynamic registration of custom version adapters."""
 

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -322,7 +322,7 @@ def test_extract_operations_invalid_version_raises_validation_error():
     v09_adapter = VersionAdapterFactory.get_adapter("v0.9")
     with pytest.raises(
         A2uiValidationError,
-        match=r"messages\.0\.version: Input should be one of \['v0\.9', 'v0\.9\.1'\]",
+        match=r"version: Input should be one of \['v0\.9', 'v0\.9\.1'\]",
     ):
         v09_adapter.extract_operations(
             {
@@ -334,7 +334,7 @@ def test_extract_operations_invalid_version_raises_validation_error():
     v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
     with pytest.raises(
         A2uiValidationError,
-        match=r"messages\.0\.version: Input should be 'v1\.0'",
+        match=r"version: Input should be 'v1\.0'",
     ):
         v10_adapter.extract_operations(
             {

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -481,3 +481,60 @@ def test_version_adapter_factory_get_adapter_formatting_variants():
 
     with pytest.raises(A2uiValidationError, match="Unsupported protocol version"):
         VersionAdapterFactory.get_adapter("v1.1")
+
+
+def test_version_adapter_factory_all_known_actions():
+    """Verifies that all_known_actions returns an aggregated set of valid actions across registered adapters."""
+    actions = VersionAdapterFactory.all_known_actions()
+    assert isinstance(actions, frozenset)
+    # v0.8 actions
+    assert "beginRendering" in actions
+    assert "surfaceUpdate" in actions
+    assert "dataModelUpdate" in actions
+    # v0.9 actions
+    assert "createSurface" in actions
+    assert "updateComponents" in actions
+    assert "updateDataModel" in actions
+    assert "deleteSurface" in actions
+
+
+def test_extract_operations_cross_version_action_rejection():
+    """Verifies that sending a cross-version action actively raises A2uiValidationError."""
+    v09_adapter = VersionAdapterFactory.get_adapter("v0.9")
+    with pytest.raises(
+        A2uiValidationError,
+        match=r"action 'beginRendering' is not supported in protocol version v0.9",
+    ):
+        v09_adapter.extract_operations({
+            "version": "v0.9",
+            "beginRendering": {"surfaceId": "s1"},
+        })
+
+    v10_adapter = VersionAdapterFactory.get_adapter("v1.0")
+    with pytest.raises(
+        A2uiValidationError,
+        match=r"action 'beginRendering' is not supported in protocol version v1.0",
+    ):
+        v10_adapter.extract_operations({
+            "version": "v1.0",
+            "beginRendering": {"surfaceId": "s1"},
+        })
+
+    v08_adapter = VersionAdapterFactory.get_adapter("v0.8")
+    with pytest.raises(
+        A2uiValidationError,
+        match=r"action 'createSurface' is not supported in protocol version v0.8",
+    ):
+        v08_adapter.extract_operations({
+            "createSurface": {"surfaceId": "s1"},
+        })
+
+    # Completely unknown action (not in any known adapter)
+    with pytest.raises(
+        A2uiValidationError,
+        match=r"message must contain exactly one update action",
+    ):
+        v09_adapter.extract_operations({
+            "version": "v0.9",
+            "completelyUnknownAction": {"surfaceId": "s1"},
+        })

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -77,9 +77,9 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible("v0.9", "v0.9.1") is True
     assert is_catalog_version_compatible("v0.9.1", "v0.9") is True
 
-    # Unsupported future or cross-major versions are rejected
-    assert is_catalog_version_compatible("v1.0", "v1.1") is False
-    assert is_catalog_version_compatible("v1.1", "v1.0") is False
+    # Major versions match for SemVer >= 1.0.0
+    assert is_catalog_version_compatible("v1.0", "v1.1") is True
+    assert is_catalog_version_compatible("v1.1", "v1.0") is True
     assert is_catalog_version_compatible("v1.0", "v2.0") is False
     assert is_catalog_version_compatible("v0.9", "v1.0") is False
     assert is_catalog_version_compatible("v1.0", "v0.9") is False
@@ -119,7 +119,7 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible("v1.0", "v1.0.1") is True
     assert is_catalog_version_compatible("1.0.2", "1.0.1") is True
     assert is_catalog_version_compatible("v1.0.1-alpha", "v1.0") is False
-    assert is_catalog_version_compatible("v1.1.0", "v1.0.0") is False
+    assert is_catalog_version_compatible("v1.1.0", "v1.0.0") is True
 
     # Falsy / invalid inputs
     assert is_catalog_version_compatible(None, "v1.0") is False
@@ -156,7 +156,8 @@ def test_adapter_catalog_compatibility_methods():
     assert v10.is_catalog_compatible("1.0.0") is True
     assert v10.is_catalog_compatible("v1_0") is True
     assert v10.is_catalog_compatible("v0.9") is False
-    assert v10.is_catalog_compatible("v1.1") is False
+    assert v10.is_catalog_compatible("v1.1") is True
+    assert v10.is_catalog_compatible("v2.0") is False
     assert v10.is_catalog_compatible(None) is False
 
 

--- a/python/a2ui_core/tests/test_adapters.py
+++ b/python/a2ui_core/tests/test_adapters.py
@@ -39,6 +39,14 @@ from a2ui.core.processing.adapters import (
 )
 
 
+@pytest.fixture(autouse=True)
+def reset_adapter_factory():
+    """Isolates tests by restoring VersionAdapterFactory._adapters after each test."""
+    orig_adapters = dict(VersionAdapterFactory._adapters)
+    yield
+    VersionAdapterFactory._adapters = orig_adapters
+
+
 def test_supported_protocol_versions():
     """Verifies membership of canonical protocol versions in SUPPORTED_PROTOCOL_VERSIONS."""
     assert "1.0" in SUPPORTED_PROTOCOL_VERSIONS
@@ -106,6 +114,13 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible(b"v1.0", "v1.0") is True
     assert is_catalog_version_compatible("v1.0", b"1.0") is True
 
+    # Patch version compatibility for SemVer >= 1.0.0
+    assert is_catalog_version_compatible("v1.0.1", "v1.0") is True
+    assert is_catalog_version_compatible("v1.0", "v1.0.1") is True
+    assert is_catalog_version_compatible("1.0.2", "1.0.1") is True
+    assert is_catalog_version_compatible("v1.0.1-alpha", "v1.0") is False
+    assert is_catalog_version_compatible("v1.1.0", "v1.0.0") is False
+
     # Falsy / invalid inputs
     assert is_catalog_version_compatible(None, "v1.0") is False
     assert is_catalog_version_compatible("v1.0", None) is False
@@ -115,6 +130,8 @@ def test_is_catalog_version_compatible():
     assert is_catalog_version_compatible("v1.0", "") is False
     assert is_catalog_version_compatible(None, "None") is False
     assert is_catalog_version_compatible("None", None) is False
+    assert is_catalog_version_compatible({}, {}) is False
+    assert is_catalog_version_compatible([], []) is False
 
 
 def test_adapter_catalog_compatibility_methods():
@@ -355,7 +372,10 @@ def test_unrecognized_or_missing_version_strings():
     """Verifies that unrecognized or missing version strings raise A2uiValidationError."""
     with pytest.raises(
         A2uiValidationError,
-        match=r"Unsupported protocol version 'v99\.0'.*Supported versions: .*v2\.0",
+        match=(
+            r"Unsupported protocol version 'v99\.0'\. Supported versions: v0\.8, v0\.9,"
+            r" v0\.9\.1, v1\.0\."
+        ),
     ):
         VersionAdapterFactory.get_adapter("v99.0")
 

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -23,8 +23,8 @@ import yaml
 from a2ui.core.catalog import Catalog
 from a2ui.core.basic_catalog import v0_8, v0_9, v1_0
 from a2ui.core.schema import ProtocolVersion
-from a2ui.core.processing import MessageProcessor
-from a2ui.core.validation import STRICT_VALIDATION, ValidationConfig
+from a2ui.core.processing import MessageProcessor, MessageProcessorOptions
+from a2ui.core.validation import STRICT_VALIDATION
 from a2ui.core.exceptions import (
     A2uiError,
     A2uiParseError,
@@ -551,7 +551,9 @@ def _assert_expected_surface_state(
 def validate_pure_validation_case(case: dict[str, Any]) -> None:
     catalogs = get_catalogs_for_test_case(case)
     val_config = STRICT_VALIDATION
-    processor = MessageProcessor(catalogs, validation_config=val_config)
+    processor = MessageProcessor(
+        catalogs, options=MessageProcessorOptions(validation_config=val_config)
+    )
 
     steps = case.get("steps")
     if not steps:
@@ -593,7 +595,9 @@ def validate_process_messages_case(case: dict[str, Any]) -> None:
         or case.get("options", {}).get("strict_mode")
     )
     val_config = STRICT_VALIDATION if is_strict else None
-    processor = MessageProcessor(catalogs, validation_config=val_config)
+    processor = MessageProcessor(
+        catalogs, options=MessageProcessorOptions(validation_config=val_config)
+    )
 
     messages = case.get("messages") or (
         [case["payload"]] if "payload" in case else None

--- a/python/a2ui_core/tests/test_conformance.py
+++ b/python/a2ui_core/tests/test_conformance.py
@@ -272,6 +272,7 @@ def get_catalogs_for_test_case(case: dict[str, Any]) -> list[Any]:
                             protocol_version=p_ver,
                             components=list(basic_catalog.components.values()),
                         )
+                    catalogs_map[c_id] = cat
                     specified_catalogs.append(cat)
     if "catalogPaths" in case and isinstance(case["catalogPaths"], list):
         for p in case["catalogPaths"]:
@@ -859,7 +860,7 @@ def validate_handle_rpc_case(case: dict[str, Any]) -> None:
             expect_resp = expect_dict["response"]
             responses = processor.process_messages(
                 message,
-                context=ExecutionContext(user_activation_present=user_activation),
+                context=ExecutionContext(is_user_activated=user_activation),
             )
             if expect_resp is None:
                 assert len(responses) == 0

--- a/python/a2ui_core/tests/test_format_pydantic_error.py
+++ b/python/a2ui_core/tests/test_format_pydantic_error.py
@@ -52,16 +52,6 @@ class Envelope(BaseModel):
 
 def test_clean_loc_part():
     """Tests unwrapping validator wrapper strings."""
-    assert _clean_loc_part("function-after[CreateSurfaceMessage]") == "CreateSurfaceMessage"
-    assert _clean_loc_part("function-before[UpdateComponentsMessage]") == "UpdateComponentsMessage"
-    assert (
-        _clean_loc_part("function-after[CreateSurfaceMessage]")
-        == "CreateSurfaceMessage"
-    )
-    assert (
-        _clean_loc_part("function-before[UpdateComponentsMessage]")
-        == "UpdateComponentsMessage"
-    )
     assert (
         _clean_loc_part("function-after[CreateSurfaceMessage]")
         == "CreateSurfaceMessage"
@@ -93,16 +83,12 @@ def test_format_pydantic_message_and_issue():
         "loc": ("user", "unknown_field"),
         "ctx": {"extra": "unknown_field"},
     }
-    assert "unrecognized key(s) in object: 'unknown_field'" in format_pydantic_message(err_extra)
-    assert "unrecognized key(s) in object: 'unknown_field'" in format_pydantic_message(
-        err_extra
-    )
     assert "unrecognized key(s) in object: 'unknown_field'" in format_pydantic_message(
         err_extra
     )
     assert format_pydantic_issue(err_extra) == (
-        "user.unknown_field: Additional properties are not allowed: "
-        "unrecognized key(s) in object: 'unknown_field' (extra inputs are not permitted)"
+        "user.unknown_field: Additional properties are not allowed: unrecognized key(s)"
+        " in object: 'unknown_field' (extra inputs are not permitted)"
     )
 
     # Missing field
@@ -114,7 +100,6 @@ def test_format_pydantic_message_and_issue():
     assert format_pydantic_message(err_missing) == "Field required"
     assert format_pydantic_issue(err_missing) == "name: Field required"
     assert (
-        format_pydantic_message(err_missing, path_str="name", match_jsonschema_missing=True)
         format_pydantic_message(
             err_missing, path_str="name", match_jsonschema_missing=True
         )

--- a/python/a2ui_core/tests/test_format_pydantic_error.py
+++ b/python/a2ui_core/tests/test_format_pydantic_error.py
@@ -1,0 +1,211 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for format_pydantic_error utilities."""
+
+from typing import Literal
+from pydantic import BaseModel, ConfigDict, ValidationError
+import pytest
+
+from a2ui.core.processing.format_pydantic_error import (
+    _clean_loc_part,
+    format_pydantic_issue,
+    format_pydantic_message,
+    format_validation_error,
+    format_validation_error_summary,
+    map_pydantic_error_code,
+)
+
+
+class StrictSample(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    age: int
+    role: Literal["admin", "user"] = "user"
+
+
+class ActionA(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    surfaceId: str
+
+
+class ActionB(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    surfaceId: str
+    count: int
+
+
+class Envelope(BaseModel):
+    messages: list[ActionA | ActionB]
+
+
+def test_clean_loc_part():
+    """Tests unwrapping validator wrapper strings."""
+    assert _clean_loc_part("function-after[CreateSurfaceMessage]") == "CreateSurfaceMessage"
+    assert _clean_loc_part("function-before[UpdateComponentsMessage]") == "UpdateComponentsMessage"
+    assert (
+        _clean_loc_part("function-after[CreateSurfaceMessage]")
+        == "CreateSurfaceMessage"
+    )
+    assert (
+        _clean_loc_part("function-before[UpdateComponentsMessage]")
+        == "UpdateComponentsMessage"
+    )
+    assert (
+        _clean_loc_part("function-after[CreateSurfaceMessage]")
+        == "CreateSurfaceMessage"
+    )
+    assert (
+        _clean_loc_part("function-before[UpdateComponentsMessage]")
+        == "UpdateComponentsMessage"
+    )
+    assert _clean_loc_part("surfaceId") == "surfaceId"
+    assert _clean_loc_part("0") == "0"
+
+
+def test_map_pydantic_error_code():
+    """Tests mapping Pydantic error types to canonical A2UI codes."""
+    assert map_pydantic_error_code("missing") == "missing_field"
+    assert map_pydantic_error_code("extra_forbidden") == "extra_field"
+    assert map_pydantic_error_code("string_type") == "type_mismatch"
+    assert map_pydantic_error_code("int_parsing") == "type_mismatch"
+    assert map_pydantic_error_code("type_error") == "type_mismatch"
+    assert map_pydantic_error_code("literal_error") == "invalid_value"
+    assert map_pydantic_error_code("value_error") == "invalid_value"
+
+
+def test_format_pydantic_message_and_issue():
+    """Tests message and issue formatting for various error types."""
+    # Extra forbidden
+    err_extra = {
+        "type": "extra_forbidden",
+        "loc": ("user", "unknown_field"),
+        "ctx": {"extra": "unknown_field"},
+    }
+    assert "unrecognized key(s) in object: 'unknown_field'" in format_pydantic_message(err_extra)
+    assert "unrecognized key(s) in object: 'unknown_field'" in format_pydantic_message(
+        err_extra
+    )
+    assert "unrecognized key(s) in object: 'unknown_field'" in format_pydantic_message(
+        err_extra
+    )
+    assert format_pydantic_issue(err_extra) == (
+        "user.unknown_field: Additional properties are not allowed: "
+        "unrecognized key(s) in object: 'unknown_field' (extra inputs are not permitted)"
+    )
+
+    # Missing field
+    err_missing = {
+        "type": "missing",
+        "loc": ("name",),
+        "msg": "Field required",
+    }
+    assert format_pydantic_message(err_missing) == "Field required"
+    assert format_pydantic_issue(err_missing) == "name: Field required"
+    assert (
+        format_pydantic_message(err_missing, path_str="name", match_jsonschema_missing=True)
+        format_pydantic_message(
+            err_missing, path_str="name", match_jsonschema_missing=True
+        )
+        == "'name' is a required property"
+    )
+
+    # Literal / enum mismatch
+    err_literal = {
+        "type": "literal_error",
+        "loc": ("role",),
+        "input": "superadmin",
+        "ctx": {"expected": "'admin' or 'user'"},
+    }
+    assert format_pydantic_issue(err_literal) == (
+        "role: Invalid enum value. Expected 'admin' or 'user', received 'superadmin'"
+    )
+
+    # Type mismatch
+    err_type_mismatch = {
+        "type": "string_type",
+        "loc": ("label",),
+        "input": 123,
+        "msg": "Input should be a valid string",
+    }
+    assert format_pydantic_message(err_type_mismatch) == (
+        "Expected string, received number (input should be a valid string)"
+    )
+    assert format_pydantic_issue(err_type_mismatch) == (
+        "label: Expected string, received number (input should be a valid string)"
+    )
+
+
+def test_format_validation_error_with_model():
+    """Tests formatting a real Pydantic ValidationError."""
+    with pytest.raises(ValidationError) as exc_info:
+        StrictSample.model_validate({"age": "not_an_int", "extra_prop": 123})
+
+    details = format_validation_error(exc_info.value)
+    codes = {d.code for d in details}
+    assert "missing_field" in codes
+    assert "extra_field" in codes
+    assert "type_mismatch" in codes
+
+    # allow_unknown_extra filters extra_field
+    details_filtered = format_validation_error(exc_info.value, allow_unknown_extra=True)
+    assert not any(d.code == "extra_field" for d in details_filtered)
+
+
+def test_format_validation_error_union_pruning():
+    """Tests pruning of irrelevant union branches when valid_actions are supplied."""
+    payload = {"messages": [{"surfaceId": "s1", "actionA": {}, "invalid": 123}]}
+    with pytest.raises(ValidationError) as exc_info:
+        Envelope.model_validate(payload)
+
+    # Without union filtering, multiple union branches report errors
+    all_details = format_validation_error(exc_info.value)
+    assert len(all_details) > 0
+
+    # With union filtering for actionA, only ActionAMessage errors are retained
+    filtered_details = format_validation_error(
+        exc_info.value,
+        messages=[{"actionA": {}}],
+        valid_actions={"actionA", "actionB"},
+    )
+    assert len(filtered_details) > 0
+
+
+def test_format_validation_error_summary():
+    """Tests joining error diagnostics into a summary string."""
+    with pytest.raises(ValidationError) as exc_info:
+        StrictSample.model_validate({})
+
+    summary = format_validation_error_summary(exc_info.value)
+    assert isinstance(summary, str)
+    assert "name" in summary
+    assert "age" in summary
+
+
+def test_format_validation_error_strip_messages_prefix():
+    """Tests stripping artificial messages.<index> prefix from error paths."""
+    payload = {"messages": [{"surfaceId": 123}]}
+    with pytest.raises(ValidationError) as exc_info:
+        Envelope.model_validate(payload)
+
+    details = format_validation_error(
+        exc_info.value,
+        messages=[{"actionA": {}}],
+        valid_actions={"actionA", "actionB"},
+        strip_messages_prefix=True,
+    )
+    assert len(details) > 0
+    for d in details:
+        assert not d.path.startswith("messages.")
+        assert d.path == "surfaceId"

--- a/python/a2ui_core/tests/test_processing.py
+++ b/python/a2ui_core/tests/test_processing.py
@@ -19,7 +19,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from a2ui.core.processing import MessageProcessor
-from a2ui.core.validation import STRICT_VALIDATION, ValidationConfig
+from a2ui.core.validation import STRICT_VALIDATION
 from a2ui.core.resolution import (
     DataContext,
     ComponentContext,
@@ -29,7 +29,6 @@ from a2ui.core.resolution import (
 from a2ui.core.basic_catalog import BasicCatalog
 from a2ui.core.catalog import (
     Catalog,
-    ComponentApi,
     FunctionImplementation,
     ModelComponentApi,
 )
@@ -1160,6 +1159,41 @@ def test_message_processor_call_renderer_function_async_coroutine():
     }])
     assert len(resp) == 1
     assert resp[0]["rendererFunctionResponse"]["functionCallId"] == "async_call_1"
+
+
+def test_message_processor_call_renderer_function_incompatible_catalog_version(
+    real_catalog_09,
+):
+    from a2ui.core.catalog.catalog import FunctionImplementation
+
+    def dummy_fn(args):
+        return "ok"
+
+    cat = real_catalog_09
+    cat.protocol_version = "0.8"
+    cat.functions["testFunc"] = FunctionImplementation(
+        name="testFunc",
+        execute=dummy_fn,
+        allowed_callers="rendererOrAgent",
+    )
+
+    processor = MessageProcessor(catalogs=[cat])
+    resp = processor.process_messages([{
+        "version": "v1.0",
+        "callRendererFunction": {
+            "functionCallId": "call_incompat",
+            "callFunction": {"call": "testFunc", "args": {}},
+        },
+    }])
+    assert len(resp) == 1
+    resp_obj = resp[0]["rendererFunctionResponse"]
+    assert resp_obj["functionCallId"] == "call_incompat"
+    assert "error" in resp_obj
+    assert resp_obj["error"]["code"] == "INVALID_FUNCTION_CALL"
+    assert (
+        "specification version (0.8) does not match message protocol version (v1.0)"
+        in resp_obj["error"]["message"]
+    )
 
 
 def test_message_processor_cleanup_pending_agent_calls(mock_catalog):

--- a/python/a2ui_core/tests/test_processing.py
+++ b/python/a2ui_core/tests/test_processing.py
@@ -18,7 +18,7 @@ import pytest
 from typing import Any, Literal
 from pydantic import BaseModel, Field
 
-from a2ui.core.processing import MessageProcessor
+from a2ui.core.processing import MessageProcessor, MessageProcessorOptions
 from a2ui.core.validation import STRICT_VALIDATION
 from a2ui.core.resolution import (
     DataContext,
@@ -412,7 +412,8 @@ def test_message_processor_throws_on_creating_component_without_type(mock_catalo
 
 def test_message_processor_strict_mode_circular_reference(real_catalog_09):
     processor = MessageProcessor(
-        catalogs=[real_catalog_09], validation_config=STRICT_VALIDATION
+        catalogs=[real_catalog_09],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     processor.process_messages([{
@@ -445,7 +446,8 @@ def test_message_processor_strict_mode_circular_reference(real_catalog_09):
 def test_message_processor_strict_mode_orphans(real_catalog_09):
     # Using strict integrity checking via validator
     processor = MessageProcessor(
-        catalogs=[real_catalog_09], validation_config=STRICT_VALIDATION
+        catalogs=[real_catalog_09],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     # Orphan node: comp-C is unreachable from root
@@ -513,7 +515,8 @@ def test_message_processor_strict_mode_component_strict_properties(
 
 def test_message_processor_strict_mode_missing_root(real_catalog_09):
     strict_processor = MessageProcessor(
-        catalogs=[real_catalog_09], validation_config=STRICT_VALIDATION
+        catalogs=[real_catalog_09],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     # Missing root component: components only has comp-A
@@ -540,7 +543,8 @@ def test_message_processor_strict_mode_missing_root(real_catalog_09):
 
 def test_message_processor_strict_mode_invalid_path_pointer(real_catalog_09):
     strict_processor = MessageProcessor(
-        catalogs=[real_catalog_09], validation_config=STRICT_VALIDATION
+        catalogs=[real_catalog_09],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     # Contains unescaped tilde ~ not followed by 0 or 1 in path pointer
@@ -681,7 +685,8 @@ def test_message_processor_custom_catalog_component_validation():
 
     catalog = CustomCatalog()
     processor = MessageProcessor(
-        catalogs=[catalog], validation_config=STRICT_VALIDATION
+        catalogs=[catalog],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     processor.process_messages([{
@@ -755,7 +760,8 @@ def test_message_processor_component_catalog_override():
     })
 
     processor = MessageProcessor(
-        catalogs=[cat_a, cat_b], validation_config=STRICT_VALIDATION
+        catalogs=[cat_a, cat_b],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     processor.process_messages([
@@ -831,7 +837,10 @@ def test_message_processor_atomic_state_rollback_on_error():
         },
     })
 
-    processor = MessageProcessor(catalogs=[cat], validation_config=STRICT_VALIDATION)
+    processor = MessageProcessor(
+        catalogs=[cat],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
+    )
 
     processor.process_messages([
         {
@@ -875,7 +884,8 @@ def test_message_processor_empty_catalogs_throws():
 )
 def test_message_processor_theme_validation(real_catalog_09):
     processor = MessageProcessor(
-        catalogs=[real_catalog_09], validation_config=STRICT_VALIDATION
+        catalogs=[real_catalog_09],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
     with pytest.raises(
         ValueError,
@@ -910,7 +920,8 @@ def test_message_processor_json_catalog_validation():
 
     catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
     processor = MessageProcessor(
-        catalogs=[catalog], validation_config=STRICT_VALIDATION
+        catalogs=[catalog],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     # 2. Process surface creation
@@ -1007,7 +1018,8 @@ def test_message_processor_json_catalog_theme_validation():
 
     catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
     processor = MessageProcessor(
-        catalogs=[catalog], validation_config=STRICT_VALIDATION
+        catalogs=[catalog],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     # Dynamic JSON Theme validation fails on incorrect color hex code pattern
@@ -1026,7 +1038,8 @@ def test_message_processor_json_catalog_theme_validation():
 
 def test_strict_mode_validates_single_message_dict(real_catalog_09):
     processor = MessageProcessor(
-        catalogs=[real_catalog_09], validation_config=STRICT_VALIDATION
+        catalogs=[real_catalog_09],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
 
     # Single message dict without 'messages' key must still be validated in strict_mode
@@ -1090,7 +1103,8 @@ def test_version_adapter_factory_unsupported_version_raises_validation_error():
 
 def test_message_processor_v0_9_1_version_payload(mock_catalog):
     processor = MessageProcessor(
-        catalogs=[mock_catalog], validation_config=STRICT_VALIDATION
+        catalogs=[mock_catalog],
+        options=MessageProcessorOptions(validation_config=STRICT_VALIDATION),
     )
     messages = [{
         "version": "v0.9.1",

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -202,3 +202,13 @@ def test_semver_objects():
     assert to_canonical_version(SemVer(0, 9, 1)) == "0.9.1"
     assert is_at_least_version(SemVer(1, 0, 0), "1.0") is True
     assert is_at_least_version(SemVer(0, 9, 0), "1.0") is False
+
+
+def test_non_ascii_digits_rejected():
+    """Verifies that non-ASCII Unicode numerals are rejected per SemVer 2.0.0."""
+    assert parse_semver("1.1١.0") is None
+    assert parse_semver("١.0.0") is None
+    # Verify non-ASCII in pre-release does not crash _compare_prerelease_id
+    v_sup = SemVer(1, 0, 0, prerelease=("²",))
+    v_num = SemVer(1, 0, 0, prerelease=("1",))
+    assert compare_semver(v_sup, v_num) > 0  # '²' treated as non-numeric identifier

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -1,0 +1,182 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SemVer 2.0.0 parsing and comparison utilities."""
+
+from a2ui.core.common.semver import (
+    SemVer,
+    compare_semver,
+    is_at_least_version,
+    is_catalog_version_compatible,
+    normalize_version_string,
+    parse_semver,
+)
+
+
+def test_parse_semver_basic():
+    """Tests basic SemVer string parsing with and without leading 'v'/'V' and bytes."""
+    assert parse_semver("v1.0") == SemVer(1, 0, 0, (), ())
+    assert parse_semver("V1.0") == SemVer(1, 0, 0, (), ())
+    assert parse_semver("1.0") == SemVer(1, 0, 0, (), ())
+    assert parse_semver("v0.9.1") == SemVer(0, 9, 1, (), ())
+    assert parse_semver("V0.9.1") == SemVer(0, 9, 1, (), ())
+    assert parse_semver("v0.10.0") == SemVer(0, 10, 0, (), ())
+    assert parse_semver("v1.10.2") == SemVer(1, 10, 2, (), ())
+    assert parse_semver(b"v1.0") == SemVer(1, 0, 0, (), ())
+    assert parse_semver(b"0.9.1") == SemVer(0, 9, 1, (), ())
+    assert parse_semver("invalid") is None
+    assert parse_semver(None) is None
+    assert parse_semver("") is None
+
+
+def test_normalize_version_string():
+    """Tests version normalization with underscores, leading 'v'/'V', and bytes."""
+    assert normalize_version_string("v1_0") == "1.0"
+    assert normalize_version_string("V1_0") == "1.0"
+    assert normalize_version_string("v0_9_1") == "0.9.1"
+    assert normalize_version_string("V0_9_1") == "0.9.1"
+    assert normalize_version_string("1_0_0-alpha.1") == "1.0.0-alpha.1"
+    assert normalize_version_string("v1_0_0-alpha.1") == "1.0.0-alpha.1"
+    assert normalize_version_string("V1_0_0-alpha.1") == "1.0.0-alpha.1"
+    assert normalize_version_string("1_0_0-dev_release") == "1.0.0-dev_release"
+    assert normalize_version_string("v1_0_0-dev_release") == "1.0.0-dev_release"
+    assert normalize_version_string("1.0.0-dev_release") == "1.0.0-dev_release"
+    assert normalize_version_string("v1_0+build_123") == "1.0+build_123"
+    assert normalize_version_string("V1_0+build_123") == "1.0+build_123"
+    assert normalize_version_string(b"v1_0") == "1.0"
+    assert normalize_version_string(b"V0_9_1") == "0.9.1"
+    assert normalize_version_string("") == ""
+    assert normalize_version_string(None) == ""
+
+
+def test_parse_semver_prerelease_and_build():
+    """Tests parsing of pre-release and build metadata per SemVer 2.0.0."""
+    assert parse_semver("1.0.0-alpha") == SemVer(1, 0, 0, ("alpha",), ())
+    assert parse_semver("1.0.0-alpha.1") == SemVer(1, 0, 0, ("alpha", "1"), ())
+    assert parse_semver("1.0.0-0.3.7") == SemVer(1, 0, 0, ("0", "3", "7"), ())
+    assert parse_semver("1.0.0-x.7.z.92") == SemVer(1, 0, 0, ("x", "7", "z", "92"), ())
+    assert parse_semver("1.0.0+20130313144700") == SemVer(
+        1, 0, 0, (), ("20130313144700",)
+    )
+    assert parse_semver("1.0.0-beta+exp.sha.5114f85") == SemVer(
+        1, 0, 0, ("beta",), ("exp", "sha", "5114f85")
+    )
+
+
+def test_reject_invalid_leading_zeros():
+    """Tests rejection of versions with invalid leading zeros in numeric components."""
+    # SemVer 2.0.0 Rule 2: MUST NOT contain leading zeroes
+    assert parse_semver("01.0.0") is None
+    assert parse_semver("1.01.0") is None
+    assert parse_semver("1.0.01") is None
+    # SemVer 2.0.0 Rule 9: Numeric pre-release identifiers MUST NOT include leading zeroes
+    assert parse_semver("1.0.0-01") is None
+    assert parse_semver("1.0.0-alpha.01") is None
+    # Single zero is allowed
+    assert parse_semver("1.0.0-alpha.0") is not None
+    # Trailing hyphens or pluses without identifiers are invalid
+    assert parse_semver("1.0.0-") is None
+    assert parse_semver("1.0.0+") is None
+    assert parse_semver("1.0.0-alpha..1") is None
+
+
+def test_compare_semver_multi_digit():
+    """Tests comparing multi-digit minor versions per SemVer rules."""
+    assert compare_semver("v0.10.0", "v0.9.1") > 0
+    assert compare_semver("v0.9.1", "v0.10.0") < 0
+    assert compare_semver("v1.10.0", "v1.2.0") > 0
+    assert compare_semver("v1.2.0", "v1.10.0") < 0
+    assert compare_semver("v1.0", "1.0.0") == 0
+    assert compare_semver("v0.9", "0.9") == 0
+
+
+def test_prerelease_precedence_chain():
+    """Tests pre-release precedence chain per SemVer 2.0.0 Section 11."""
+    # Rule 11.3: normal version has higher precedence than pre-release version
+    assert compare_semver("1.0.0-alpha", "1.0.0") < 0
+    assert compare_semver("1.0.0", "1.0.0-alpha") > 0
+
+    # Rule 11.4 canonical chain from semver.org:
+    # 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
+    chain = [
+        "1.0.0-alpha",
+        "1.0.0-alpha.1",
+        "1.0.0-alpha.beta",
+        "1.0.0-beta",
+        "1.0.0-beta.2",
+        "1.0.0-beta.11",
+        "1.0.0-rc.1",
+        "1.0.0",
+    ]
+    for i in range(len(chain) - 1):
+        assert (
+            compare_semver(chain[i], chain[i + 1]) < 0
+        ), f"Expected {chain[i]} < {chain[i + 1]}"
+        assert (
+            compare_semver(chain[i + 1], chain[i]) > 0
+        ), f"Expected {chain[i + 1]} > {chain[i]}"
+
+    # Rule 11.4.3: Numeric identifiers always have lower precedence than non-numeric identifiers
+    assert compare_semver("1.0.0-1", "1.0.0-alpha") < 0
+    assert compare_semver("1.0.0-alpha", "1.0.0-1") > 0
+
+    # Numeric pre-release compared numerically (2 < 11, not lexical "11" < "2")
+    assert compare_semver("1.0.0-2", "1.0.0-11") < 0
+
+
+def test_ignore_build_metadata():
+    """Tests that build metadata is ignored during SemVer comparisons."""
+    assert compare_semver("1.0.0+20130313144700", "1.0.0") == 0
+    assert compare_semver("1.0.0-beta+exp.sha.5114f85", "1.0.0-beta") == 0
+    assert compare_semver("1.0.0+build.1", "1.0.0+build.2") == 0
+
+
+def test_is_at_least_version():
+    """Tests is_at_least_version for various releases and pre-releases."""
+    assert is_at_least_version("v1.0", "1.0") is True
+    assert is_at_least_version("1.0", "1.0") is True
+    assert is_at_least_version("v1.0.0", "1.0") is True
+    assert is_at_least_version("v1.1", "1.0") is True
+    assert is_at_least_version("v2.0.0", "1.0") is True
+    assert is_at_least_version("v0.9.1", "1.0") is False
+    assert is_at_least_version("v0.9", "1.0") is False
+    assert is_at_least_version("v0.8", "1.0") is False
+    assert is_at_least_version(None, "1.0") is False
+    assert is_at_least_version("invalid", "1.0") is False
+
+    # Pre-release version is lower than target release
+    assert is_at_least_version("1.0.0-alpha", "1.0.0") is False
+    assert is_at_least_version("1.0.0", "1.0.0-alpha") is True
+
+
+def test_is_catalog_version_compatible():
+    """Tests catalog version compatibility for equal and forward-compatible versions."""
+    assert is_catalog_version_compatible("v1.0", "v1.0") is True
+    assert is_catalog_version_compatible("V1.0", "v1.0") is True
+    assert is_catalog_version_compatible("v1.0", "V1.0") is True
+    assert is_catalog_version_compatible("v1.0", "v1.1") is True
+    assert is_catalog_version_compatible("v1.0.0", "v1.0.1") is True
+    assert is_catalog_version_compatible("v1.1", "v1.0") is False
+    assert is_catalog_version_compatible("v0.9", "v0.9") is True
+    assert is_catalog_version_compatible("V0.9", "0.9") is True
+    assert is_catalog_version_compatible("0.9", "V0.9") is True
+    assert is_catalog_version_compatible("v0.9", "1.0") is False
+    assert is_catalog_version_compatible("Vcustom", "vcustom") is True
+    assert is_catalog_version_compatible("custom", "Vcustom") is True
+    assert is_catalog_version_compatible(None, "v1.0") is False
+    assert is_catalog_version_compatible("v1.0", None) is False
+    assert is_catalog_version_compatible(None, None) is False
+    assert is_catalog_version_compatible("", "") is False
+    assert is_catalog_version_compatible(None, "None") is False
+    assert is_catalog_version_compatible("None", None) is False

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -122,12 +122,12 @@ def test_prerelease_precedence_chain():
         "1.0.0",
     ]
     for i in range(len(chain) - 1):
-        assert compare_semver(chain[i], chain[i + 1]) < 0, (
-            f"Expected {chain[i]} < {chain[i + 1]}"
-        )
-        assert compare_semver(chain[i + 1], chain[i]) > 0, (
-            f"Expected {chain[i + 1]} > {chain[i]}"
-        )
+        assert (
+            compare_semver(chain[i], chain[i + 1]) < 0
+        ), f"Expected {chain[i]} < {chain[i + 1]}"
+        assert (
+            compare_semver(chain[i + 1], chain[i]) > 0
+        ), f"Expected {chain[i + 1]} > {chain[i]}"
 
     # Rule 11.4.3: Numeric identifiers always have lower precedence than non-numeric identifiers
     assert compare_semver("1.0.0-1", "1.0.0-alpha") < 0

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -18,9 +18,9 @@ from a2ui.core.common.semver import (
     SemVer,
     compare_semver,
     is_at_least_version,
-    is_catalog_version_compatible,
     normalize_version_string,
     parse_semver,
+    to_canonical_version,
 )
 
 
@@ -160,23 +160,26 @@ def test_is_at_least_version():
     assert is_at_least_version("1.0.0", "1.0.0-alpha") is True
 
 
-def test_is_catalog_version_compatible():
-    """Tests catalog version compatibility for equal and forward-compatible versions."""
-    assert is_catalog_version_compatible("v1.0", "v1.0") is True
-    assert is_catalog_version_compatible("V1.0", "v1.0") is True
-    assert is_catalog_version_compatible("v1.0", "V1.0") is True
-    assert is_catalog_version_compatible("v1.0", "v1.1") is True
-    assert is_catalog_version_compatible("v1.0.0", "v1.0.1") is True
-    assert is_catalog_version_compatible("v1.1", "v1.0") is False
-    assert is_catalog_version_compatible("v0.9", "v0.9") is True
-    assert is_catalog_version_compatible("V0.9", "0.9") is True
-    assert is_catalog_version_compatible("0.9", "V0.9") is True
-    assert is_catalog_version_compatible("v0.9", "1.0") is False
-    assert is_catalog_version_compatible("Vcustom", "vcustom") is True
-    assert is_catalog_version_compatible("custom", "Vcustom") is True
-    assert is_catalog_version_compatible(None, "v1.0") is False
-    assert is_catalog_version_compatible("v1.0", None) is False
-    assert is_catalog_version_compatible(None, None) is False
-    assert is_catalog_version_compatible("", "") is False
-    assert is_catalog_version_compatible(None, "None") is False
-    assert is_catalog_version_compatible("None", None) is False
+def test_to_canonical_version():
+    """Tests canonical string formatting for semantic versions."""
+    assert to_canonical_version("v1.0") == "1.0"
+    assert to_canonical_version("1.0") == "1.0"
+    assert to_canonical_version("V1.0") == "1.0"
+    assert to_canonical_version("1.0.0") == "1.0"
+    assert to_canonical_version("v1.0.0") == "1.0"
+    assert to_canonical_version("v1_0") == "1.0"
+    assert to_canonical_version("V1_0") == "1.0"
+    assert to_canonical_version("v0.9.1") == "0.9.1"
+    assert to_canonical_version("0.9.1") == "0.9.1"
+    assert to_canonical_version("v0_9_1") == "0.9.1"
+    assert to_canonical_version("v0.9") == "0.9"
+    assert to_canonical_version("0.9") == "0.9"
+    assert to_canonical_version("v0_9") == "0.9"
+    assert to_canonical_version("v0.8") == "0.8"
+    assert to_canonical_version("0.8.0") == "0.8"
+    assert to_canonical_version("1.0.0-beta.1") == "1.0.0-beta.1"
+    assert to_canonical_version("1.0.0+build.1") == "1.0.0+build.1"
+    assert to_canonical_version(b"v1.0") == "1.0"
+    assert to_canonical_version("invalid") is None
+    assert to_canonical_version("") is None
+    assert to_canonical_version(None) is None

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -22,10 +22,11 @@ from a2ui.core.common.semver import (
     parse_semver,
     to_canonical_version,
 )
+from a2ui.core.schema import ProtocolVersion
 
 
 def test_parse_semver_basic():
-    """Tests basic SemVer string parsing with and without leading 'v'/'V' and bytes."""
+    """Tests basic SemVer string parsing with and without leading 'v'/'V' and ProtocolVersion."""
     assert parse_semver("v1.0") == SemVer(1, 0, 0, (), ())
     assert parse_semver("V1.0") == SemVer(1, 0, 0, (), ())
     assert parse_semver("1.0") == SemVer(1, 0, 0, (), ())
@@ -33,15 +34,15 @@ def test_parse_semver_basic():
     assert parse_semver("V0.9.1") == SemVer(0, 9, 1, (), ())
     assert parse_semver("v0.10.0") == SemVer(0, 10, 0, (), ())
     assert parse_semver("v1.10.2") == SemVer(1, 10, 2, (), ())
-    assert parse_semver(b"v1.0") == SemVer(1, 0, 0, (), ())
-    assert parse_semver(b"0.9.1") == SemVer(0, 9, 1, (), ())
+    assert parse_semver(ProtocolVersion.V1_0) == SemVer(1, 0, 0, (), ())
+    assert parse_semver(ProtocolVersion.V0_9_1) == SemVer(0, 9, 1, (), ())
     assert parse_semver("invalid") is None
     assert parse_semver(None) is None
     assert parse_semver("") is None
 
 
 def test_normalize_version_string():
-    """Tests version normalization with underscores, leading 'v'/'V', and bytes."""
+    """Tests version normalization with underscores, leading 'v'/'V', and ProtocolVersion."""
     assert normalize_version_string("v1_0") == "1.0"
     assert normalize_version_string("V1_0") == "1.0"
     assert normalize_version_string("v0_9_1") == "0.9.1"
@@ -54,8 +55,8 @@ def test_normalize_version_string():
     assert normalize_version_string("1.0.0-dev_release") == "1.0.0-dev_release"
     assert normalize_version_string("v1_0+build_123") == "1.0+build_123"
     assert normalize_version_string("V1_0+build_123") == "1.0+build_123"
-    assert normalize_version_string(b"v1_0") == "1.0"
-    assert normalize_version_string(b"V0_9_1") == "0.9.1"
+    assert normalize_version_string(ProtocolVersion.V1_0) == "1.0"
+    assert normalize_version_string(ProtocolVersion.V0_9_1) == "0.9.1"
     assert normalize_version_string("") == ""
     assert normalize_version_string(None) == ""
 
@@ -187,7 +188,8 @@ def test_to_canonical_version():
     assert to_canonical_version("0.8.0") == "0.8"
     assert to_canonical_version("1.0.0-beta.1") == "1.0.0-beta.1"
     assert to_canonical_version("1.0.0+build.1") == "1.0.0+build.1"
-    assert to_canonical_version(b"v1.0") == "1.0"
+    assert to_canonical_version(ProtocolVersion.V1_0) == "1.0"
+    assert to_canonical_version(ProtocolVersion.V0_9_1) == "0.9.1"
     assert to_canonical_version("invalid") is None
     assert to_canonical_version("") is None
     assert to_canonical_version(None) is None
@@ -202,6 +204,8 @@ def test_semver_objects():
     assert to_canonical_version(SemVer(0, 9, 1)) == "0.9.1"
     assert is_at_least_version(SemVer(1, 0, 0), "1.0") is True
     assert is_at_least_version(SemVer(0, 9, 0), "1.0") is False
+    assert is_at_least_version(ProtocolVersion.V1_0, "1.0") is True
+    assert is_at_least_version(ProtocolVersion.V0_9, ProtocolVersion.V1_0) is False
 
 
 def test_non_ascii_digits_rejected():

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -134,6 +134,13 @@ def test_prerelease_precedence_chain():
     # Numeric pre-release compared numerically (2 < 11, not lexical "11" < "2")
     assert compare_semver("1.0.0-2", "1.0.0-11") < 0
 
+    # Numeric pre-release compared safely with large numbers
+    assert compare_semver("1.0.0-9007199254740991", "1.0.0-9007199254740992") < 0
+    assert compare_semver("1.0.0-9007199254740992", "1.0.0-9007199254740991") > 0
+    assert (
+        compare_semver("1.0.0-100000000000000000000", "1.0.0-9999999999999999999") > 0
+    )
+
 
 def test_ignore_build_metadata():
     """Tests that build metadata is ignored during SemVer comparisons."""
@@ -153,6 +160,7 @@ def test_is_at_least_version():
     assert is_at_least_version("v0.9", "1.0") is False
     assert is_at_least_version("v0.8", "1.0") is False
     assert is_at_least_version(None, "1.0") is False
+    assert is_at_least_version("", "1.0") is False
     assert is_at_least_version("invalid", "1.0") is False
 
     # Pre-release version is lower than target release
@@ -183,3 +191,14 @@ def test_to_canonical_version():
     assert to_canonical_version("invalid") is None
     assert to_canonical_version("") is None
     assert to_canonical_version(None) is None
+
+
+def test_semver_objects():
+    """Tests comparing, evaluating, and canonicalizing SemVer dataclass instances directly."""
+    assert compare_semver(SemVer(1, 0, 0), "1.0.0") == 0
+    assert compare_semver(SemVer(1, 1, 0), "1.0.0") > 0
+    assert compare_semver("1.0.0", SemVer(1, 0, 0)) == 0
+    assert to_canonical_version(SemVer(1, 0, 0)) == "1.0"
+    assert to_canonical_version(SemVer(0, 9, 1)) == "0.9.1"
+    assert is_at_least_version(SemVer(1, 0, 0), "1.0") is True
+    assert is_at_least_version(SemVer(0, 9, 0), "1.0") is False

--- a/python/a2ui_core/tests/test_semver.py
+++ b/python/a2ui_core/tests/test_semver.py
@@ -21,6 +21,7 @@ from a2ui.core.common.semver import (
     normalize_version_string,
     parse_semver,
     to_canonical_version,
+    to_semver,
 )
 from a2ui.core.schema import ProtocolVersion
 
@@ -121,12 +122,12 @@ def test_prerelease_precedence_chain():
         "1.0.0",
     ]
     for i in range(len(chain) - 1):
-        assert (
-            compare_semver(chain[i], chain[i + 1]) < 0
-        ), f"Expected {chain[i]} < {chain[i + 1]}"
-        assert (
-            compare_semver(chain[i + 1], chain[i]) > 0
-        ), f"Expected {chain[i + 1]} > {chain[i]}"
+        assert compare_semver(chain[i], chain[i + 1]) < 0, (
+            f"Expected {chain[i]} < {chain[i + 1]}"
+        )
+        assert compare_semver(chain[i + 1], chain[i]) > 0, (
+            f"Expected {chain[i + 1]} > {chain[i]}"
+        )
 
     # Rule 11.4.3: Numeric identifiers always have lower precedence than non-numeric identifiers
     assert compare_semver("1.0.0-1", "1.0.0-alpha") < 0
@@ -216,3 +217,16 @@ def test_non_ascii_digits_rejected():
     v_sup = SemVer(1, 0, 0, prerelease=("²",))
     v_num = SemVer(1, 0, 0, prerelease=("1",))
     assert compare_semver(v_sup, v_num) > 0  # '²' treated as non-numeric identifier
+
+
+def test_to_semver():
+    """Tests converting strings, ProtocolVersion enums, and SemVer instances via to_semver."""
+    assert to_semver(None) is None
+    assert to_semver("") is None
+    assert to_semver("invalid") is None
+    assert to_semver(SemVer(1, 2, 3)) == SemVer(1, 2, 3)
+    assert to_semver("v1.0") == SemVer(1, 0, 0)
+    assert to_semver("v1_0") == SemVer(1, 0, 0)
+    assert to_semver(ProtocolVersion.V1_0) == SemVer(1, 0, 0)
+    assert to_semver(ProtocolVersion.V0_9_1) == SemVer(0, 9, 1)
+    assert to_semver("1.0.0-beta.1") == SemVer(1, 0, 0, prerelease=("beta", "1"))

--- a/typescript/web_core/package.json
+++ b/typescript/web_core/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/src/common/events.d.ts",
       "default": "./dist/src/common/events.js"
     },
+    "./semver": {
+      "types": "./dist/src/common/semver.d.ts",
+      "default": "./dist/src/common/semver.js"
+    },
     "./v0_8": {
       "types": "./dist/src/v0_8/index.d.ts",
       "default": "./dist/src/v0_8/index.js"

--- a/typescript/web_core/src/catalog/schema_generator.test.ts
+++ b/typescript/web_core/src/catalog/schema_generator.test.ts
@@ -348,18 +348,31 @@ describe('Catalog.catalogSchema & schema_generator', () => {
     };
 
     const catalog = new Catalog('guid-550e8400-e29b-41d4-a716-446655440000', [CustomWidget]);
-    const v10Schema = generateCatalogSchema(catalog, {
-      protocolVersion: 'v1.0',
-    });
-    const v10Defs = v10Schema['$defs'] as Record<string, any>;
-    assert.ok(v10Defs);
-    assert.ok(v10Defs['DynamicString']);
 
-    const v08Schema = generateCatalogSchema(catalog, {
-      protocolVersion: 'v0.8',
-    });
-    const v08Defs = v08Schema['$defs'] as Record<string, any>;
-    assert.ok(v08Defs);
+    for (const v10Ver of ['v1.0', '1.0', 'v1_0', '1.0.0', 'V1.0']) {
+      const v10Schema = generateCatalogSchema(catalog, {
+        protocolVersion: v10Ver,
+      });
+      const v10Defs = v10Schema['$defs'] as Record<string, any>;
+      assert.ok(v10Defs, `Expected $defs for version ${v10Ver}`);
+      assert.ok(v10Defs['DynamicString'], `Expected DynamicString for version ${v10Ver}`);
+    }
+
+    for (const v08Ver of ['v0.8', '0.8', 'v0_8', '0.8.0']) {
+      const v08Schema = generateCatalogSchema(catalog, {
+        protocolVersion: v08Ver,
+      });
+      const v08Defs = v08Schema['$defs'] as Record<string, any>;
+      assert.ok(v08Defs, `Expected $defs for version ${v08Ver}`);
+    }
+
+    for (const v09Ver of ['v0.9', '0.9', 'v0.9.1', '0.9.1', 'v0_9']) {
+      const v09Schema = generateCatalogSchema(catalog, {
+        protocolVersion: v09Ver,
+      });
+      const v09Defs = v09Schema['$defs'] as Record<string, any>;
+      assert.ok(v09Defs, `Expected $defs for version ${v09Ver}`);
+    }
   });
 
   it('respects explicit standardDefs in GenerateCatalogSchemaOptions', () => {

--- a/typescript/web_core/src/catalog/schema_generator.ts
+++ b/typescript/web_core/src/catalog/schema_generator.ts
@@ -20,12 +20,13 @@ import {ComponentApi, FunctionApi, CatalogInterface} from './types.js';
 import {V08_STANDARD_DEFS} from '../v0_8/standard_defs.js';
 import {V09_STANDARD_DEFS} from '../v0_9/standard_defs.js';
 import {V10_STANDARD_DEFS} from '../v1_0/standard_defs.js';
+import {normalizeVersionString, toCanonicalVersion} from '../common/semver.js';
 
 const STANDARD_DEFS_BY_VERSION: Readonly<Record<string, Record<string, unknown>>> = {
-  'v0.8': V08_STANDARD_DEFS,
-  'v0.9': V09_STANDARD_DEFS,
-  'v0.9.1': V09_STANDARD_DEFS,
-  'v1.0': V10_STANDARD_DEFS,
+  '0.8': V08_STANDARD_DEFS,
+  '0.9': V09_STANDARD_DEFS,
+  '0.9.1': V09_STANDARD_DEFS,
+  '1.0': V10_STANDARD_DEFS,
 };
 
 /**
@@ -38,8 +39,13 @@ function getStandardDefsForCatalog(
   if (options?.standardDefs) {
     return options.standardDefs;
   }
-  if (options?.protocolVersion && options.protocolVersion in STANDARD_DEFS_BY_VERSION) {
-    return STANDARD_DEFS_BY_VERSION[options.protocolVersion];
+  if (options?.protocolVersion) {
+    const key =
+      toCanonicalVersion(options.protocolVersion) ??
+      normalizeVersionString(options.protocolVersion);
+    if (key in STANDARD_DEFS_BY_VERSION) {
+      return STANDARD_DEFS_BY_VERSION[key];
+    }
   }
   return V09_STANDARD_DEFS;
 }

--- a/typescript/web_core/src/catalog/types.ts
+++ b/typescript/web_core/src/catalog/types.ts
@@ -311,7 +311,7 @@ export class Catalog<
     protocolVersion?: ProtocolVersion | string,
   ) {
     this.id = id;
-    this.protocolVersion = protocolVersion;
+    this.protocolVersion = typeof protocolVersion === 'string' ? protocolVersion : undefined;
 
     const compMap = new Map<string, T>();
     for (const comp of components) {

--- a/typescript/web_core/src/common/semver.test.ts
+++ b/typescript/web_core/src/common/semver.test.ts
@@ -283,5 +283,9 @@ describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
       isAtLeastVersion({major: 0, minor: 9, patch: 0, prerelease: [], build: []}, '1.0'),
       false,
     );
+    assert.strictEqual(toCanonicalVersion({major: NaN} as any), null);
+    assert.strictEqual(toCanonicalVersion({major: -1} as any), null);
+    assert.strictEqual(toCanonicalVersion({major: 1, minor: -2} as any), null);
+    assert.strictEqual(toCanonicalVersion({major: 1, patch: 1.5} as any), null);
   });
 });

--- a/typescript/web_core/src/common/semver.test.ts
+++ b/typescript/web_core/src/common/semver.test.ts
@@ -142,6 +142,11 @@ describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
     assert.strictEqual(parseSemVer('1.0.0-alpha..1'), null);
   });
 
+  it('rejects non-ASCII Unicode numerals per SemVer 2.0.0', () => {
+    assert.strictEqual(parseSemVer('1.1١.0'), null);
+    assert.strictEqual(parseSemVer('١.0.0'), null);
+  });
+
   it('compares multi-digit minor versions correctly unlike float comparisons', () => {
     assert.ok(compareSemVer('v0.10.0', 'v0.9.1') > 0);
     assert.ok(compareSemVer('v0.9.1', 'v0.10.0') < 0);

--- a/typescript/web_core/src/common/semver.test.ts
+++ b/typescript/web_core/src/common/semver.test.ts
@@ -76,6 +76,7 @@ describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
       build: [],
     });
     assert.strictEqual(parseSemVer('invalid'), null);
+    assert.strictEqual(parseSemVer(''), null);
     assert.strictEqual(parseSemVer(undefined), null);
     assert.strictEqual(parseSemVer(null), null);
   });
@@ -207,6 +208,8 @@ describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
     assert.strictEqual(isAtLeastVersion('v0.9', '1.0'), false);
     assert.strictEqual(isAtLeastVersion('v0.8', '1.0'), false);
     assert.strictEqual(isAtLeastVersion(undefined, '1.0'), false);
+    assert.strictEqual(isAtLeastVersion(null, '1.0'), false);
+    assert.strictEqual(isAtLeastVersion('', '1.0'), false);
     assert.strictEqual(isAtLeastVersion('invalid', '1.0'), false);
 
     // Pre-release version is lower than target release
@@ -260,5 +263,25 @@ describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
     // Partial object missing prerelease and build arrays
     assert.strictEqual(compareSemVer({major: 1} as unknown as string, '1.0.0'), 0);
     assert.strictEqual(compareSemVer({major: 1, minor: 1} as unknown as string, '1.0.0'), 1);
+    assert.strictEqual(
+      compareSemVer('1.0.0', {major: 1, minor: 0, patch: 0, prerelease: [], build: []}),
+      0,
+    );
+    assert.strictEqual(
+      toCanonicalVersion({major: 1, minor: 0, patch: 0, prerelease: [], build: []}),
+      '1.0',
+    );
+    assert.strictEqual(
+      toCanonicalVersion({major: 0, minor: 9, patch: 1, prerelease: [], build: []}),
+      '0.9.1',
+    );
+    assert.strictEqual(
+      isAtLeastVersion({major: 1, minor: 0, patch: 0, prerelease: [], build: []}, '1.0'),
+      true,
+    );
+    assert.strictEqual(
+      isAtLeastVersion({major: 0, minor: 9, patch: 0, prerelease: [], build: []}, '1.0'),
+      false,
+    );
   });
 });

--- a/typescript/web_core/src/common/semver.test.ts
+++ b/typescript/web_core/src/common/semver.test.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it} from 'node:test';
+import assert from 'node:assert';
+import {
+  parseSemVer,
+  compareSemVer,
+  isAtLeastVersion,
+  isCatalogVersionCompatible,
+  normalizeVersionString,
+} from './semver.js';
+
+describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
+  it('correctly parses semver strings with and without leading v', () => {
+    assert.deepStrictEqual(parseSemVer('v1.0'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('V1.0'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('1.0'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('v0.9.1'), {
+      major: 0,
+      minor: 9,
+      patch: 1,
+      prerelease: [],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('V0.9.1'), {
+      major: 0,
+      minor: 9,
+      patch: 1,
+      prerelease: [],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('v0.10.0'), {
+      major: 0,
+      minor: 10,
+      patch: 0,
+      prerelease: [],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('v1.10.2'), {
+      major: 1,
+      minor: 10,
+      patch: 2,
+      prerelease: [],
+      build: [],
+    });
+    assert.strictEqual(parseSemVer('invalid'), null);
+    assert.strictEqual(parseSemVer(undefined), null);
+    assert.strictEqual(parseSemVer(null), null);
+  });
+
+  it('parses pre-release and build metadata per semver.org spec', () => {
+    assert.deepStrictEqual(parseSemVer('1.0.0-alpha'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['alpha'],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('1.0.0-alpha.1'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['alpha', '1'],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('1.0.0-0.3.7'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['0', '3', '7'],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('1.0.0-x.7.z.92'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['x', '7', 'z', '92'],
+      build: [],
+    });
+    assert.deepStrictEqual(parseSemVer('1.0.0+20130313144700'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+      build: ['20130313144700'],
+    });
+    assert.deepStrictEqual(parseSemVer('1.0.0-beta+exp.sha.5114f85'), {
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['beta'],
+      build: ['exp', 'sha', '5114f85'],
+    });
+  });
+
+  it('rejects invalid versions with leading zeros in numeric components', () => {
+    // SemVer 2.0.0 Rule 2: MUST NOT contain leading zeroes
+    assert.strictEqual(parseSemVer('01.0.0'), null);
+    assert.strictEqual(parseSemVer('1.01.0'), null);
+    assert.strictEqual(parseSemVer('1.0.01'), null);
+    // SemVer 2.0.0 Rule 9: Numeric pre-release identifiers MUST NOT include leading zeroes
+    assert.strictEqual(parseSemVer('1.0.0-01'), null);
+    assert.strictEqual(parseSemVer('1.0.0-alpha.01'), null);
+    // Single zero is allowed
+    assert.ok(parseSemVer('1.0.0-alpha.0') !== null);
+    // Trailing hyphens or pluses without identifiers are invalid
+    assert.strictEqual(parseSemVer('1.0.0-'), null);
+    assert.strictEqual(parseSemVer('1.0.0+'), null);
+    assert.strictEqual(parseSemVer('1.0.0-alpha..1'), null);
+  });
+
+  it('compares multi-digit minor versions correctly unlike float comparisons', () => {
+    assert.ok(compareSemVer('v0.10.0', 'v0.9.1') > 0);
+    assert.ok(compareSemVer('v0.9.1', 'v0.10.0') < 0);
+    assert.ok(compareSemVer('v1.10.0', 'v1.2.0') > 0);
+    assert.ok(compareSemVer('v1.2.0', 'v1.10.0') < 0);
+    assert.strictEqual(compareSemVer('v1.0', '1.0.0'), 0);
+    assert.strictEqual(compareSemVer('v0.9', '0.9'), 0);
+  });
+
+  it('evaluates pre-release precedence per semver.org section 11', () => {
+    // Rule 11.3: normal version has higher precedence than pre-release version
+    assert.ok(compareSemVer('1.0.0-alpha', '1.0.0') < 0);
+    assert.ok(compareSemVer('1.0.0', '1.0.0-alpha') > 0);
+
+    // Rule 11.4 canonical chain from semver.org:
+    // 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
+    const chain = [
+      '1.0.0-alpha',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha.beta',
+      '1.0.0-beta',
+      '1.0.0-beta.2',
+      '1.0.0-beta.11',
+      '1.0.0-rc.1',
+      '1.0.0',
+    ];
+    for (let i = 0; i < chain.length - 1; i++) {
+      assert.ok(
+        compareSemVer(chain[i], chain[i + 1]) < 0,
+        `Expected ${chain[i]} < ${chain[i + 1]}`,
+      );
+      assert.ok(
+        compareSemVer(chain[i + 1], chain[i]) > 0,
+        `Expected ${chain[i + 1]} > ${chain[i]}`,
+      );
+    }
+
+    // Rule 11.4.3: Numeric identifiers always have lower precedence than non-numeric identifiers
+    assert.ok(compareSemVer('1.0.0-1', '1.0.0-alpha') < 0);
+    assert.ok(compareSemVer('1.0.0-alpha', '1.0.0-1') > 0);
+
+    // Numeric pre-release compared numerically (2 < 11, not lexical "11" < "2")
+    assert.ok(compareSemVer('1.0.0-2', '1.0.0-11') < 0);
+
+    // Numeric pre-release compared safely without Number.MAX_SAFE_INTEGER precision issues
+    assert.ok(compareSemVer('1.0.0-9007199254740991', '1.0.0-9007199254740992') < 0);
+    assert.ok(compareSemVer('1.0.0-9007199254740992', '1.0.0-9007199254740991') > 0);
+    assert.ok(compareSemVer('1.0.0-100000000000000000000', '1.0.0-9999999999999999999') > 0);
+  });
+
+  it('ignores build metadata during precedence comparison per semver.org section 10', () => {
+    assert.strictEqual(compareSemVer('1.0.0+20130313144700', '1.0.0'), 0);
+    assert.strictEqual(compareSemVer('1.0.0-beta+exp.sha.5114f85', '1.0.0-beta'), 0);
+    assert.strictEqual(compareSemVer('1.0.0+build.1', '1.0.0+build.2'), 0);
+  });
+
+  it('evaluates isAtLeastVersion correctly across versions and pre-releases', () => {
+    assert.strictEqual(isAtLeastVersion('v1.0', '1.0'), true);
+    assert.strictEqual(isAtLeastVersion('1.0', '1.0'), true);
+    assert.strictEqual(isAtLeastVersion('v1.0.0', '1.0'), true);
+    assert.strictEqual(isAtLeastVersion('v1.1', '1.0'), true);
+    assert.strictEqual(isAtLeastVersion('v2.0.0', '1.0'), true);
+    assert.strictEqual(isAtLeastVersion('v0.9.1', '1.0'), false);
+    assert.strictEqual(isAtLeastVersion('v0.9', '1.0'), false);
+    assert.strictEqual(isAtLeastVersion('v0.8', '1.0'), false);
+    assert.strictEqual(isAtLeastVersion(undefined, '1.0'), false);
+    assert.strictEqual(isAtLeastVersion('invalid', '1.0'), false);
+
+    // Pre-release version is lower than target release
+    assert.strictEqual(isAtLeastVersion('1.0.0-alpha', '1.0.0'), false);
+    assert.strictEqual(isAtLeastVersion('1.0.0', '1.0.0-alpha'), true);
+  });
+
+  it('normalizes version strings with underscores and leading v/V', () => {
+    assert.strictEqual(normalizeVersionString('v1_0'), '1.0');
+    assert.strictEqual(normalizeVersionString('V1_0'), '1.0');
+    assert.strictEqual(normalizeVersionString('v0_9_1'), '0.9.1');
+    assert.strictEqual(normalizeVersionString('V0_9_1'), '0.9.1');
+    assert.strictEqual(normalizeVersionString('1_0_0-alpha.1'), '1.0.0-alpha.1');
+    assert.strictEqual(normalizeVersionString('v1_0_0-alpha.1'), '1.0.0-alpha.1');
+    assert.strictEqual(normalizeVersionString('V1_0_0-alpha.1'), '1.0.0-alpha.1');
+    assert.strictEqual(normalizeVersionString('1_0_0-dev_release'), '1.0.0-dev_release');
+    assert.strictEqual(normalizeVersionString('v1_0_0-dev_release'), '1.0.0-dev_release');
+    assert.strictEqual(normalizeVersionString('1.0.0-dev_release'), '1.0.0-dev_release');
+    assert.strictEqual(normalizeVersionString('v1_0+build_123'), '1.0+build_123');
+    assert.strictEqual(normalizeVersionString('V1_0+build_123'), '1.0+build_123');
+    assert.strictEqual(normalizeVersionString(''), '');
+    assert.strictEqual(normalizeVersionString(undefined), '');
+    assert.strictEqual(normalizeVersionString(null), '');
+  });
+
+  it('evaluates isCatalogVersionCompatible correctly', () => {
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('V1.0', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'V1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.0', 'v1.0.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.1', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('V0.9', '0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('0.9', 'V0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('Vcustom', 'vcustom'), true);
+    assert.strictEqual(isCatalogVersionCompatible('custom', 'Vcustom'), true);
+    assert.strictEqual(isCatalogVersionCompatible(undefined, 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', undefined), false);
+    assert.strictEqual(isCatalogVersionCompatible(null, 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', null), false);
+    assert.strictEqual(isCatalogVersionCompatible(null, null), false);
+    assert.strictEqual(isCatalogVersionCompatible('', ''), false);
+  });
+
+  it('handles partial objects safely in toSemVer', () => {
+    // Partial object missing prerelease and build arrays
+    assert.strictEqual(compareSemVer({major: 1} as unknown as string, '1.0.0'), 0);
+    assert.strictEqual(compareSemVer({major: 1, minor: 1} as unknown as string, '1.0.0'), 1);
+  });
+});

--- a/typescript/web_core/src/common/semver.test.ts
+++ b/typescript/web_core/src/common/semver.test.ts
@@ -20,8 +20,8 @@ import {
   parseSemVer,
   compareSemVer,
   isAtLeastVersion,
-  isCatalogVersionCompatible,
   normalizeVersionString,
+  toCanonicalVersion,
 } from './semver.js';
 
 describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
@@ -232,25 +232,28 @@ describe('SemVer Utilities (SemVer 2.0.0 Spec)', () => {
     assert.strictEqual(normalizeVersionString(null), '');
   });
 
-  it('evaluates isCatalogVersionCompatible correctly', () => {
-    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.0'), true);
-    assert.strictEqual(isCatalogVersionCompatible('V1.0', 'v1.0'), true);
-    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'V1.0'), true);
-    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.1'), true);
-    assert.strictEqual(isCatalogVersionCompatible('v1.0.0', 'v1.0.1'), true);
-    assert.strictEqual(isCatalogVersionCompatible('v1.1', 'v1.0'), false);
-    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v0.9'), true);
-    assert.strictEqual(isCatalogVersionCompatible('V0.9', '0.9'), true);
-    assert.strictEqual(isCatalogVersionCompatible('0.9', 'V0.9'), true);
-    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v1.0'), false);
-    assert.strictEqual(isCatalogVersionCompatible('Vcustom', 'vcustom'), true);
-    assert.strictEqual(isCatalogVersionCompatible('custom', 'Vcustom'), true);
-    assert.strictEqual(isCatalogVersionCompatible(undefined, 'v1.0'), false);
-    assert.strictEqual(isCatalogVersionCompatible('v1.0', undefined), false);
-    assert.strictEqual(isCatalogVersionCompatible(null, 'v1.0'), false);
-    assert.strictEqual(isCatalogVersionCompatible('v1.0', null), false);
-    assert.strictEqual(isCatalogVersionCompatible(null, null), false);
-    assert.strictEqual(isCatalogVersionCompatible('', ''), false);
+  it('canonicalizes version strings correctly with toCanonicalVersion', () => {
+    assert.strictEqual(toCanonicalVersion('v1.0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('1.0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('V1.0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('1.0.0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('v1.0.0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('v1_0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('V1_0'), '1.0');
+    assert.strictEqual(toCanonicalVersion('v0.9.1'), '0.9.1');
+    assert.strictEqual(toCanonicalVersion('0.9.1'), '0.9.1');
+    assert.strictEqual(toCanonicalVersion('v0_9_1'), '0.9.1');
+    assert.strictEqual(toCanonicalVersion('v0.9'), '0.9');
+    assert.strictEqual(toCanonicalVersion('0.9'), '0.9');
+    assert.strictEqual(toCanonicalVersion('v0_9'), '0.9');
+    assert.strictEqual(toCanonicalVersion('v0.8'), '0.8');
+    assert.strictEqual(toCanonicalVersion('0.8.0'), '0.8');
+    assert.strictEqual(toCanonicalVersion('1.0.0-beta.1'), '1.0.0-beta.1');
+    assert.strictEqual(toCanonicalVersion('1.0.0+build.1'), '1.0.0+build.1');
+    assert.strictEqual(toCanonicalVersion('invalid'), null);
+    assert.strictEqual(toCanonicalVersion(''), null);
+    assert.strictEqual(toCanonicalVersion(null), null);
+    assert.strictEqual(toCanonicalVersion(undefined), null);
   });
 
   it('handles partial objects safely in toSemVer', () => {

--- a/typescript/web_core/src/common/semver.ts
+++ b/typescript/web_core/src/common/semver.ts
@@ -106,7 +106,7 @@ export function parseSemVer(versionStr: string | undefined | null): SemVer | nul
  * @param v The version string or object to convert.
  * @returns A SemVer object if valid, or null otherwise.
  */
-function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
+export function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
   if (!v) {
     return null;
   }

--- a/typescript/web_core/src/common/semver.ts
+++ b/typescript/web_core/src/common/semver.ts
@@ -56,7 +56,7 @@ const SEMVER_REGEX =
  *   '1_0_0-dev_release' -> '1.0.0-dev_release'
  *
  * @param version The raw version string to normalize.
- * @returns The normalized version string, or empty string if input is falsy.
+ * @return The normalized version string, or empty string if input is falsy.
  */
 export function normalizeVersionString(version: string | undefined | null): string {
   if (!version || typeof version !== 'string') {
@@ -81,7 +81,7 @@ export function normalizeVersionString(version: string | undefined | null): stri
  * Parses a semantic version string according to SemVer 2.0.0.
  *
  * @param versionStr The version string to parse.
- * @returns A SemVer object if valid, or null if the string cannot be parsed.
+ * @return A SemVer object if valid, or null if the string cannot be parsed.
  */
 export function parseSemVer(versionStr: string | undefined | null): SemVer | null {
   if (!versionStr || typeof versionStr !== 'string') {
@@ -104,7 +104,7 @@ export function parseSemVer(versionStr: string | undefined | null): SemVer | nul
  * Converts a string or partial SemVer object into a normalized SemVer representation.
  *
  * @param v The version string or object to convert.
- * @returns A SemVer object if valid, or null otherwise.
+ * @return A SemVer object if valid, or null otherwise.
  */
 export function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
   if (!v) {
@@ -141,7 +141,7 @@ export function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
  * returns the full SemVer string (e.g. '0.9.1', '1.0.0-beta.1').
  *
  * @param version The version string or SemVer object to canonicalize.
- * @returns The canonical version string, or null if the input cannot be parsed.
+ * @return The canonical version string, or null if the input cannot be parsed.
  */
 export function toCanonicalVersion(version: string | SemVer | undefined | null): string | null {
   if (!version) {
@@ -164,7 +164,7 @@ export function toCanonicalVersion(version: string | SemVer | undefined | null):
  *
  * @param idA First pre-release identifier.
  * @param idB Second pre-release identifier.
- * @returns Negative number if idA < idB, 0 if equal, positive number if idA > idB.
+ * @return Negative number if idA < idB, 0 if equal, positive number if idA > idB.
  */
 function comparePrereleaseId(idA: string, idB: string): number {
   const isNumA = /^\d+$/.test(idA);
@@ -201,7 +201,7 @@ function comparePrereleaseId(idA: string, idB: string): number {
  *
  * @param preA First list of pre-release identifiers.
  * @param preB Second list of pre-release identifiers.
- * @returns Negative number if preA < preB, 0 if equal, positive number if preA > preB.
+ * @return Negative number if preA < preB, 0 if equal, positive number if preA > preB.
  */
 function comparePrereleaseLists(preA: readonly string[], preB: readonly string[]): number {
   if (preA.length === 0 && preB.length === 0) {
@@ -235,7 +235,7 @@ function comparePrereleaseLists(preA: readonly string[], preB: readonly string[]
  *
  * @param a First version string or SemVer object.
  * @param b Second version string or SemVer object.
- * @returns Negative number if a < b, 0 if a == b, positive number if a > b.
+ * @return Negative number if a < b, 0 if a == b, positive number if a > b.
  */
 export function compareSemVer(
   a: string | SemVer | undefined | null,
@@ -271,7 +271,7 @@ export function compareSemVer(
  *
  * @param version The version string to check (e.g. 'v1.0', 'v1.1', 'v2.0').
  * @param minVersion The minimum version requirement (e.g. 'v1.0', '1.0.0').
- * @returns Whether version is at least minVersion.
+ * @return Whether version is at least minVersion.
  */
 export function isAtLeastVersion(
   version: string | SemVer | undefined | null,

--- a/typescript/web_core/src/common/semver.ts
+++ b/typescript/web_core/src/common/semver.ts
@@ -19,15 +19,15 @@
  */
 export interface SemVer {
   /** Major version number indicating breaking API changes. */
-  major: number;
+  readonly major: number;
   /** Minor version number indicating backwards-compatible features. */
-  minor: number;
+  readonly minor: number;
   /** Patch version number indicating backwards-compatible bug fixes. */
-  patch: number;
+  readonly patch: number;
   /** Dot-separated pre-release identifiers. */
-  prerelease: string[];
+  readonly prerelease: readonly string[];
   /** Dot-separated build metadata identifiers. */
-  build: string[];
+  readonly build: readonly string[];
 }
 
 /**
@@ -112,15 +112,45 @@ function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
   }
   if (typeof v === 'object') {
     const obj = v as Partial<SemVer>;
+    if (typeof obj.major !== 'number') {
+      return null;
+    }
     return {
-      major: typeof obj.major === 'number' ? obj.major : 0,
+      major: obj.major,
       minor: typeof obj.minor === 'number' ? obj.minor : 0,
       patch: typeof obj.patch === 'number' ? obj.patch : 0,
       prerelease: Array.isArray(obj.prerelease) ? obj.prerelease : [],
       build: Array.isArray(obj.build) ? obj.build : [],
     };
   }
-  return parseSemVer(v);
+  return parseSemVer(normalizeVersionString(v));
+}
+
+/**
+ * Formats a semantic version into a canonical string representation.
+ *
+ * For standard versions with zero patch and no pre-release or build metadata,
+ * returns `${major}.${minor}` (e.g. '0.8', '0.9', '1.0').
+ * For versions with non-zero patch, pre-release identifiers, or build metadata,
+ * returns the full SemVer string (e.g. '0.9.1', '1.0.0-beta.1').
+ *
+ * @param version The version string or SemVer object to canonicalize.
+ * @returns The canonical version string, or null if the input cannot be parsed.
+ */
+export function toCanonicalVersion(version: string | SemVer | undefined | null): string | null {
+  if (!version) {
+    return null;
+  }
+  const parsed = toSemVer(version);
+  if (!parsed) {
+    return null;
+  }
+  if (parsed.patch === 0 && parsed.prerelease.length === 0 && parsed.build.length === 0) {
+    return `${parsed.major}.${parsed.minor}`;
+  }
+  const pre = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join('.')}` : '';
+  const bld = parsed.build.length > 0 ? `+${parsed.build.join('.')}` : '';
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}${pre}${bld}`;
 }
 
 /**
@@ -167,7 +197,7 @@ function comparePrereleaseId(idA: string, idB: string): number {
  * @param preB Second list of pre-release identifiers.
  * @returns Negative number if preA < preB, 0 if equal, positive number if preA > preB.
  */
-function comparePrereleaseLists(preA: string[], preB: string[]): number {
+function comparePrereleaseLists(preA: readonly string[], preB: readonly string[]): number {
   if (preA.length === 0 && preB.length === 0) {
     return 0;
   }
@@ -250,34 +280,4 @@ export function isAtLeastVersion(
     return false;
   }
   return compareSemVer(parsed, minParsed) >= 0;
-}
-
-/**
- * Evaluates whether a catalog protocol version is compatible with an incoming message version.
- *
- * For versions >= 1.0, forward compatibility is allowed (catalog <= message).
- * For versions < 1.0, versions must match identically.
- *
- * @param catalogVersion The catalog's declared protocol version.
- * @param messageVersion The incoming message's declared protocol version.
- * @returns Whether the catalog version is compatible with the message version.
- */
-export function isCatalogVersionCompatible(
-  catalogVersion: string | SemVer | undefined | null,
-  messageVersion: string | SemVer | undefined | null,
-): boolean {
-  if (!catalogVersion || !messageVersion) {
-    return false;
-  }
-  const catSemVer = toSemVer(catalogVersion);
-  const msgSemVer = toSemVer(messageVersion);
-  if (catSemVer && msgSemVer) {
-    if (isAtLeastVersion(catSemVer, '1.0')) {
-      return compareSemVer(catSemVer, msgSemVer) <= 0;
-    }
-    return compareSemVer(catSemVer, msgSemVer) === 0;
-  }
-  const normCat = String(catalogVersion).replace(/^v/i, '');
-  const normMsg = String(messageVersion).replace(/^v/i, '');
-  return normCat === normMsg;
 }

--- a/typescript/web_core/src/common/semver.ts
+++ b/typescript/web_core/src/common/semver.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Structured representation of a semantic version according to Semantic Versioning 2.0.0 (https://semver.org/).
+ */
+export interface SemVer {
+  /** Major version number indicating breaking API changes. */
+  major: number;
+  /** Minor version number indicating backwards-compatible features. */
+  minor: number;
+  /** Patch version number indicating backwards-compatible bug fixes. */
+  patch: number;
+  /** Dot-separated pre-release identifiers. */
+  prerelease: string[];
+  /** Dot-separated build metadata identifiers. */
+  build: string[];
+}
+
+/**
+ * Official SemVer 2.0.0 regular expression from https://semver.org/,
+ * extended with optional leading 'v'/'V' and optional patch component for protocol compatibility.
+ *
+ * Capturing groups:
+ * 1: major (0|[1-9]\d*)
+ * 2: minor (0|[1-9]\d*)
+ * 3: patch (optional 0|[1-9]\d*)
+ * 4: prerelease (optional dot-separated identifiers)
+ * 5: buildmetadata (optional dot-separated identifiers)
+ */
+const SEMVER_REGEX =
+  /^[vV]?(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/**
+ * Normalizes a version string by stripping any leading 'v'/'V' and replacing underscores with dots in the core release segment.
+ *
+ * Preserves pre-release ('-') and build metadata ('+') suffixes intact.
+ *
+ * Examples:
+ *   'v1_0' -> '1.0'
+ *   'V1_0' -> '1.0'
+ *   'v0_9_1' -> '0.9.1'
+ *   '1_0_0-dev_release' -> '1.0.0-dev_release'
+ *
+ * @param version The raw version string to normalize.
+ * @returns The normalized version string, or empty string if input is falsy.
+ */
+export function normalizeVersionString(version: string | undefined | null): string {
+  if (!version || typeof version !== 'string') {
+    return '';
+  }
+  const text = version.trim().replace(/^[vV]/, '');
+  const dashIdx = text.indexOf('-');
+  const plusIdx = text.indexOf('+');
+  let splitIdx = text.length;
+  if (dashIdx !== -1 && plusIdx !== -1) {
+    splitIdx = Math.min(dashIdx, plusIdx);
+  } else if (dashIdx !== -1) {
+    splitIdx = dashIdx;
+  } else if (plusIdx !== -1) {
+    splitIdx = plusIdx;
+  }
+  const core = text.slice(0, splitIdx).replace(/_/g, '.');
+  return `${core}${text.slice(splitIdx)}`;
+}
+
+/**
+ * Parses a semantic version string according to SemVer 2.0.0.
+ *
+ * @param versionStr The version string to parse.
+ * @returns A SemVer object if valid, or null if the string cannot be parsed.
+ */
+export function parseSemVer(versionStr: string | undefined | null): SemVer | null {
+  if (!versionStr || typeof versionStr !== 'string') {
+    return null;
+  }
+  const match = versionStr.trim().match(SEMVER_REGEX);
+  if (!match) {
+    return null;
+  }
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: match[3] !== undefined ? parseInt(match[3], 10) : 0,
+    prerelease: match[4] ? match[4].split('.') : [],
+    build: match[5] ? match[5].split('.') : [],
+  };
+}
+
+/**
+ * Converts a string or partial SemVer object into a normalized SemVer representation.
+ *
+ * @param v The version string or object to convert.
+ * @returns A SemVer object if valid, or null otherwise.
+ */
+function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
+  if (!v) {
+    return null;
+  }
+  if (typeof v === 'object') {
+    const obj = v as Partial<SemVer>;
+    return {
+      major: typeof obj.major === 'number' ? obj.major : 0,
+      minor: typeof obj.minor === 'number' ? obj.minor : 0,
+      patch: typeof obj.patch === 'number' ? obj.patch : 0,
+      prerelease: Array.isArray(obj.prerelease) ? obj.prerelease : [],
+      build: Array.isArray(obj.build) ? obj.build : [],
+    };
+  }
+  return parseSemVer(v);
+}
+
+/**
+ * Compares two dot-separated pre-release identifiers per SemVer 2.0.0 Rule 11.4.
+ *
+ * @param idA First pre-release identifier.
+ * @param idB Second pre-release identifier.
+ * @returns Negative number if idA < idB, 0 if equal, positive number if idA > idB.
+ */
+function comparePrereleaseId(idA: string, idB: string): number {
+  const isNumA = /^\d+$/.test(idA);
+  const isNumB = /^\d+$/.test(idB);
+  if (isNumA && isNumB) {
+    if (idA.length !== idB.length) {
+      return idA.length - idB.length;
+    }
+    if (idA < idB) {
+      return -1;
+    }
+    if (idA > idB) {
+      return 1;
+    }
+    return 0;
+  }
+  if (isNumA) {
+    return -1; // Numeric identifiers have lower precedence than non-numeric
+  }
+  if (isNumB) {
+    return 1;
+  }
+  if (idA < idB) {
+    return -1;
+  }
+  if (idA > idB) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Compares pre-release identifier lists per SemVer 2.0.0 Rules 11.3 and 11.4.
+ *
+ * @param preA First list of pre-release identifiers.
+ * @param preB Second list of pre-release identifiers.
+ * @returns Negative number if preA < preB, 0 if equal, positive number if preA > preB.
+ */
+function comparePrereleaseLists(preA: string[], preB: string[]): number {
+  if (preA.length === 0 && preB.length === 0) {
+    return 0;
+  }
+  if (preA.length === 0) {
+    return 1; // Normal version has higher precedence than pre-release version
+  }
+  if (preB.length === 0) {
+    return -1;
+  }
+
+  const minLen = Math.min(preA.length, preB.length);
+  for (let i = 0; i < minLen; i++) {
+    const diff = comparePrereleaseId(preA[i], preB[i]);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  return preA.length - preB.length;
+}
+
+/**
+ * Compares two semantic version strings or SemVer objects according to SemVer 2.0.0 precedence rules (Section 11).
+ *
+ * 1. Precedence is determined by comparing major, minor, and patch numerically.
+ * 2. When major, minor, and patch are equal, a pre-release version has lower precedence than a normal version (e.g. 1.0.0-alpha < 1.0.0).
+ * 3. Precedence for two pre-release versions is determined by comparing dot-separated identifiers from left to right.
+ * 4. Build metadata does NOT figure into precedence.
+ *
+ * @param a First version string or SemVer object.
+ * @param b Second version string or SemVer object.
+ * @returns Negative number if a < b, 0 if a == b, positive number if a > b.
+ */
+export function compareSemVer(
+  a: string | SemVer | undefined | null,
+  b: string | SemVer | undefined | null,
+): number {
+  const vA = toSemVer(a);
+  const vB = toSemVer(b);
+  if (!vA && !vB) {
+    return 0;
+  }
+  if (!vA) {
+    return -1;
+  }
+  if (!vB) {
+    return 1;
+  }
+
+  if (vA.major !== vB.major) {
+    return vA.major - vB.major;
+  }
+  if (vA.minor !== vB.minor) {
+    return vA.minor - vB.minor;
+  }
+  if (vA.patch !== vB.patch) {
+    return vA.patch - vB.patch;
+  }
+
+  return comparePrereleaseLists(vA.prerelease, vB.prerelease);
+}
+
+/**
+ * Checks if a given version string is at least the target minimum version.
+ *
+ * @param version The version string to check (e.g. 'v1.0', 'v1.1', 'v2.0').
+ * @param minVersion The minimum version requirement (e.g. 'v1.0', '1.0.0').
+ * @returns Whether version is at least minVersion.
+ */
+export function isAtLeastVersion(
+  version: string | SemVer | undefined | null,
+  minVersion: string | SemVer,
+): boolean {
+  if (!version) {
+    return false;
+  }
+  const parsed = toSemVer(version);
+  const minParsed = toSemVer(minVersion);
+  if (!parsed || !minParsed) {
+    return false;
+  }
+  return compareSemVer(parsed, minParsed) >= 0;
+}
+
+/**
+ * Evaluates whether a catalog protocol version is compatible with an incoming message version.
+ *
+ * For versions >= 1.0, forward compatibility is allowed (catalog <= message).
+ * For versions < 1.0, versions must match identically.
+ *
+ * @param catalogVersion The catalog's declared protocol version.
+ * @param messageVersion The incoming message's declared protocol version.
+ * @returns Whether the catalog version is compatible with the message version.
+ */
+export function isCatalogVersionCompatible(
+  catalogVersion: string | SemVer | undefined | null,
+  messageVersion: string | SemVer | undefined | null,
+): boolean {
+  if (!catalogVersion || !messageVersion) {
+    return false;
+  }
+  const catSemVer = toSemVer(catalogVersion);
+  const msgSemVer = toSemVer(messageVersion);
+  if (catSemVer && msgSemVer) {
+    if (isAtLeastVersion(catSemVer, '1.0')) {
+      return compareSemVer(catSemVer, msgSemVer) <= 0;
+    }
+    return compareSemVer(catSemVer, msgSemVer) === 0;
+  }
+  const normCat = String(catalogVersion).replace(/^v/i, '');
+  const normMsg = String(messageVersion).replace(/^v/i, '');
+  return normCat === normMsg;
+}

--- a/typescript/web_core/src/common/semver.ts
+++ b/typescript/web_core/src/common/semver.ts
@@ -112,7 +112,13 @@ function toSemVer(v: string | SemVer | undefined | null): SemVer | null {
   }
   if (typeof v === 'object') {
     const obj = v as Partial<SemVer>;
-    if (typeof obj.major !== 'number') {
+    if (
+      typeof obj.major !== 'number' ||
+      !Number.isInteger(obj.major) ||
+      obj.major < 0 ||
+      (typeof obj.minor === 'number' && (!Number.isInteger(obj.minor) || obj.minor < 0)) ||
+      (typeof obj.patch === 'number' && (!Number.isInteger(obj.patch) || obj.patch < 0))
+    ) {
       return null;
     }
     return {

--- a/typescript/web_core/src/common/semver.ts
+++ b/typescript/web_core/src/common/semver.ts
@@ -235,29 +235,29 @@ export function compareSemVer(
   a: string | SemVer | undefined | null,
   b: string | SemVer | undefined | null,
 ): number {
-  const vA = toSemVer(a);
-  const vB = toSemVer(b);
-  if (!vA && !vB) {
+  const versionA = toSemVer(a);
+  const versionB = toSemVer(b);
+  if (!versionA && !versionB) {
     return 0;
   }
-  if (!vA) {
+  if (!versionA) {
     return -1;
   }
-  if (!vB) {
+  if (!versionB) {
     return 1;
   }
 
-  if (vA.major !== vB.major) {
-    return vA.major - vB.major;
+  if (versionA.major !== versionB.major) {
+    return versionA.major - versionB.major;
   }
-  if (vA.minor !== vB.minor) {
-    return vA.minor - vB.minor;
+  if (versionA.minor !== versionB.minor) {
+    return versionA.minor - versionB.minor;
   }
-  if (vA.patch !== vB.patch) {
-    return vA.patch - vB.patch;
+  if (versionA.patch !== versionB.patch) {
+    return versionA.patch - versionB.patch;
   }
 
-  return comparePrereleaseLists(vA.prerelease, vB.prerelease);
+  return comparePrereleaseLists(versionA.prerelease, versionB.prerelease);
 }
 
 /**

--- a/typescript/web_core/src/index.ts
+++ b/typescript/web_core/src/index.ts
@@ -30,3 +30,4 @@ export * from './reactivity/index.js';
 export * from './expressions/index.js';
 export * from './errors.js';
 export * from './common/events.js';
+export * from './common/semver.js';

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -523,4 +523,70 @@ describe('MessageProcessor Dependency Injection', () => {
         err instanceof A2uiValidationError && err.message.includes('Unsupported protocol version'),
     );
   });
+
+  it('aggregates all known actions across registered adapters', () => {
+    const factory = new VersionAdapterFactory();
+    const actions = factory.getAllKnownActions();
+    assert.ok(actions instanceof Set);
+    assert.strictEqual(actions.has('beginRendering'), true);
+    assert.strictEqual(actions.has('surfaceUpdate'), true);
+    assert.strictEqual(actions.has('dataModelUpdate'), true);
+    assert.strictEqual(actions.has('createSurface'), true);
+    assert.strictEqual(actions.has('updateComponents'), true);
+    assert.strictEqual(actions.has('updateDataModel'), true);
+    assert.strictEqual(actions.has('deleteSurface'), true);
+
+    const staticActions = VersionAdapterFactory.getAllKnownActions();
+    assert.strictEqual(staticActions.has('createSurface'), true);
+    assert.strictEqual(staticActions.has('beginRendering'), true);
+  });
+
+  it('rejects cross-version actions with A2uiValidationError', () => {
+    const v09 = VersionAdapterFactory.getAdapter('v0.9');
+    assert.throws(
+      () =>
+        v09.extractOperations({
+          version: 'v0.9',
+          beginRendering: {surfaceId: 's1'},
+        }),
+      (err: any) =>
+        err instanceof A2uiValidationError &&
+        /action 'beginRendering' is not supported in protocol version v0.9/.test(err.message),
+    );
+
+    const v10 = VersionAdapterFactory.getAdapter('v1.0');
+    assert.throws(
+      () =>
+        v10.extractOperations({
+          version: 'v1.0',
+          beginRendering: {surfaceId: 's1'},
+        }),
+      (err: any) =>
+        err instanceof A2uiValidationError &&
+        /action 'beginRendering' is not supported in protocol version v1.0/.test(err.message),
+    );
+
+    const v08 = VersionAdapterFactory.getAdapter('v0.8');
+    assert.throws(
+      () =>
+        v08.extractOperations({
+          createSurface: {surfaceId: 's1'},
+        }),
+      (err: any) =>
+        err instanceof A2uiValidationError &&
+        /action 'createSurface' is not supported in protocol version v0.8/.test(err.message),
+    );
+
+    // Completely unknown action
+    assert.throws(
+      () =>
+        v09.extractOperations({
+          version: 'v0.9',
+          completelyUnknownAction: {surfaceId: 's1'},
+        }),
+      (err: any) =>
+        err instanceof A2uiValidationError &&
+        /message must contain exactly one update action/.test(err.message),
+    );
+  });
 });

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -476,11 +476,14 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('1.0', v10Obj), true);
     assert.strictEqual(isCatalogVersionCompatible(v09Obj, v091Obj), true);
 
-    // Patch version compatibility for SemVer >= 1.0.0
+    // Patch and pre-release version compatibility for SemVer >= 1.0.0
     assert.strictEqual(isCatalogVersionCompatible('v1.0.1', 'v1.0'), true);
     assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.0.1'), true);
     assert.strictEqual(isCatalogVersionCompatible('1.0.2', '1.0.1'), true);
-    assert.strictEqual(isCatalogVersionCompatible('v1.0.1-alpha', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.1-alpha', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.0-beta.1', 'v1.0.0-rc.2'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.2.0-beta', 'v1.0.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.0-alpha', 'v2.0.0-alpha'), false);
     assert.strictEqual(isCatalogVersionCompatible('v1.1.0', 'v1.0.0'), true);
 
     // Falsy / invalid inputs

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -476,6 +476,13 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('1.0', v10Obj), true);
     assert.strictEqual(isCatalogVersionCompatible(v09Obj, v091Obj), true);
 
+    // Patch version compatibility for SemVer >= 1.0.0
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.1', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.0.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('1.0.2', '1.0.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.1-alpha', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.1.0', 'v1.0.0'), false);
+
     // Falsy / invalid inputs
     assert.strictEqual(isCatalogVersionCompatible(undefined, 'v1.0'), false);
     assert.strictEqual(isCatalogVersionCompatible('v1.0', undefined), false);
@@ -487,6 +494,8 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('v1.0', ''), false);
     assert.strictEqual(isCatalogVersionCompatible(null, 'None'), false);
     assert.strictEqual(isCatalogVersionCompatible('None', null), false);
+    assert.strictEqual(isCatalogVersionCompatible({} as any, {} as any), false);
+    assert.strictEqual(isCatalogVersionCompatible([] as any, [] as any), false);
   });
 
   it('evaluates compatibleCatalogVersions and isCatalogCompatible on adapter instances', () => {

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -105,6 +105,22 @@ describe('VersionAdapterFactory', () => {
     assert.deepStrictEqual(op.theme, {primaryColor: '#FF0000'});
   });
 
+  it('resolves unversioned deleteSurface to v0.8 adapter', () => {
+    const payload = {
+      deleteSurface: {
+        surfaceId: 's1',
+      },
+    };
+
+    const adapter = VersionAdapterFactory.resolveFromPayload(payload);
+    assert.strictEqual(adapter.version, 'v0.8');
+
+    const ops = adapter.extractOperations(payload);
+    assert.strictEqual(ops.length, 1);
+    assert.strictEqual(ops[0].type, 'deleteSurface');
+    assert.strictEqual((ops[0] as InternalDeleteSurfaceOp).surfaceId, 's1');
+  });
+
   it('extracts surfaceUpdate and dataModelUpdate operations in v0.8 adapter', () => {
     const adapter = VersionAdapterFactory.getAdapter('v0.8');
 
@@ -412,6 +428,20 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('custom', 'Vcustom'), true);
     assert.strictEqual(isCatalogVersionCompatible('custom', 'other'), false);
 
+    // v0.8 matches
+    assert.strictEqual(isCatalogVersionCompatible('v0.8', 'v0.8'), true);
+    assert.strictEqual(isCatalogVersionCompatible('0.8', 'v0.8'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.8', '0.8.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.8', 'v0.9'), false);
+
+    // SemVer object inputs
+    const v10Obj = {major: 1, minor: 0, patch: 0, prerelease: [], build: []};
+    const v09Obj = {major: 0, minor: 9, patch: 0, prerelease: [], build: []};
+    const v091Obj = {major: 0, minor: 9, patch: 1, prerelease: [], build: []};
+    assert.strictEqual(isCatalogVersionCompatible(v10Obj, '1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('1.0', v10Obj), true);
+    assert.strictEqual(isCatalogVersionCompatible(v09Obj, v091Obj), true);
+
     // Falsy / invalid inputs
     assert.strictEqual(isCatalogVersionCompatible(undefined, 'v1.0'), false);
     assert.strictEqual(isCatalogVersionCompatible('v1.0', undefined), false);
@@ -419,6 +449,10 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('v1.0', null), false);
     assert.strictEqual(isCatalogVersionCompatible(null, null), false);
     assert.strictEqual(isCatalogVersionCompatible('', ''), false);
+    assert.strictEqual(isCatalogVersionCompatible('', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', ''), false);
+    assert.strictEqual(isCatalogVersionCompatible(null, 'None'), false);
+    assert.strictEqual(isCatalogVersionCompatible('None', null), false);
   });
 
   it('evaluates compatibleCatalogVersions and isCatalogCompatible on adapter instances', () => {

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -197,6 +197,11 @@ describe('VersionAdapterFactory', () => {
     VersionAdapterFactory.registerAdapter(customAdapter);
     const resolved = VersionAdapterFactory.getAdapter('v2.0');
     assert.strictEqual(resolved.version, 'v2.0');
+    // Verify format-tolerant retrieval of dynamically registered adapters
+    assert.strictEqual(VersionAdapterFactory.getAdapter('2.0').version, 'v2.0');
+    assert.strictEqual(VersionAdapterFactory.getAdapter('2.0.0').version, 'v2.0');
+    assert.strictEqual(VersionAdapterFactory.getAdapter('v2.0.0').version, 'v2.0');
+    assert.strictEqual(VersionAdapterFactory.getAdapter('V2.0').version, 'v2.0');
 
     const ops = resolved.extractOperations({});
     assert.strictEqual(ops.length, 1);
@@ -209,12 +214,19 @@ describe('VersionAdapterFactory', () => {
       () => VersionAdapterFactory.getAdapter('v99.0'),
       err =>
         err instanceof A2uiValidationError &&
-        /Unsupported protocol version 'v99\.0'/.test(err.message),
+        /Unsupported protocol version 'v99\.0'/.test(err.message) &&
+        /Supported versions: .*v2\.0/.test(err.message),
     );
     assert.throws(
       () => VersionAdapterFactory.resolveFromPayload({}),
       err =>
         err instanceof A2uiValidationError && /missing a valid 'version' string/.test(err.message),
+    );
+    assert.throws(
+      () => VersionAdapterFactory.resolveFromPayload({version: 123}),
+      err =>
+        err instanceof A2uiValidationError &&
+        /'version' property must be a string, got number/.test(err.message),
     );
   });
 

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -444,8 +444,8 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('v0.9.1', 'v0.9'), true);
 
     // Unsupported future or cross-major versions are rejected
-    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.1'), false);
-    assert.strictEqual(isCatalogVersionCompatible('v1.1', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.1', 'v1.0'), true);
     assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v2.0'), false);
     assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v1.0'), false);
     assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v0.9'), false);
@@ -481,7 +481,7 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.0.1'), true);
     assert.strictEqual(isCatalogVersionCompatible('1.0.2', '1.0.1'), true);
     assert.strictEqual(isCatalogVersionCompatible('v1.0.1-alpha', 'v1.0'), false);
-    assert.strictEqual(isCatalogVersionCompatible('v1.1.0', 'v1.0.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.1.0', 'v1.0.0'), true);
 
     // Falsy / invalid inputs
     assert.strictEqual(isCatalogVersionCompatible(undefined, 'v1.0'), false);
@@ -520,7 +520,8 @@ describe('MessageProcessor Dependency Injection', () => {
     assert.strictEqual(v10.isCatalogCompatible('1.0.0'), true);
     assert.strictEqual(v10.isCatalogCompatible('v1_0'), true);
     assert.strictEqual(v10.isCatalogCompatible('v0.9'), false);
-    assert.strictEqual(v10.isCatalogCompatible('v1.1'), false);
+    assert.strictEqual(v10.isCatalogCompatible('v1.1'), true);
+    assert.strictEqual(v10.isCatalogCompatible('v2.0'), false);
     assert.strictEqual(v10.isCatalogCompatible(undefined), false);
   });
 

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -160,6 +160,28 @@ describe('VersionAdapterFactory', () => {
     );
   });
 
+  it('throws A2uiValidationError in adapters when payload version is invalid', () => {
+    const v09Adapter = VersionAdapterFactory.getAdapter('v0.9');
+    assert.throws(
+      () =>
+        v09Adapter.extractOperations({
+          version: 'v1.0',
+          createSurface: {surfaceId: 's1', catalogId: 'c1'},
+        }),
+      err => err instanceof A2uiValidationError && /Invalid v0.9 message/.test(err.message),
+    );
+
+    const v10Adapter = VersionAdapterFactory.getAdapter('v1.0');
+    assert.throws(
+      () =>
+        v10Adapter.extractOperations({
+          version: 'v0.9',
+          createSurface: {surfaceId: 's1', catalogId: 'c1'},
+        }),
+      err => err instanceof A2uiValidationError && /Invalid v1.0 message/.test(err.message),
+    );
+  });
+
   it('supports dynamic registration of custom version adapters', () => {
     const customAdapter: VersionAdapter = {
       version: 'v2.0',

--- a/typescript/web_core/src/processing/adapters/adapters.test.ts
+++ b/typescript/web_core/src/processing/adapters/adapters.test.ts
@@ -25,7 +25,15 @@ import {
   InternalUpdateDataModelOp,
   InternalDeleteSurfaceOp,
 } from '../operations.js';
-import {VersionAdapter} from './base.js';
+import {
+  VersionAdapter,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  DEFAULT_CATALOG_COMPATIBILITY,
+  isCatalogVersionCompatible,
+} from './base.js';
+import {V0Point8Adapter} from './v0_8.js';
+import {V0Point9Adapter} from './v0_9.js';
+import {V1Point0Adapter} from './v1_0.js';
 
 describe('VersionAdapterFactory', () => {
   it('resolves v1.0 adapter and extracts operations with initial state and surface properties', () => {
@@ -355,5 +363,108 @@ describe('MessageProcessor Dependency Injection', () => {
     const comp = surface?.componentsModel.get('t1');
     assert.strictEqual(comp?.properties.text, 'Hello');
     assert.strictEqual(comp?.properties.color, 'blue');
+  });
+
+  it('validates SUPPORTED_PROTOCOL_VERSIONS and DEFAULT_CATALOG_COMPATIBILITY', () => {
+    assert.ok(SUPPORTED_PROTOCOL_VERSIONS.has('1.0'));
+    assert.ok(SUPPORTED_PROTOCOL_VERSIONS.has('0.9.1'));
+    assert.ok(SUPPORTED_PROTOCOL_VERSIONS.has('0.9'));
+    assert.ok(SUPPORTED_PROTOCOL_VERSIONS.has('0.8'));
+    assert.strictEqual(SUPPORTED_PROTOCOL_VERSIONS.has('1.1'), false);
+    assert.ok(DEFAULT_CATALOG_COMPATIBILITY['0.9.1']?.has('0.9'));
+  });
+
+  it('evaluates isCatalogVersionCompatible correctly with supported sets', () => {
+    // Exact canonical matches across formatting variations
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('V1.0', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'V1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('1.0', 'v1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0.0', '1.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v1_0', '1.0.0'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('V0.9', '0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('0.9', 'V0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0_9', '0.9'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9.1', '0.9.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0_9_1', '0.9.1'), true);
+
+    // Backward compatibility between 0.9 and 0.9.1
+    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v0.9.1'), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9.1', 'v0.9'), true);
+
+    // Unsupported future or cross-major versions are rejected
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.1'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.1', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v2.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v0.9'), false);
+
+    // Custom compatibility map override
+    const customMap = {
+      '1.1': new Set(['1.0', '1.1']),
+    };
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', 'v1.1', customMap), true);
+    assert.strictEqual(isCatalogVersionCompatible('v0.9', 'v1.1', customMap), false);
+
+    // Custom non-semver fallback
+    assert.strictEqual(isCatalogVersionCompatible('Vcustom', 'vcustom'), true);
+    assert.strictEqual(isCatalogVersionCompatible('custom', 'Vcustom'), true);
+    assert.strictEqual(isCatalogVersionCompatible('custom', 'other'), false);
+
+    // Falsy / invalid inputs
+    assert.strictEqual(isCatalogVersionCompatible(undefined, 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', undefined), false);
+    assert.strictEqual(isCatalogVersionCompatible(null, 'v1.0'), false);
+    assert.strictEqual(isCatalogVersionCompatible('v1.0', null), false);
+    assert.strictEqual(isCatalogVersionCompatible(null, null), false);
+    assert.strictEqual(isCatalogVersionCompatible('', ''), false);
+  });
+
+  it('evaluates compatibleCatalogVersions and isCatalogCompatible on adapter instances', () => {
+    const v08 = new V0Point8Adapter();
+    assert.ok(v08.compatibleCatalogVersions.has('0.8'));
+    assert.strictEqual(v08.isCatalogCompatible('v0.8'), true);
+    assert.strictEqual(v08.isCatalogCompatible('0.8'), true);
+    assert.strictEqual(v08.isCatalogCompatible('v0.9'), false);
+
+    const v09 = new V0Point9Adapter();
+    assert.ok(v09.compatibleCatalogVersions.has('0.9'));
+    assert.ok(v09.compatibleCatalogVersions.has('0.9.1'));
+    assert.strictEqual(v09.isCatalogCompatible('v0.9'), true);
+    assert.strictEqual(v09.isCatalogCompatible('v0.9.1'), true);
+    assert.strictEqual(v09.isCatalogCompatible('0.9'), true);
+    assert.strictEqual(v09.isCatalogCompatible('0.9.1'), true);
+    assert.strictEqual(v09.isCatalogCompatible('v1.0'), false);
+
+    const v10 = new V1Point0Adapter();
+    assert.ok(v10.compatibleCatalogVersions.has('1.0'));
+    assert.strictEqual(v10.isCatalogCompatible('v1.0'), true);
+    assert.strictEqual(v10.isCatalogCompatible('1.0.0'), true);
+    assert.strictEqual(v10.isCatalogCompatible('v1_0'), true);
+    assert.strictEqual(v10.isCatalogCompatible('v0.9'), false);
+    assert.strictEqual(v10.isCatalogCompatible('v1.1'), false);
+    assert.strictEqual(v10.isCatalogCompatible(undefined), false);
+  });
+
+  it('resolves adapters by canonical and formatted version strings', () => {
+    const factory = new VersionAdapterFactory();
+    assert.strictEqual(factory.getAdapter('v1.0').version, 'v1.0');
+    assert.strictEqual(factory.getAdapter('1.0').version, 'v1.0');
+    assert.strictEqual(factory.getAdapter('1.0.0').version, 'v1.0');
+    assert.strictEqual(factory.getAdapter('v1_0').version, 'v1.0');
+    assert.strictEqual(factory.getAdapter('V1.0').version, 'v1.0');
+    assert.strictEqual(factory.getAdapter('v0.9.1').version, 'v0.9');
+    assert.strictEqual(factory.getAdapter('0.9.1').version, 'v0.9');
+    assert.strictEqual(factory.getAdapter('v0.9').version, 'v0.9');
+    assert.strictEqual(factory.getAdapter('0.9').version, 'v0.9');
+    assert.strictEqual(factory.getAdapter('v0.8').version, 'v0.8');
+    assert.strictEqual(factory.getAdapter('0.8').version, 'v0.8');
+
+    assert.throws(
+      () => factory.getAdapter('v1.1'),
+      (err: any) =>
+        err instanceof A2uiValidationError && err.message.includes('Unsupported protocol version'),
+    );
   });
 });

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -57,7 +57,7 @@ export const DEFAULT_CATALOG_COMPATIBILITY: Readonly<Record<string, ReadonlySet<
  * @param catalogVersion The catalog's declared protocol version.
  * @param messageVersion The incoming message or surface declared protocol version.
  * @param compatibilityMap Optional explicit compatibility mapping. Defaults to DEFAULT_CATALOG_COMPATIBILITY.
- * @returns Whether the catalog version is compatible with the message version.
+ * @return Whether the catalog version is compatible with the message version.
  */
 export function isCatalogVersionCompatible(
   catalogVersion: string | SemVer | undefined | null,
@@ -128,7 +128,7 @@ export interface VersionAdapter {
    * Checks if a catalog protocol version is compatible with this adapter.
    *
    * @param catalogVersion The catalog's declared protocol version.
-   * @returns Whether the catalog version is compatible.
+   * @return Whether the catalog version is compatible.
    */
   isCatalogCompatible?(catalogVersion: string | SemVer | undefined | null): boolean;
 
@@ -182,15 +182,18 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
   abstract readonly version: ProtocolVersion;
   protected abstract readonly schema: z.ZodTypeAny;
 
+  /** Canonical catalog protocol versions compatible with this adapter. */
   get compatibleCatalogVersions(): ReadonlySet<string> {
     const canonical = toCanonicalVersion(this.version);
     return canonical ? new Set([canonical]) : new Set();
   }
 
+  /** Set of valid message action keys supported by this protocol version. */
   get validActions(): ReadonlySet<string> {
     return new Set(this.getNativeActionKeys());
   }
 
+  /** Checks if a catalog protocol version is compatible with this adapter. */
   isCatalogCompatible(catalogVersion: string | SemVer | undefined | null): boolean {
     if (!catalogVersion) {
       return false;

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -102,6 +102,9 @@ export interface VersionAdapter {
   /** Set of canonical catalog protocol versions compatible with this adapter. */
   readonly compatibleCatalogVersions?: ReadonlySet<string>;
 
+  /** Set of action keys supported by this version adapter. */
+  readonly validActions?: ReadonlySet<string>;
+
   /**
    * Checks if a catalog protocol version is compatible with this adapter.
    *
@@ -119,17 +122,19 @@ export interface VersionAdapter {
   extractOperations(payload: unknown): InternalOperation[];
 }
 
-const ALL_KNOWN_ACTION_KEYS = [
-  'beginRendering',
-  'surfaceUpdate',
-  'dataModelUpdate',
-  'createSurface',
-  'updateComponents',
-  'updateDataModel',
-  'deleteSurface',
-  'callRendererFunction',
-  'agentFunctionResponse',
-] as const;
+/** Provider callback returning the set of all known action keys across registered adapters. */
+export type KnownActionsProvider = () => ReadonlySet<string>;
+
+let globalKnownActionsProvider: KnownActionsProvider | undefined;
+
+/**
+ * Registers a provider callback to dynamically supply known action keys across adapters.
+ *
+ * @param provider Callback returning a ReadonlySet of all known action keys.
+ */
+export function registerKnownActionsProvider(provider: KnownActionsProvider): void {
+  globalKnownActionsProvider = provider;
+}
 
 function validateActionSurfaceIds(
   msgObj: Record<string, unknown>,
@@ -163,6 +168,10 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
     return canonical ? new Set([canonical]) : new Set();
   }
 
+  get validActions(): ReadonlySet<string> {
+    return new Set(this.getNativeActionKeys());
+  }
+
   isCatalogCompatible(catalogVersion: string | SemVer | undefined | null): boolean {
     if (!catalogVersion) {
       return false;
@@ -188,13 +197,10 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
       return this.extractOperations(msgObj.messages);
     }
 
-    validateActionSurfaceIds(msgObj, ALL_KNOWN_ACTION_KEYS);
-
     const nativeActionKeys = this.getNativeActionKeys();
+    validateActionSurfaceIds(msgObj, nativeActionKeys);
+
     const presentNativeKeys = nativeActionKeys.filter(k => k in msgObj);
-    const presentOtherKnownKeys = ALL_KNOWN_ACTION_KEYS.filter(
-      k => !nativeActionKeys.includes(k) && k in msgObj,
-    );
 
     if (presentNativeKeys.length > 1) {
       throw new A2uiValidationError(
@@ -202,9 +208,21 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
       );
     }
 
-    // Ignore cross-version messages
-    if (presentNativeKeys.length === 0 && presentOtherKnownKeys.length > 0) {
-      return [];
+    if (presentNativeKeys.length === 0) {
+      const allKnown = globalKnownActionsProvider
+        ? globalKnownActionsProvider()
+        : new Set(nativeActionKeys);
+      const otherAction = Object.keys(msgObj).find(
+        k => allKnown.has(k) && !nativeActionKeys.includes(k),
+      );
+      if (otherAction) {
+        throw new A2uiValidationError(
+          `Invalid ${this.version} message: action '${otherAction}' is not supported in protocol version ${this.version}. Allowed actions: ${nativeActionKeys.join(', ')}.`,
+        );
+      }
+      throw new A2uiValidationError(
+        `Invalid ${this.version} message: message must contain exactly one update action: ${nativeActionKeys.join(', ')}.`,
+      );
     }
 
     const preparedPayload = this.preparePayloadForValidation(msgObj);

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -77,7 +77,7 @@ export function isCatalogVersionCompatible(
     if (compatible && compatible.has(catCanonical)) {
       return true;
     }
-    // For SemVer >= 1.0.0, patch releases within the same major.minor are compatible
+    // For SemVer >= 1.0.0, releases within the same major version are compatible
     const catSv = toSemVer(catalogVersion);
     const msgSv = toSemVer(messageVersion);
     if (
@@ -85,7 +85,6 @@ export function isCatalogVersionCompatible(
       msgSv &&
       catSv.major >= 1 &&
       catSv.major === msgSv.major &&
-      catSv.minor === msgSv.minor &&
       catSv.prerelease.length === 0 &&
       msgSv.prerelease.length === 0
     ) {
@@ -196,13 +195,7 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
     if (!catalogVersion) {
       return false;
     }
-    const canonical = toCanonicalVersion(catalogVersion);
-    if (canonical) {
-      return this.compatibleCatalogVersions.has(canonical);
-    }
-    const normCat = normalizeVersionString(String(catalogVersion));
-    const normSelf = normalizeVersionString(String(this.version));
-    return normCat.length > 0 && normCat === normSelf;
+    return isCatalogVersionCompatible(catalogVersion, this.version);
   }
 
   protected abstract getNativeActionKeys(): string[];

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -215,13 +215,14 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
       const otherAction = Object.keys(msgObj).find(
         k => allKnown.has(k) && !nativeActionKeys.includes(k),
       );
+      const sortedAllowed = nativeActionKeys.slice().sort().join(', ');
       if (otherAction) {
         throw new A2uiValidationError(
-          `Invalid ${this.version} message: action '${otherAction}' is not supported in protocol version ${this.version}. Allowed actions: ${nativeActionKeys.join(', ')}.`,
+          `Invalid ${this.version} message: action '${otherAction}' is not supported in protocol version ${this.version}. Allowed actions: ${sortedAllowed}.`,
         );
       }
       throw new A2uiValidationError(
-        `Invalid ${this.version} message: message must contain exactly one update action: ${nativeActionKeys.join(', ')}.`,
+        `Invalid ${this.version} message: message must contain exactly one update action: ${sortedAllowed}.`,
       );
     }
 

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -18,7 +18,7 @@ import {z} from 'zod';
 import {InternalOperation} from '../operations.js';
 import {A2uiValidationError} from '../../errors.js';
 import {formatZodIssue} from '../format-zod-issue.js';
-import {SemVer, normalizeVersionString, toCanonicalVersion} from '../../common/semver.js';
+import {SemVer, normalizeVersionString, toSemVer, toCanonicalVersion} from '../../common/semver.js';
 
 /**
  * Union of supported A2UI protocol version strings.
@@ -74,11 +74,31 @@ export function isCatalogVersionCompatible(
       return true;
     }
     const compatible = compatibilityMap[msgCanonical];
-    return compatible ? compatible.has(catCanonical) : false;
+    if (compatible && compatible.has(catCanonical)) {
+      return true;
+    }
+    // For SemVer >= 1.0.0, patch releases within the same major.minor are compatible
+    const catSv = toSemVer(catalogVersion);
+    const msgSv = toSemVer(messageVersion);
+    if (
+      catSv &&
+      msgSv &&
+      catSv.major >= 1 &&
+      catSv.major === msgSv.major &&
+      catSv.minor === msgSv.minor &&
+      catSv.prerelease.length === 0 &&
+      msgSv.prerelease.length === 0
+    ) {
+      return true;
+    }
+    return false;
   }
   // Fallback for non-semver custom identifiers (e.g. 'custom' vs 'Vcustom')
-  const normCat = normalizeVersionString(String(catalogVersion));
-  const normMsg = normalizeVersionString(String(messageVersion));
+  if (typeof catalogVersion !== 'string' || typeof messageVersion !== 'string') {
+    return false;
+  }
+  const normCat = normalizeVersionString(catalogVersion);
+  const normMsg = normalizeVersionString(messageVersion);
   return normCat.length > 0 && normCat === normMsg;
 }
 
@@ -200,7 +220,7 @@ export abstract class BaseVersionAdapter implements VersionAdapter {
     const nativeActionKeys = this.getNativeActionKeys();
     validateActionSurfaceIds(msgObj, nativeActionKeys);
 
-    const presentNativeKeys = nativeActionKeys.filter(k => k in msgObj);
+    const presentNativeKeys = nativeActionKeys.filter(k => k in msgObj).sort();
 
     if (presentNativeKeys.length > 1) {
       throw new A2uiValidationError(

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -67,26 +67,25 @@ export function isCatalogVersionCompatible(
   if (!catalogVersion || !messageVersion) {
     return false;
   }
-  const catCanonical = toCanonicalVersion(catalogVersion);
-  const msgCanonical = toCanonicalVersion(messageVersion);
-  if (catCanonical && msgCanonical) {
-    if (catCanonical === msgCanonical) {
+  const catalogCanonical = toCanonicalVersion(catalogVersion);
+  const messageCanonical = toCanonicalVersion(messageVersion);
+  if (catalogCanonical && messageCanonical) {
+    if (catalogCanonical === messageCanonical) {
       return true;
     }
-    const compatible = compatibilityMap[msgCanonical];
-    if (compatible && compatible.has(catCanonical)) {
+    const compatible = compatibilityMap[messageCanonical];
+    if (compatible && compatible.has(catalogCanonical)) {
       return true;
     }
-    // For SemVer >= 1.0.0, releases within the same major version are compatible
-    const catSv = toSemVer(catalogVersion);
-    const msgSv = toSemVer(messageVersion);
+    // For SemVer >= 1.0.0, releases within the same major version are compatible,
+    // ignoring pre-release identifiers.
+    const catalogSemver = toSemVer(catalogVersion);
+    const messageSemver = toSemVer(messageVersion);
     if (
-      catSv &&
-      msgSv &&
-      catSv.major >= 1 &&
-      catSv.major === msgSv.major &&
-      catSv.prerelease.length === 0 &&
-      msgSv.prerelease.length === 0
+      catalogSemver &&
+      messageSemver &&
+      catalogSemver.major >= 1 &&
+      catalogSemver.major === messageSemver.major
     ) {
       return true;
     }
@@ -96,9 +95,9 @@ export function isCatalogVersionCompatible(
   if (typeof catalogVersion !== 'string' || typeof messageVersion !== 'string') {
     return false;
   }
-  const normCat = normalizeVersionString(catalogVersion);
-  const normMsg = normalizeVersionString(messageVersion);
-  return normCat.length > 0 && normCat === normMsg;
+  const normalizedCatalog = normalizeVersionString(catalogVersion);
+  const normalizedMessage = normalizeVersionString(messageVersion);
+  return normalizedCatalog.length > 0 && normalizedCatalog === normalizedMessage;
 }
 
 /**

--- a/typescript/web_core/src/processing/adapters/base.ts
+++ b/typescript/web_core/src/processing/adapters/base.ts
@@ -17,12 +17,70 @@
 import {z} from 'zod';
 import {InternalOperation} from '../operations.js';
 import {A2uiValidationError} from '../../errors.js';
-import {formatZodIssue} from '../message-processor.js';
+import {formatZodIssue} from '../format-zod-issue.js';
+import {SemVer, normalizeVersionString, toCanonicalVersion} from '../../common/semver.js';
 
 /**
  * Union of supported A2UI protocol version strings.
  */
 export type ProtocolVersion = 'v0.8' | 'v0.9' | 'v0.9.1' | 'v1.0' | (string & {});
+
+/**
+ * Canonical protocol versions supported by the A2UI runtime.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS: ReadonlySet<string> = new Set([
+  '0.8',
+  '0.9',
+  '0.9.1',
+  '1.0',
+]);
+
+/**
+ * Default explicit catalog-to-message protocol compatibility mapping.
+ *
+ * Maps an incoming message or surface protocol version to the set of catalog
+ * protocol specification versions that it can accommodate.
+ */
+export const DEFAULT_CATALOG_COMPATIBILITY: Readonly<Record<string, ReadonlySet<string>>> = {
+  '0.8': new Set(['0.8']),
+  '0.9': new Set(['0.9', '0.9.1']),
+  '0.9.1': new Set(['0.9.1', '0.9']),
+  '1.0': new Set(['1.0']),
+};
+
+/**
+ * Evaluates whether a catalog protocol version is compatible with an incoming message or surface version.
+ *
+ * Compatibility is verified against explicit supported version sets.
+ * Minor formatting differences ('v1.0', '1.0', '1.0.0', 'v1_0') normalize to the same canonical version.
+ *
+ * @param catalogVersion The catalog's declared protocol version.
+ * @param messageVersion The incoming message or surface declared protocol version.
+ * @param compatibilityMap Optional explicit compatibility mapping. Defaults to DEFAULT_CATALOG_COMPATIBILITY.
+ * @returns Whether the catalog version is compatible with the message version.
+ */
+export function isCatalogVersionCompatible(
+  catalogVersion: string | SemVer | undefined | null,
+  messageVersion: string | SemVer | undefined | null,
+  compatibilityMap: Readonly<Record<string, ReadonlySet<string>>> = DEFAULT_CATALOG_COMPATIBILITY,
+): boolean {
+  if (!catalogVersion || !messageVersion) {
+    return false;
+  }
+  const catCanonical = toCanonicalVersion(catalogVersion);
+  const msgCanonical = toCanonicalVersion(messageVersion);
+  if (catCanonical && msgCanonical) {
+    if (catCanonical === msgCanonical) {
+      return true;
+    }
+    const compatible = compatibilityMap[msgCanonical];
+    return compatible ? compatible.has(catCanonical) : false;
+  }
+  // Fallback for non-semver custom identifiers (e.g. 'custom' vs 'Vcustom')
+  const normCat = normalizeVersionString(String(catalogVersion));
+  const normMsg = normalizeVersionString(String(messageVersion));
+  return normCat.length > 0 && normCat === normMsg;
+}
 
 /**
  * Resolves a version adapter for a given protocol version or raw payload.
@@ -40,6 +98,17 @@ export interface VersionAdapterResolver {
 export interface VersionAdapter {
   /** Protocol version string supported by this adapter (e.g. 'v1.0'). */
   readonly version: ProtocolVersion;
+
+  /** Set of canonical catalog protocol versions compatible with this adapter. */
+  readonly compatibleCatalogVersions?: ReadonlySet<string>;
+
+  /**
+   * Checks if a catalog protocol version is compatible with this adapter.
+   *
+   * @param catalogVersion The catalog's declared protocol version.
+   * @returns Whether the catalog version is compatible.
+   */
+  isCatalogCompatible?(catalogVersion: string | SemVer | undefined | null): boolean;
 
   /**
    * Converts a raw message payload or payload list into canonical internal operations.
@@ -88,6 +157,24 @@ function validateActionSurfaceIds(
 export abstract class BaseVersionAdapter implements VersionAdapter {
   abstract readonly version: ProtocolVersion;
   protected abstract readonly schema: z.ZodTypeAny;
+
+  get compatibleCatalogVersions(): ReadonlySet<string> {
+    const canonical = toCanonicalVersion(this.version);
+    return canonical ? new Set([canonical]) : new Set();
+  }
+
+  isCatalogCompatible(catalogVersion: string | SemVer | undefined | null): boolean {
+    if (!catalogVersion) {
+      return false;
+    }
+    const canonical = toCanonicalVersion(catalogVersion);
+    if (canonical) {
+      return this.compatibleCatalogVersions.has(canonical);
+    }
+    const normCat = normalizeVersionString(String(catalogVersion));
+    const normSelf = normalizeVersionString(String(this.version));
+    return normCat.length > 0 && normCat === normSelf;
+  }
 
   protected abstract getNativeActionKeys(): string[];
 

--- a/typescript/web_core/src/processing/adapters/factory.ts
+++ b/typescript/web_core/src/processing/adapters/factory.ts
@@ -77,7 +77,12 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
       if ('version' in item && typeof (item as {version: unknown}).version === 'string') {
         return this.getAdapter((item as {version: string}).version);
       }
-      if ('beginRendering' in item || 'surfaceUpdate' in item || 'dataModelUpdate' in item) {
+      if (
+        'beginRendering' in item ||
+        'surfaceUpdate' in item ||
+        'dataModelUpdate' in item ||
+        'deleteSurface' in item
+      ) {
         return this.getAdapter('v0.8');
       }
     }

--- a/typescript/web_core/src/processing/adapters/factory.ts
+++ b/typescript/web_core/src/processing/adapters/factory.ts
@@ -15,6 +15,7 @@
  */
 
 import {A2uiValidationError} from '../../errors.js';
+import {parseSemVer} from '../../common/semver.js';
 import {ProtocolVersion, VersionAdapter, VersionAdapterResolver} from './base.js';
 import {V0Point8Adapter} from './v0_8.js';
 import {V0Point9Adapter} from './v0_9.js';
@@ -48,7 +49,17 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
    * @throws A2uiValidationError if the version string is unsupported.
    */
   getAdapter(version: ProtocolVersion | string): VersionAdapter {
-    const adapter = this.adapters.get(version);
+    let adapter = this.adapters.get(version);
+    if (!adapter) {
+      const parsed = parseSemVer(version);
+      if (parsed) {
+        if (parsed.major === 0 && parsed.minor === 9 && parsed.patch === 1) {
+          adapter = this.adapters.get('v0.9.1');
+        } else {
+          adapter = this.adapters.get(`v${parsed.major}.${parsed.minor}`);
+        }
+      }
+    }
     if (!adapter) {
       const supported = Array.from(this.adapters.keys()).join(', ');
       throw new A2uiValidationError(

--- a/typescript/web_core/src/processing/adapters/factory.ts
+++ b/typescript/web_core/src/processing/adapters/factory.ts
@@ -16,7 +16,12 @@
 
 import {A2uiValidationError} from '../../errors.js';
 import {normalizeVersionString, toCanonicalVersion} from '../../common/semver.js';
-import {ProtocolVersion, VersionAdapter, VersionAdapterResolver} from './base.js';
+import {
+  ProtocolVersion,
+  VersionAdapter,
+  VersionAdapterResolver,
+  registerKnownActionsProvider,
+} from './base.js';
 import {V0Point8Adapter} from './v0_8.js';
 import {V0Point9Adapter} from './v0_9.js';
 import {V1Point0Adapter} from './v1_0.js';
@@ -31,6 +36,21 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
     ['0.9.1', new V0Point9Adapter()],
     ['1.0', new V1Point0Adapter()],
   ]);
+
+  /**
+   * Returns the aggregated set of all action keys supported by all registered adapters.
+   */
+  getAllKnownActions(): ReadonlySet<string> {
+    const actions = new Set<string>();
+    for (const adapter of this.adapters.values()) {
+      if (adapter.validActions) {
+        for (const action of adapter.validActions) {
+          actions.add(action);
+        }
+      }
+    }
+    return actions;
+  }
 
   /**
    * Dynamically registers a version adapter on this factory instance.
@@ -119,7 +139,16 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
   static resolveFromPayload(payload: unknown): VersionAdapter {
     return defaultVersionAdapterFactory.resolveFromPayload(payload);
   }
+
+  /**
+   * Returns the aggregated set of all action keys supported by all registered adapters
+   * from the default singleton factory instance.
+   */
+  static getAllKnownActions(): ReadonlySet<string> {
+    return defaultVersionAdapterFactory.getAllKnownActions();
+  }
 }
 
 /** Default singleton version adapter factory instance. */
 export const defaultVersionAdapterFactory = new VersionAdapterFactory();
+registerKnownActionsProvider(() => defaultVersionAdapterFactory.getAllKnownActions());

--- a/typescript/web_core/src/processing/adapters/factory.ts
+++ b/typescript/web_core/src/processing/adapters/factory.ts
@@ -73,7 +73,11 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
     const key = toCanonicalVersion(version) ?? normalizeVersionString(version);
     const adapter = this.adapters.get(key);
     if (!adapter) {
-      const supported = ['v0.8', 'v0.9', 'v0.9.1', 'v1.0'].join(', ');
+      const supported = Array.from(
+        new Set(Array.from(this.adapters.keys()).map(k => (k.startsWith('v') ? k : `v${k}`))),
+      )
+        .sort()
+        .join(', ');
       throw new A2uiValidationError(
         `[VersionAdapterFactory] Unsupported protocol version '${version}'. Supported versions: ${supported}.`,
       );
@@ -94,8 +98,14 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
       if ('messages' in item && Array.isArray((item as any).messages)) {
         return this.resolveFromPayload((item as any).messages);
       }
-      if ('version' in item && typeof (item as {version: unknown}).version === 'string') {
-        return this.getAdapter((item as {version: string}).version);
+      if ('version' in item) {
+        const ver = (item as {version: unknown}).version;
+        if (typeof ver !== 'string') {
+          throw new A2uiValidationError(
+            `[VersionAdapterFactory] Message payload is missing a valid 'version' string: 'version' property must be a string, got ${typeof ver}.`,
+          );
+        }
+        return this.getAdapter(ver);
       }
       if (
         'beginRendering' in item ||

--- a/typescript/web_core/src/processing/adapters/factory.ts
+++ b/typescript/web_core/src/processing/adapters/factory.ts
@@ -15,7 +15,7 @@
  */
 
 import {A2uiValidationError} from '../../errors.js';
-import {parseSemVer} from '../../common/semver.js';
+import {normalizeVersionString, toCanonicalVersion} from '../../common/semver.js';
 import {ProtocolVersion, VersionAdapter, VersionAdapterResolver} from './base.js';
 import {V0Point8Adapter} from './v0_8.js';
 import {V0Point9Adapter} from './v0_9.js';
@@ -26,10 +26,10 @@ import {V1Point0Adapter} from './v1_0.js';
  */
 export class VersionAdapterFactory implements VersionAdapterResolver {
   private readonly adapters = new Map<string, VersionAdapter>([
-    ['v0.8', new V0Point8Adapter()],
-    ['v0.9', new V0Point9Adapter()],
-    ['v0.9.1', new V0Point9Adapter()],
-    ['v1.0', new V1Point0Adapter()],
+    ['0.8', new V0Point8Adapter()],
+    ['0.9', new V0Point9Adapter()],
+    ['0.9.1', new V0Point9Adapter()],
+    ['1.0', new V1Point0Adapter()],
   ]);
 
   /**
@@ -38,7 +38,8 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
    * @param adapter The version adapter instance to register.
    */
   registerAdapter(adapter: VersionAdapter): void {
-    this.adapters.set(adapter.version, adapter);
+    const key = toCanonicalVersion(adapter.version) ?? normalizeVersionString(adapter.version);
+    this.adapters.set(key, adapter);
   }
 
   /**
@@ -49,19 +50,10 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
    * @throws A2uiValidationError if the version string is unsupported.
    */
   getAdapter(version: ProtocolVersion | string): VersionAdapter {
-    let adapter = this.adapters.get(version);
+    const key = toCanonicalVersion(version) ?? normalizeVersionString(version);
+    const adapter = this.adapters.get(key);
     if (!adapter) {
-      const parsed = parseSemVer(version);
-      if (parsed) {
-        if (parsed.major === 0 && parsed.minor === 9 && parsed.patch === 1) {
-          adapter = this.adapters.get('v0.9.1');
-        } else {
-          adapter = this.adapters.get(`v${parsed.major}.${parsed.minor}`);
-        }
-      }
-    }
-    if (!adapter) {
-      const supported = Array.from(this.adapters.keys()).join(', ');
+      const supported = ['v0.8', 'v0.9', 'v0.9.1', 'v1.0'].join(', ');
       throw new A2uiValidationError(
         `[VersionAdapterFactory] Unsupported protocol version '${version}'. Supported versions: ${supported}.`,
       );

--- a/typescript/web_core/src/processing/adapters/factory.ts
+++ b/typescript/web_core/src/processing/adapters/factory.ts
@@ -39,6 +39,8 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
 
   /**
    * Returns the aggregated set of all action keys supported by all registered adapters.
+   *
+   * @return A set of all supported action key strings.
    */
   getAllKnownActions(): ReadonlySet<string> {
     const actions = new Set<string>();
@@ -66,7 +68,7 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
    * Resolves the version adapter for the specified version string from this factory instance.
    *
    * @param version The protocol version string (e.g. 'v1.0').
-   * @returns The matching version adapter.
+   * @return The matching version adapter.
    * @throws A2uiValidationError if the version string is unsupported.
    */
   getAdapter(version: ProtocolVersion | string): VersionAdapter {
@@ -134,7 +136,7 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
    * Resolves a version adapter for the specified version from the default singleton factory instance.
    *
    * @param version Protocol version string.
-   * @returns Matching version adapter.
+   * @return Matching version adapter.
    */
   static getAdapter(version: ProtocolVersion | string): VersionAdapter {
     return defaultVersionAdapterFactory.getAdapter(version);
@@ -153,6 +155,8 @@ export class VersionAdapterFactory implements VersionAdapterResolver {
   /**
    * Returns the aggregated set of all action keys supported by all registered adapters
    * from the default singleton factory instance.
+   *
+   * @return A set of all supported action key strings.
    */
   static getAllKnownActions(): ReadonlySet<string> {
     return defaultVersionAdapterFactory.getAllKnownActions();

--- a/typescript/web_core/src/processing/adapters/v0_8.ts
+++ b/typescript/web_core/src/processing/adapters/v0_8.ts
@@ -92,6 +92,7 @@ export class V0Point8Adapter extends BaseVersionAdapter {
           cs?.dataModel && typeof cs.dataModel === 'object' && !Array.isArray(cs.dataModel)
             ? (cs.dataModel as Record<string, unknown>)
             : undefined,
+        version: typeof msgObj.version === 'string' ? msgObj.version : this.version,
       });
     }
     if ('surfaceUpdate' in msgObj) {

--- a/typescript/web_core/src/processing/adapters/v0_9.ts
+++ b/typescript/web_core/src/processing/adapters/v0_9.ts
@@ -50,6 +50,7 @@ export class V0Point9Adapter extends BaseVersionAdapter {
           cs?.dataModel && typeof cs.dataModel === 'object' && !Array.isArray(cs.dataModel)
             ? (cs.dataModel as Record<string, unknown>)
             : undefined,
+        version: typeof msgObj.version === 'string' ? msgObj.version : this.version,
       });
     }
     if ('updateComponents' in msgObj) {

--- a/typescript/web_core/src/processing/adapters/v0_9.ts
+++ b/typescript/web_core/src/processing/adapters/v0_9.ts
@@ -25,6 +25,10 @@ export class V0Point9Adapter extends BaseVersionAdapter {
   readonly version: ProtocolVersion = 'v0.9';
   protected readonly schema = A2uiMessageSchema;
 
+  override get compatibleCatalogVersions(): ReadonlySet<string> {
+    return new Set(['0.9', '0.9.1']);
+  }
+
   protected getNativeActionKeys(): string[] {
     return ['createSurface', 'updateComponents', 'updateDataModel', 'deleteSurface'];
   }

--- a/typescript/web_core/src/processing/adapters/v1_0.ts
+++ b/typescript/web_core/src/processing/adapters/v1_0.ts
@@ -49,6 +49,7 @@ export class V1Point0Adapter extends BaseVersionAdapter {
           cs?.dataModel && typeof cs.dataModel === 'object' && !Array.isArray(cs.dataModel)
             ? (cs.dataModel as Record<string, unknown>)
             : undefined,
+        version: typeof msgObj.version === 'string' ? msgObj.version : this.version,
       });
     }
     if ('updateComponents' in msgObj) {

--- a/typescript/web_core/src/processing/format-zod-issue.ts
+++ b/typescript/web_core/src/processing/format-zod-issue.ts
@@ -19,6 +19,11 @@ import {z} from 'zod';
 /**
  * Formats a single Zod issue into a human-readable diagnostic message.
  *
+ * Direct attribute extraction is used so that issue details (such as unrecognized
+ * property keys or invalid enum options) are preserved even when running in
+ * optimized/minified production builds where Zod's internal error map messages
+ * may be obfuscated or stripped.
+ *
  * @param err Zod validation issue to format.
  * @returns Human-readable formatted error message.
  */

--- a/typescript/web_core/src/processing/format-zod-issue.ts
+++ b/typescript/web_core/src/processing/format-zod-issue.ts
@@ -25,7 +25,7 @@ import {z} from 'zod';
  * may be obfuscated or stripped.
  *
  * @param err Zod validation issue to format.
- * @returns Human-readable formatted error message.
+ * @return Human-readable formatted error message.
  */
 export function formatZodIssue(err: z.ZodIssue): string {
   const path = err.path.join('.') || 'root';

--- a/typescript/web_core/src/processing/format-zod-issue.ts
+++ b/typescript/web_core/src/processing/format-zod-issue.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {z} from 'zod';
+
+/**
+ * Formats a single Zod issue into a human-readable diagnostic message.
+ *
+ * @param err Zod validation issue to format.
+ * @returns Human-readable formatted error message.
+ */
+export function formatZodIssue(err: z.ZodIssue): string {
+  const path = err.path.join('.') || 'root';
+
+  switch (err.code) {
+    case z.ZodIssueCode.invalid_union: {
+      const unionIssues = (err as z.ZodInvalidUnionIssue).unionErrors?.flatMap(uErr => uErr.issues);
+      if (unionIssues && unionIssues.length > 0) {
+        return unionIssues.map(formatZodIssue).join('; ');
+      }
+      return `${path}: Invalid union`;
+    }
+
+    case z.ZodIssueCode.unrecognized_keys: {
+      const keysStr = (err as z.ZodUnrecognizedKeysIssue).keys.map(k => `'${k}'`).join(', ');
+      return `${path}: Unrecognized key(s) in object: ${keysStr}`;
+    }
+
+    case z.ZodIssueCode.invalid_enum_value: {
+      const issue = err as z.ZodInvalidEnumValueIssue;
+      const optionsStr = issue.options.map(o => String(o)).join(' | ');
+      return `${path}: Invalid enum value. Expected ${optionsStr}, received '${String(issue.received)}'`;
+    }
+
+    case z.ZodIssueCode.invalid_type: {
+      const issue = err as z.ZodInvalidTypeIssue;
+      return `${path}: Expected ${issue.expected}, received ${issue.received}`;
+    }
+
+    case z.ZodIssueCode.custom:
+      return `${path}: ${err.message}`;
+
+    default:
+      return err.message ? `${path}: ${err.message}` : `${path}: Validation error (${err.code})`;
+  }
+}

--- a/typescript/web_core/src/processing/message-processor.test.ts
+++ b/typescript/web_core/src/processing/message-processor.test.ts
@@ -953,6 +953,58 @@ describe('MessageProcessor', () => {
         },
       );
     });
+
+    it('fails when component references a catalog with incompatible specification version', () => {
+      const surfaceCatalog = new Catalog(
+        'cat-v1',
+        [{name: 'RootBox', schema: z.object({})}],
+        [],
+        undefined,
+        undefined,
+        '1.0',
+      );
+      const incompatCatalog = new Catalog(
+        'cat-v08',
+        [{name: 'OldCard', schema: z.object({})}],
+        [],
+        undefined,
+        undefined,
+        '0.8',
+      );
+      const processor = new MessageProcessor([surfaceCatalog, incompatCatalog]);
+
+      processor.processMessages({
+        version: 'v1.0',
+        createSurface: {surfaceId: 'surface-1', catalogId: 'cat-v1'},
+      });
+
+      assert.throws(
+        () => {
+          processor.processMessages({
+            version: 'v1.0',
+            updateComponents: {
+              surfaceId: 'surface-1',
+              components: [
+                {
+                  id: 'c1',
+                  component: 'OldCard',
+                  catalogId: 'cat-v08',
+                },
+              ],
+            },
+          });
+        },
+        (err: any) => {
+          assert.ok(err instanceof A2uiValidationError);
+          assert.ok(
+            err.message.includes(
+              "catalog 'cat-v08' specification version (0.8) does not match surface default catalog version (1.0)",
+            ),
+          );
+          return true;
+        },
+      );
+    });
   });
 
   describe('MessageProcessor Full Pipeline & Validation Integration', () => {

--- a/typescript/web_core/src/processing/message-processor.ts
+++ b/typescript/web_core/src/processing/message-processor.ts
@@ -22,7 +22,6 @@ import {ComponentModel} from '../state/component-model.js';
 import {SurfaceComponentsModel} from '../state/surface-components-model.js';
 import {DataModel} from '../state/data-model.js';
 import {Subscription} from '../common/events.js';
-import {z} from 'zod';
 
 import {A2uiStateError, A2uiValidationError} from '../errors.js';
 import {defaultVersionAdapterFactory} from './adapters/factory.js';
@@ -134,48 +133,9 @@ export interface MessageProcessorOptions {
  * Direct attribute extraction is used so that issue details (such as unrecognized
  * property keys or invalid enum options) are preserved even when running in
  * optimized/minified production builds where Zod's internal error map messages
- * may degrade into generic strings (e.g. "Expected undefined, received undefined").
-/**
- * Formats a Zod validation issue into a descriptive, human-readable error string.
- *
- * @param err Zod validation issue to format.
- * @returns Human-readable formatted error message.
  */
-export function formatZodIssue(err: z.ZodIssue): string {
-  const path = err.path.join('.') || 'root';
-
-  switch (err.code) {
-    case z.ZodIssueCode.invalid_union: {
-      const unionIssues = (err as z.ZodInvalidUnionIssue).unionErrors?.flatMap(uErr => uErr.issues);
-      if (unionIssues && unionIssues.length > 0) {
-        return unionIssues.map(formatZodIssue).join('; ');
-      }
-      return `${path}: Invalid union`;
-    }
-
-    case z.ZodIssueCode.unrecognized_keys: {
-      const keysStr = (err as z.ZodUnrecognizedKeysIssue).keys.map(k => `'${k}'`).join(', ');
-      return `${path}: Unrecognized key(s) in object: ${keysStr}`;
-    }
-
-    case z.ZodIssueCode.invalid_enum_value: {
-      const issue = err as z.ZodInvalidEnumValueIssue;
-      const optionsStr = issue.options.map(o => String(o)).join(' | ');
-      return `${path}: Invalid enum value. Expected ${optionsStr}, received '${String(issue.received)}'`;
-    }
-
-    case z.ZodIssueCode.invalid_type: {
-      const issue = err as z.ZodInvalidTypeIssue;
-      return `${path}: Expected ${issue.expected}, received ${issue.received}`;
-    }
-
-    case z.ZodIssueCode.custom:
-      return `${path}: ${err.message}`;
-
-    default:
-      return err.message ? `${path}: ${err.message}` : `${path}: Validation error (${err.code})`;
-  }
-}
+import {formatZodIssue} from './format-zod-issue.js';
+export {formatZodIssue};
 
 /**
  * Central processor for A2UI protocol messages and surface state management.

--- a/typescript/web_core/src/processing/message-processor.ts
+++ b/typescript/web_core/src/processing/message-processor.ts
@@ -35,7 +35,11 @@ import {
   isInternalOperation,
 } from './operations.js';
 
-import {ProtocolVersion, VersionAdapterResolver} from './adapters/base.js';
+import {
+  isCatalogVersionCompatible,
+  ProtocolVersion,
+  VersionAdapterResolver,
+} from './adapters/base.js';
 import {RendererCapabilities} from '../v1_0/schema/index.js';
 import type {ServerToClientMessage as V08ServerToClientMessage} from '../v0_8/types/types.js';
 import type {
@@ -128,13 +132,6 @@ export interface MessageProcessorOptions {
   defaultTimeoutMs?: number;
 }
 
-/**
- * Formats a Zod validation issue into a descriptive, human-readable string.
- *
- * Direct attribute extraction is used so that issue details (such as unrecognized
- * property keys or invalid enum options) are preserved even when running in
- * optimized/minified production builds where Zod's internal error map messages
- */
 import {formatZodIssue} from './format-zod-issue.js';
 export {formatZodIssue};
 
@@ -643,6 +640,15 @@ export class MessageProcessor<T extends ComponentApi = ComponentApi> {
         if (!found) {
           throw new A2uiValidationError(
             `Unknown catalog ID '${rawCatalogId}' for component '${id}'. Available catalogs: ${this.catalogs.map(c => c.id).join(', ')}`,
+          );
+        }
+        if (
+          found.protocolVersion &&
+          surface.catalog.protocolVersion &&
+          !isCatalogVersionCompatible(found.protocolVersion, surface.catalog.protocolVersion)
+        ) {
+          throw new A2uiValidationError(
+            `Component '${id}' catalog '${rawCatalogId}' specification version (${found.protocolVersion}) does not match surface default catalog version (${surface.catalog.protocolVersion}).`,
           );
         }
         targetCatalog = found;

--- a/typescript/web_core/src/processing/message-processor.ts
+++ b/typescript/web_core/src/processing/message-processor.ts
@@ -25,6 +25,7 @@ import {Subscription} from '../common/events.js';
 
 import {A2uiStateError, A2uiValidationError} from '../errors.js';
 import {defaultVersionAdapterFactory} from './adapters/factory.js';
+import {toCanonicalVersion} from '../common/semver.js';
 import {
   InternalOperation,
   InternalCreateSurfaceOp,
@@ -223,9 +224,10 @@ export class MessageProcessor<T extends ComponentApi = ComponentApi> {
 
     const inlineCatalogs = options?.includeInlineCatalogs
       ? this.catalogs.map(c => {
-          if (version === 'v1.0') {
+          if (toCanonicalVersion(version) === '1.0') {
             return generateCatalogSchema(c, {
               componentEnvelopeRef: options?.componentEnvelopeRef,
+              protocolVersion: version,
             });
           }
           return this.generateLegacyInlineCatalog(
@@ -454,10 +456,14 @@ export class MessageProcessor<T extends ComponentApi = ComponentApi> {
     const checkMsg = (msg: unknown) => {
       if (typeof msg === 'object' && msg !== null && 'version' in msg) {
         const msgVer = (msg as {version?: string}).version;
-        if (msgVer && msgVer !== expected) {
-          throw new A2uiValidationError(
-            `Message version '${msgVer}' does not match expected target version '${expected}'`,
-          );
+        if (msgVer) {
+          const normMsg = toCanonicalVersion(msgVer) ?? msgVer;
+          const normExpected = toCanonicalVersion(expected) ?? expected;
+          if (normMsg !== normExpected) {
+            throw new A2uiValidationError(
+              `Message version '${msgVer}' does not match expected target version '${expected}'`,
+            );
+          }
         }
       }
     };

--- a/typescript/web_core/src/processing/message-processor.ts
+++ b/typescript/web_core/src/processing/message-processor.ts
@@ -578,6 +578,17 @@ export class MessageProcessor<T extends ComponentApi = ComponentApi> {
       throw new A2uiStateError(`Catalog not found: ${catalogId}`);
     }
 
+    const msgVersion = op.version ?? this.version;
+    if (
+      catalog.protocolVersion &&
+      msgVersion &&
+      !isCatalogVersionCompatible(catalog.protocolVersion, msgVersion)
+    ) {
+      throw new A2uiValidationError(
+        `Surface '${surfaceId}' catalog '${catalogId ?? catalog.id}' specification version (${catalog.protocolVersion}) does not match message protocol version (${msgVersion}).`,
+      );
+    }
+
     if (this.model.getSurface(surfaceId)) {
       throw new A2uiStateError(`Surface ${surfaceId} already exists.`);
     }

--- a/typescript/web_core/src/processing/operations.ts
+++ b/typescript/web_core/src/processing/operations.ts
@@ -46,6 +46,8 @@ export interface InternalCreateSurfaceOp {
   readonly components?: InternalComponentPayload[];
   /** Initial key-value state tree for the surface data model. */
   readonly dataModel?: Record<string, unknown>;
+  /** Protocol version of the originating message envelope or adapter. */
+  readonly version?: string;
 }
 
 /**

--- a/typescript/web_core/src/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/rpc/rpc-handler.ts
@@ -26,7 +26,7 @@ import {
   RendererFunctionResponseMessage,
   CallAgentFunctionMessage,
 } from '../v1_0/schema/renderer-to-agent.js';
-import {isCatalogVersionCompatible} from '../common/semver.js';
+import {isCatalogVersionCompatible} from '../processing/adapters/base.js';
 
 /**
  * Standard error codes for A2UI RPC failures.

--- a/typescript/web_core/src/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/rpc/rpc-handler.ts
@@ -26,6 +26,7 @@ import {
   RendererFunctionResponseMessage,
   CallAgentFunctionMessage,
 } from '../v1_0/schema/renderer-to-agent.js';
+import {isCatalogVersionCompatible} from '../common/semver.js';
 
 /**
  * Standard error codes for A2UI RPC failures.
@@ -351,10 +352,12 @@ export class RpcHandler {
       return {error: 'No catalog available for function resolution.'};
     }
 
-    if (catalog.protocolVersion && expectedVersion && catalog.protocolVersion !== expectedVersion) {
-      return {
-        error: `Catalog '${catalog.id}' specification version (${catalog.protocolVersion}) does not match message protocol version (${expectedVersion}).`,
-      };
+    if (catalog.protocolVersion && expectedVersion) {
+      if (!isCatalogVersionCompatible(catalog.protocolVersion, expectedVersion)) {
+        return {
+          error: `Catalog '${catalog.id}' specification version (${catalog.protocolVersion}) does not match message protocol version (${expectedVersion}).`,
+        };
+      }
     }
 
     const funcImpl = catalog.functions?.get(call);

--- a/typescript/web_core/src/rpc/rpc.test.ts
+++ b/typescript/web_core/src/rpc/rpc.test.ts
@@ -616,7 +616,46 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     );
   });
 
-  it('rejects callRendererFunction when catalog protocolVersion does not match message version', async () => {
+  it('rejects callRendererFunction when catalog protocolVersion is newer and incompatible', async () => {
+    const v20Catalog = new Catalog(
+      'v20_catalog',
+      [],
+      [customRpcImpl],
+      undefined,
+      undefined,
+      'v2.0',
+    );
+    const handler = new RpcHandler([v20Catalog]);
+    const surface = new SurfaceModel('s1', v20Catalog);
+    const context = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-version-mismatch',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'v20_catalog',
+            args: {text: 'test'},
+          },
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.ok(res.rendererFunctionResponse.error);
+    assert.strictEqual(res.rendererFunctionResponse.error.code, RpcErrorCode.INVALID_FUNCTION_CALL);
+    assert.ok(res.rendererFunctionResponse.error.message.includes('specification version (v2.0)'));
+    assert.ok(
+      res.rendererFunctionResponse.error.message.includes(
+        'does not match message protocol version (v1.0)',
+      ),
+    );
+  });
+
+  it('rejects callRendererFunction when catalog protocolVersion is pre-v1.0 (e.g. v0.9 on v1.0)', async () => {
     const v09Catalog = new Catalog(
       'v09_catalog',
       [],
@@ -633,11 +672,11 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
       {
         version: 'v1.0',
         callRendererFunction: {
-          functionCallId: 'call-version-mismatch',
+          functionCallId: 'call-v09-mismatch',
           callFunction: {
             call: 'customRpc',
             catalogId: 'v09_catalog',
-            args: {text: 'test'},
+            args: {text: 'pre-v1.0'},
           },
         },
       },
@@ -647,10 +686,44 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
 
     assert.ok(res.rendererFunctionResponse.error);
     assert.strictEqual(res.rendererFunctionResponse.error.code, RpcErrorCode.INVALID_FUNCTION_CALL);
-    assert.ok(res.rendererFunctionResponse.error.message.includes('specification version (v0.9)'));
     assert.ok(
-      res.rendererFunctionResponse.error.message.includes('message protocol version (v1.0)'),
+      res.rendererFunctionResponse.error.message.includes(
+        'does not match message protocol version',
+      ),
     );
+  });
+
+  it('allows callRendererFunction when catalog protocolVersion is compatible with newer message version (e.g. v1.0 on v1.1)', async () => {
+    const v10Catalog = new Catalog(
+      'v10_catalog',
+      [],
+      [customRpcImpl],
+      undefined,
+      undefined,
+      'v1.0',
+    );
+    const handler = new RpcHandler([v10Catalog]);
+    const surface = new SurfaceModel('s1', v10Catalog);
+    const context = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.1' as any,
+        callRendererFunction: {
+          functionCallId: 'call-version-forward-compat',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'v10_catalog',
+            args: {text: 'forward-compat'},
+          },
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: forward-compat');
+    assert.strictEqual(res.rendererFunctionResponse.error, undefined);
   });
 
   it('allows callRendererFunction when catalog protocolVersion matches message version', async () => {
@@ -683,6 +756,39 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     );
 
     assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: matched');
+    assert.strictEqual(res.rendererFunctionResponse.error, undefined);
+  });
+
+  it('allows callRendererFunction when version prefix differs (e.g. 1.0 vs v1.0)', async () => {
+    const unprefixCatalog = new Catalog(
+      'unprefix_catalog',
+      [],
+      [customRpcImpl],
+      undefined,
+      undefined,
+      '1.0',
+    );
+    const handler = new RpcHandler([unprefixCatalog]);
+    const surface = new SurfaceModel('s1', unprefixCatalog);
+    const context = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-version-prefix-norm',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'unprefix_catalog',
+            args: {text: 'normalized'},
+          },
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: normalized');
     assert.strictEqual(res.rendererFunctionResponse.error, undefined);
   });
 });

--- a/typescript/web_core/src/rpc/rpc.test.ts
+++ b/typescript/web_core/src/rpc/rpc.test.ts
@@ -693,7 +693,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     );
   });
 
-  it('allows callRendererFunction when catalog protocolVersion is compatible with newer message version (e.g. v1.0 on v1.1)', async () => {
+  it('rejects callRendererFunction when message version is outside supported compatibility sets (e.g. v1.1 on v1.0)', async () => {
     const v10Catalog = new Catalog(
       'v10_catalog',
       [],
@@ -710,11 +710,11 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
       {
         version: 'v1.1' as any,
         callRendererFunction: {
-          functionCallId: 'call-version-forward-compat',
+          functionCallId: 'call-version-unsupported',
           callFunction: {
             call: 'customRpc',
             catalogId: 'v10_catalog',
-            args: {text: 'forward-compat'},
+            args: {text: 'unsupported'},
           },
         },
       },
@@ -722,7 +722,81 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
       true,
     );
 
-    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: forward-compat');
+    assert.strictEqual(res.rendererFunctionResponse.value, undefined);
+    assert.strictEqual(
+      res.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
+    assert.ok(
+      res.rendererFunctionResponse.error.message.includes(
+        'does not match message protocol version',
+      ),
+    );
+  });
+
+  it('allows callRendererFunction when catalog protocolVersion formatting differs but normalizes to same version (e.g. v1_0 on 1.0.0)', async () => {
+    const v10Catalog = new Catalog(
+      'v10_catalog',
+      [],
+      [customRpcImpl],
+      undefined,
+      undefined,
+      'v1_0',
+    );
+    const handler = new RpcHandler([v10Catalog]);
+    const surface = new SurfaceModel('s1', v10Catalog);
+    const context = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: '1.0.0' as any,
+        callRendererFunction: {
+          functionCallId: 'call-version-normalize',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'v10_catalog',
+            args: {text: 'format-tolerance'},
+          },
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: format-tolerance');
+    assert.strictEqual(res.rendererFunctionResponse.error, undefined);
+  });
+
+  it('allows callRendererFunction when catalog protocolVersion is compatible via explicit mapping (e.g. v0.9 catalog on v0.9.1 message)', async () => {
+    const v09Catalog = new Catalog(
+      'v09_catalog',
+      [],
+      [customRpcImpl],
+      undefined,
+      undefined,
+      'v0.9',
+    );
+    const handler = new RpcHandler([v09Catalog]);
+    const surface = new SurfaceModel('s1', v09Catalog);
+    const context = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v0.9.1' as any,
+        callRendererFunction: {
+          functionCallId: 'call-version-v09-v091',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'v09_catalog',
+            args: {text: 'v09-on-v091'},
+          },
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: v09-on-v091');
     assert.strictEqual(res.rendererFunctionResponse.error, undefined);
   });
 

--- a/typescript/web_core/src/rpc/rpc.test.ts
+++ b/typescript/web_core/src/rpc/rpc.test.ts
@@ -693,7 +693,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     );
   });
 
-  it('rejects callRendererFunction when message version is outside supported compatibility sets (e.g. v1.1 on v1.0)', async () => {
+  it('rejects callRendererFunction when message version is outside supported compatibility sets (e.g. v2.0 on v1.0)', async () => {
     const v10Catalog = new Catalog(
       'v10_catalog',
       [],
@@ -708,7 +708,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
 
     const res = await handler.handleCallRendererFunction(
       {
-        version: 'v1.1' as any,
+        version: 'v2.0' as any,
         callRendererFunction: {
           functionCallId: 'call-version-unsupported',
           callFunction: {
@@ -732,6 +732,39 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
         'does not match message protocol version',
       ),
     );
+  });
+
+  it('allows callRendererFunction when message minor version differs within 1.x (e.g. v1.1 on v1.0)', async () => {
+    const v10Catalog = new Catalog(
+      'v10_catalog',
+      [],
+      [customRpcImpl],
+      undefined,
+      undefined,
+      'v1.0',
+    );
+    const handler = new RpcHandler([v10Catalog]);
+    const surface = new SurfaceModel('s1', v10Catalog);
+    const context = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.1' as any,
+        callRendererFunction: {
+          functionCallId: 'call-version-v11',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'v10_catalog',
+            args: {text: 'supported'},
+          },
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: supported');
+    assert.strictEqual(res.rendererFunctionResponse.error, undefined);
   });
 
   it('allows callRendererFunction when catalog protocolVersion formatting differs but normalizes to same version (e.g. v1_0 on 1.0.0)', async () => {

--- a/typescript/web_core/tests/conformance/conformance_test.mjs
+++ b/typescript/web_core/tests/conformance/conformance_test.mjs
@@ -19,6 +19,8 @@ import assert from 'node:assert';
 import yaml from 'js-yaml';
 import {MessageProcessor, STRICT_VALIDATION} from '../../dist/src/processing/message-processor.js';
 import {Catalog, createFunctionImplementation} from '../../dist/src/catalog/types.js';
+import {SUPPORTED_PROTOCOL_VERSIONS} from '../../dist/src/processing/adapters/base.js';
+import {toCanonicalVersion} from '../../dist/src/common/semver.js';
 import {
   BASIC_COMPONENTS as V0_8_BASIC_COMPONENTS,
   ThemeSchema as V0_8_ThemeSchema,
@@ -83,12 +85,6 @@ const CONFORMANCE_ROOT =
   process.env.CONFORMANCE_ROOT || path.resolve(__dirname, '../../../../conformance');
 const CORE_DIR = path.join(CONFORMANCE_ROOT, 'core');
 const AGENT_DIR = path.join(CONFORMANCE_ROOT, 'agent');
-
-/**
- * Set of A2UI protocol versions supported by this TypeScript conformance harness.
- * Test cases specifying protocol versions outside this set are skipped.
- */
-const SUPPORTED_PROTOCOL_VERSIONS = new Set(['v0.8', 'v0.9', 'v1.0']);
 
 /**
  * Transition skip list containing specific test case names to skip.
@@ -168,13 +164,13 @@ async function runConformanceHarness() {
 
     for (const testCase of testCases) {
       const {name, action, catalog, args} = testCase;
-      let version = catalog?.protocolVersion || args?.version || 'v0.8';
-      if (!version.startsWith('v')) version = `v${version}`;
+      const rawVersion = catalog?.protocolVersion || args?.version || '0.8';
+      const version = toCanonicalVersion(rawVersion) || rawVersion;
 
       if (!SUPPORTED_PROTOCOL_VERSIONS.has(version)) {
         totalSkipped++;
         console.log(
-          `  ⁃ [SKIPPED] ${name} (version ${version} not in SUPPORTED_PROTOCOL_VERSIONS)`,
+          `  ⁃ [SKIPPED] ${name} (version ${rawVersion} not in SUPPORTED_PROTOCOL_VERSIONS)`,
         );
         continue;
       }
@@ -475,7 +471,8 @@ function validateGetRendererCapabilitiesTestCase(testCase) {
 }
 
 function getBasicCatalog(version) {
-  if (version === 'v1.0') {
+  const norm = toCanonicalVersion(version) || version;
+  if (norm === '1.0') {
     return new Catalog(
       'https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json',
       v1_0Components,
@@ -485,7 +482,7 @@ function getBasicCatalog(version) {
       V10_CHILD_REF_OPTIONS,
     );
   }
-  if (version === 'v0.9') {
+  if (norm === '0.9' || norm === '0.9.1') {
     return new Catalog(
       'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json',
       v0_9Components,
@@ -495,7 +492,7 @@ function getBasicCatalog(version) {
       V09_CHILD_REF_OPTIONS,
     );
   }
-  if (version === 'v0.8') {
+  if (norm === '0.8') {
     return new Catalog(
       'https://a2ui.org/specification/v0_8/catalogs/basic/catalog.json',
       v0_8Components,
@@ -704,10 +701,11 @@ function jsonSchemaToZod(schemaDef) {
 }
 
 function getCatalogsForTestCase(testCase) {
+  const normProto = toCanonicalVersion(testCase.protocolVersion) || testCase.protocolVersion;
   const refOptions =
-    testCase.protocolVersion === 'v0.8'
+    normProto === '0.8'
       ? V08_CHILD_REF_OPTIONS
-      : testCase.protocolVersion === 'v0.9'
+      : normProto === '0.9' || normProto === '0.9.1'
         ? V09_CHILD_REF_OPTIONS
         : V10_CHILD_REF_OPTIONS;
   const catalogsMap = new Map(allCatalogs.map(c => [c.id, c]));

--- a/typescript/web_core/tests/conformance/conformance_test.mjs
+++ b/typescript/web_core/tests/conformance/conformance_test.mjs
@@ -43,21 +43,14 @@ const v0_8Components = V0_8_BASIC_COMPONENTS;
 const v0_9Components = V0_9_BASIC_COMPONENTS;
 const v1_0Components = V1_0_BASIC_COMPONENTS;
 
-const basicCatalog = new Catalog(
-  'basic',
-  v0_9Components,
-  [],
-  undefined,
-  undefined,
-  V09_CHILD_REF_OPTIONS,
-);
+const basicCatalog = new Catalog('basic', v0_9Components, [], undefined, undefined, 'v0.9');
 const v0_8Catalog = new Catalog(
   'v0.8:basic',
   v0_8Components,
   [],
   V0_8_ThemeSchema,
   undefined,
-  V08_CHILD_REF_OPTIONS,
+  'v0.8',
 );
 const v0_9Catalog = new Catalog(
   'v0.9:basic',
@@ -65,7 +58,7 @@ const v0_9Catalog = new Catalog(
   V0_9_BASIC_FUNCTIONS,
   V0_9_ThemeSchema,
   undefined,
-  V09_CHILD_REF_OPTIONS,
+  'v0.9',
 );
 const v1_0Catalog = new Catalog(
   'v1.0:basic',
@@ -73,7 +66,7 @@ const v1_0Catalog = new Catalog(
   V1_0_BASIC_FUNCTIONS,
   undefined,
   undefined,
-  V10_CHILD_REF_OPTIONS,
+  'v1.0',
 );
 const allCatalogs = [basicCatalog, v0_8Catalog, v0_9Catalog, v1_0Catalog];
 
@@ -702,25 +695,30 @@ function jsonSchemaToZod(schemaDef) {
 
 function getCatalogsForTestCase(testCase) {
   const normProto = toCanonicalVersion(testCase.protocolVersion) || testCase.protocolVersion;
-  const refOptions =
-    normProto === '0.8'
-      ? V08_CHILD_REF_OPTIONS
-      : normProto === '0.9' || normProto === '0.9.1'
-        ? V09_CHILD_REF_OPTIONS
-        : V10_CHILD_REF_OPTIONS;
   const catalogsMap = new Map(allCatalogs.map(c => [c.id, c]));
-  const addCatalogId = id => {
+  if (normProto === '1.0') {
+    catalogsMap.set(
+      'basic',
+      new Catalog('basic', v1_0Components, V1_0_BASIC_FUNCTIONS, undefined, undefined, '1.0'),
+    );
+  } else if (normProto === '0.8') {
+    catalogsMap.set(
+      'basic',
+      new Catalog('basic', v0_8Components, [], V0_8_ThemeSchema, undefined, '0.8'),
+    );
+  }
+  const addCatalogId = (id, version = normProto) => {
     if (id && !catalogsMap.has(id)) {
-      catalogsMap.set(
-        id,
-        new Catalog(id, flexibleComponents, [], undefined, undefined, refOptions),
-      );
+      catalogsMap.set(id, new Catalog(id, flexibleComponents, [], undefined, undefined, version));
     }
   };
 
   if (testCase.catalogs) {
     for (const cat of testCase.catalogs) {
       if (cat.catalogId) {
+        const catProto = cat.protocolVersion
+          ? toCanonicalVersion(cat.protocolVersion) || cat.protocolVersion
+          : normProto;
         if (cat.components || cat.theme) {
           const compApis = cat.components
             ? Object.entries(cat.components).map(([name, def]) => ({
@@ -731,10 +729,10 @@ function getCatalogsForTestCase(testCase) {
           const themeSchema = cat.theme ? jsonSchemaToZod(cat.theme) : undefined;
           catalogsMap.set(
             cat.catalogId,
-            new Catalog(cat.catalogId, compApis, [], themeSchema, undefined, refOptions),
+            new Catalog(cat.catalogId, compApis, [], themeSchema, undefined, catProto),
           );
         } else {
-          addCatalogId(cat.catalogId);
+          addCatalogId(cat.catalogId, catProto);
         }
       }
     }

--- a/typescript/web_core/tests/conformance/conformance_test.mjs
+++ b/typescript/web_core/tests/conformance/conformance_test.mjs
@@ -319,7 +319,8 @@ async function validateRpcTestCase(testCase) {
     catId = 'basic';
   }
 
-  const cat = new Catalog(catId, [], funcs, undefined, undefined, V10_CHILD_REF_OPTIONS);
+  const catProto = testCase.catalog?.protocolVersion || 'v1.0';
+  const cat = new Catalog(catId, [], funcs, undefined, undefined, catProto);
   let sentOutboundMsg;
   const processor = new MessageProcessor([cat], undefined, {
     version: 'v1.0',


### PR DESCRIPTION
## Summary

Implements SemVer 2.0.0 parsing and comparison across TypeScript (`typescript/web_core`) and Python (`python/a2ui_core`, `python/a2ui_agent`), and standardizes protocol version compatibility and cross-version action rejection across adapters, RPC handlers, and message processors.

Part of the v1.0 protocol conformance alignment stack (base for PR #2537).

## Changes

### TypeScript Engine (`typescript/web_core`)
- **SemVer Implementation**: Added `src/common/semver.ts` with SemVer 2.0.0 parsing (`parseSemVer`), precedence comparisons (`compareSemVer`), minimum version checking (`isAtLeastVersion`), and canonical formatting (`toCanonicalVersion`).
- **Version Adapters & Compatibility**:
  - Defined `SUPPORTED_PROTOCOL_VERSIONS` (`0.8`, `0.9`, `0.9.1`, `1.0`) and `DEFAULT_CATALOG_COMPATIBILITY`.
  - Moved `isCatalogVersionCompatible` to `adapters/base.ts`, supporting mutual compatibility between v0.9 and v0.9.1, and intra-major compatibility for SemVer `>= 1.0.0`.
  - Standardized `VersionAdapterFactory` registration, canonical version lookup, and dynamic action discovery (`supportedActions`, `allKnownActions`).
  - Adapters reject actions belonging to different protocol versions (e.g. `beginRendering` in v0.9/v1.0, `createSurface` in v0.8) with explicit error messages.
  - Propagated message envelope `version` through adapters to `InternalCreateSurfaceOp`.
- **Message Processor**:
  - Added surface catalog protocol version compatibility validation during `createSurface`.
  - Added Zod issue formatting helper in `format-zod-issue.ts`.
- **RPC Handler**: Added catalog version compatibility checks for inbound renderer function calls.
- **Catalog Schema Generator**: Updated schema generation rules to use SemVer comparisons for version-specific features.

### Python Engine (`python/a2ui_core` & `python/a2ui_agent`)
- **SemVer Implementation**: Added `a2ui.core.common.semver` with `SemVer` dataclass, `parse_semver`, `normalize_version_string`, `compare_semver`, `is_at_least_version`, and `to_canonical_version`. Fully typed with `ProtocolVersion | str | None` and `ProtocolVersion | str | SemVer | None` without `bytes` or `Any`.
- **Version Adapters & Compatibility**:
  - Defined `SUPPORTED_PROTOCOL_VERSIONS` and `DEFAULT_CATALOG_COMPATIBILITY`.
  - Implemented `is_catalog_version_compatible` in `adapters/base.py`.
  - Standardized `VersionAdapterFactory` resolution and dynamic action aggregation.
  - Adapters reject cross-version actions with explicit error messages.
  - Propagated envelope `version` to `InternalCreateSurfaceOp`.
- **Message Processor**: Enforced surface catalog protocol version compatibility on `createSurface`.
- **Execution Context**: Reverted `ExecutionContext` to a dataclass with `is_user_activated: bool = False`, removing deprecated `user_activation_present` properties.
- **Catalog & Validator**:
  - Standardized version comparisons across catalog and payload validators.
  - Aligned catalog ID UAX `#31` syntax checks with SemVer comparisons for version 1.0.0 and above.
- **Schema Utilities**: Normalized version lookups in `load_from_bundled_resource` and `get_spec_dir`, tolerating format variations (`v1_0`, `v1.0`, `1.0.0`).

### Conformance & Unit Test Suites
- **Conformance Test Vectors**:
  - Added explicit error message assertions for unsupported actions to `message_processor_v0_8.yaml`, `message_processor_v0_9.yaml`, and `message_processor_v1_0.yaml`.
  - Added test case `test_v08_catalog_rejects_v09_create_surface_message` to verify that v0.9 `createSurface` targeting a v0.8 catalog is rejected.
  - Updated catalog registration in Python and TypeScript conformance runners to properly set catalog protocol versions.
- **Unit Tests**:
  - Added `typescript/web_core/src/common/semver.test.ts` (parsing, precedence, pre-release rules, build metadata).
  - Added `python/a2ui_core/tests/test_semver.py` and expanded `tests/test_adapters.py`.
  - Expanded `rpc.test.ts` and `adapters.test.ts` with cross-version and compatibility tests.

## Impact & Risks

- **Breaking Changes**: None. Version comparison functions preserve backward compatibility with existing version string formats (`'v1.0'`, `'1.0'`, `'v1_0'`).
- **Performance**: Parsing and comparisons operate on regexes and integer tuples without external dependencies.
- **Dependencies**: No new external dependencies added.

## Testing

1. **TypeScript test suite**:
   ```bash
   yarn --cwd typescript/web_core build
   yarn --cwd typescript/web_core test
   yarn --cwd typescript/web_core lint
   yarn --cwd typescript/web_core format:check
   ```
   All 637 tests pass; clean build, lint (0 errors), and formatting.

2. **Python test suite**:
   ```bash
   uv run pytest python/a2ui_core/tests python/a2ui_agent/tests
   uv run mypy python/a2ui_core/src
   uv run pyink --check python/a2ui_core/src python/a2ui_core/tests
   ```
   All 803 tests pass; clean mypy type checks (77 source files) and formatting.

3. **Conformance test verification**:
   ```bash
   uv run pytest python/a2ui_core/tests/test_conformance.py -k "create_surface or begin_rendering"
   ```
   All 14 targeted conformance test vectors pass.
