### PR TITLE
refactor(react): replace synthetic module aliasing with dynamic React 18 matrix script

### DIFF
--- a/.github/workflows/web_ci.yml
+++ b/.github/workflows/web_ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Test Renderers
         run: eval "yarn workspaces foreach -A $RENDERERS_INC -p run test"
       - name: Test React 18 Compatibility
-        run: ./renderers/react/scripts/test-react18.sh
+        run: yarn workspace @a2ui/react run test:react18
       - name: Verify NPM Publish Script
         run: node --test renderers/scripts/publish_npm.test.mjs
 

--- a/.github/workflows/web_ci.yml
+++ b/.github/workflows/web_ci.yml
@@ -103,6 +103,8 @@ jobs:
         run: eval "yarn workspaces foreach -A $RENDERERS_INC -p --topological-dev run build"
       - name: Test Renderers
         run: eval "yarn workspaces foreach -A $RENDERERS_INC -p run test"
+      - name: Test React 18 Compatibility
+        run: ./renderers/react/scripts/test-react18.sh
       - name: Verify NPM Publish Script
         run: node --test renderers/scripts/publish_npm.test.mjs
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -26,6 +26,7 @@ conformance/test_data/**
 **/pnpm-lock.yaml
 renderers/angular/a2ui_explorer/src/app/generated/**
 renderers/lit/a2ui_explorer/src/generated/**
+renderers/react/a2ui_explorer/src/generated/**
 .next
 **/.next
 

--- a/renderers/react/a2ui_explorer/karma.conf.cjs
+++ b/renderers/react/a2ui_explorer/karma.conf.cjs
@@ -16,18 +16,6 @@
 
 const path = require('path');
 
-const isReact18 = process.env.REACT_VERSION === '18';
-const react18Aliases = isReact18
-  ? {
-      'react/jsx-dev-runtime': require.resolve('react-18/jsx-dev-runtime'),
-      'react/jsx-runtime': require.resolve('react-18/jsx-runtime'),
-      'react-dom/client': require.resolve('react-dom-18/client'),
-      'react-dom/server': require.resolve('react-dom-18/server'),
-      'react-dom': require.resolve('react-dom-18'),
-      react: require.resolve('react-18'),
-    }
-  : {};
-
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -49,7 +37,6 @@ module.exports = function (config) {
       format: 'iife',
       sourcemap: true,
       alias: {
-        ...react18Aliases,
         '@a2ui/react/v0_9': path.resolve(__dirname, '../src/v0_9/index.ts'),
         '@a2ui/react/v0_8': path.resolve(__dirname, '../src/v0_8/index.ts'),
         '@a2ui/react/styles': path.resolve(__dirname, '../src/styles/index.ts'),
@@ -61,13 +48,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    customLaunchers: {
-      ChromeHeadlessNoSandbox: {
-        base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--no-zygote'],
-      },
-    },
-    browsers: ['ChromeHeadlessNoSandbox'],
+    browsers: ['ChromeHeadless'],
     singleRun: true,
     concurrency: Infinity,
     hostname: '127.0.0.1',

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -80,9 +80,8 @@
     "demo": "yarn workspace @a2ui/react-explorer dev",
     "test": "wireit",
     "test:unit": "wireit",
-    "test:unit:react18": "wireit",
     "test:integration": "wireit",
-    "test:integration:react18": "wireit",
+    "test:react18": "./scripts/test-react18.sh",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
@@ -108,13 +107,10 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@testing-library/react-18": "npm:@testing-library/react@^14.3.1",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
-    "@types/react-18": "npm:@types/react@^18.3.1",
     "@types/react-dom": "^19.2.3",
-    "@types/react-dom-18": "npm:@types/react-dom@^18.3.1",
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
@@ -127,9 +123,7 @@
     "prettier": "^3.8.4",
     "puppeteer": "^25.1.0",
     "react": "^19.2.7",
-    "react-18": "npm:react@^18.3.1",
     "react-dom": "^19.2.7",
-    "react-dom-18": "npm:react-dom@^18.3.1",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",
     "typescript": "5.9.3",
@@ -159,9 +153,7 @@
     "test": {
       "dependencies": [
         "test:unit",
-        "test:unit:react18",
-        "test:integration",
-        "test:integration:react18"
+        "test:integration"
       ]
     },
     "test:unit": {
@@ -174,21 +166,8 @@
         "tsconfig.json"
       ]
     },
-    "test:unit:react18": {
-      "command": "REACT_VERSION=18 vitest run",
-      "dependencies": [
-        "build"
-      ],
-      "files": [
-        "src/**/*",
-        "tsconfig.json"
-      ]
-    },
     "test:integration": {
       "command": "yarn workspace @a2ui/react-explorer test:ci"
-    },
-    "test:integration:react18": {
-      "command": "REACT_VERSION=18 yarn workspace @a2ui/react-explorer test:ci"
     },
     "clean": {
       "command": "rm -rf dist .tsbuildinfo .wireit"

--- a/renderers/react/scripts/test-react18.sh
+++ b/renderers/react/scripts/test-react18.sh
@@ -19,6 +19,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REACT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${REACT_DIR}/../.." && pwd)"
 
+# Allow Yarn to update the lockfile in CI during temporary dependency swapping
+export YARN_ENABLE_IMMUTABLE_INSTALLS=false
+
 REACT_PKG="${REACT_DIR}/package.json"
 EXPLORER_PKG="${REACT_DIR}/a2ui_explorer/package.json"
 ROOT_LOCK="${REPO_ROOT}/yarn.lock"

--- a/renderers/react/scripts/test-react18.sh
+++ b/renderers/react/scripts/test-react18.sh
@@ -19,9 +19,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REACT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${REACT_DIR}/../.." && pwd)"
 
-# Allow Yarn to update the lockfile in CI during temporary dependency swapping
-export YARN_ENABLE_IMMUTABLE_INSTALLS=false
-
 REACT_PKG="${REACT_DIR}/package.json"
 EXPLORER_PKG="${REACT_DIR}/a2ui_explorer/package.json"
 ROOT_LOCK="${REPO_ROOT}/yarn.lock"
@@ -53,32 +50,21 @@ trap cleanup EXIT INT TERM
 echo "=== Building @a2ui/react ==="
 yarn --cwd "${REACT_DIR}" build
 
-# Temporarily swap dependencies to React 18 in a single pass
+# Temporarily swap devDependencies to React 18
 echo "=== Swapping to React 18 dependencies ==="
-node -e '
-const fs = require("fs");
-[
-  [process.argv[1], "devDependencies", {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.1",
-    "@testing-library/react": "^14.3.1"
-  }],
-  [process.argv[2], "dependencies", {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.1"
-  }]
-].forEach(([file, key, deps]) => {
-  const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
-  pkg[key] = { ...pkg[key], ...deps };
-  fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
-});
-' "${REACT_PKG}" "${EXPLORER_PKG}"
+yarn --cwd "${REACT_DIR}" add -D \
+  "react@^18.3.1" \
+  "react-dom@^18.3.1" \
+  "@types/react@^18.3.1" \
+  "@types/react-dom@^18.3.1" \
+  "@testing-library/react@^14.3.1"
 
-yarn --cwd "${REPO_ROOT}" install
+yarn --cwd "${REACT_DIR}/a2ui_explorer" add \
+  "react@^18.3.1" \
+  "react-dom@^18.3.1" \
+  "@types/react@^18.3.1" \
+  "@types/react-dom@^18.3.1"
+
 DEPS_SWAPPED=true
 
 # Run unit tests under real React 18

--- a/renderers/react/scripts/test-react18.sh
+++ b/renderers/react/scripts/test-react18.sh
@@ -19,25 +19,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REACT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${REACT_DIR}/../.." && pwd)"
 
+REACT_PKG="${REACT_DIR}/package.json"
+EXPLORER_PKG="${REACT_DIR}/a2ui_explorer/package.json"
+ROOT_LOCK="${REPO_ROOT}/yarn.lock"
+
+TRACKED_FILES=("${REACT_PKG}" "${EXPLORER_PKG}" "${ROOT_LOCK}")
+
 echo "=== Testing @a2ui/react with React 18 ==="
 
-# Save backups so we restore the exact starting state
-cp "${REACT_DIR}/package.json" "${REACT_DIR}/package.json.bak"
-cp "${REACT_DIR}/a2ui_explorer/package.json" "${REACT_DIR}/a2ui_explorer/package.json.bak"
-cp "${REPO_ROOT}/yarn.lock" "${REPO_ROOT}/yarn.lock.bak"
+# Preflight: ensure no uncommitted changes in tracked dependency files
+if ! git -C "${REPO_ROOT}" diff --quiet HEAD -- "${TRACKED_FILES[@]}"; then
+  echo "Error: Uncommitted changes detected in package.json or yarn.lock."
+  echo "Please commit or stash your changes before running the React 18 test matrix."
+  exit 1
+fi
+
+DEPS_SWAPPED=false
 
 cleanup() {
+  trap - EXIT INT TERM
   echo "=== Restoring original React 19 dependencies ==="
-  if [[ -f "${REACT_DIR}/package.json.bak" ]]; then
-    mv -f "${REACT_DIR}/package.json.bak" "${REACT_DIR}/package.json"
+  git -C "${REPO_ROOT}" checkout -- "${TRACKED_FILES[@]}"
+  if [[ "${DEPS_SWAPPED}" == "true" ]]; then
+    yarn --cwd "${REPO_ROOT}" install
   fi
-  if [[ -f "${REACT_DIR}/a2ui_explorer/package.json.bak" ]]; then
-    mv -f "${REACT_DIR}/a2ui_explorer/package.json.bak" "${REACT_DIR}/a2ui_explorer/package.json"
-  fi
-  if [[ -f "${REPO_ROOT}/yarn.lock.bak" ]]; then
-    mv -f "${REPO_ROOT}/yarn.lock.bak" "${REPO_ROOT}/yarn.lock"
-  fi
-  yarn --cwd "${REPO_ROOT}" install
 }
 trap cleanup EXIT INT TERM
 
@@ -45,20 +50,33 @@ trap cleanup EXIT INT TERM
 echo "=== Building @a2ui/react ==="
 yarn --cwd "${REACT_DIR}" build
 
-# Temporarily swap devDependencies to React 18
+# Temporarily swap dependencies to React 18 in a single pass
 echo "=== Swapping to React 18 dependencies ==="
-yarn --cwd "${REACT_DIR}" add -D \
-  "react@^18.3.1" \
-  "react-dom@^18.3.1" \
-  "@types/react@^18.3.1" \
-  "@types/react-dom@^18.3.1" \
-  "@testing-library/react@^14.3.1"
+node -e '
+const fs = require("fs");
+[
+  [process.argv[1], "devDependencies", {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@testing-library/react": "^14.3.1"
+  }],
+  [process.argv[2], "dependencies", {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1"
+  }]
+].forEach(([file, key, deps]) => {
+  const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+  pkg[key] = { ...pkg[key], ...deps };
+  fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
+});
+' "${REACT_PKG}" "${EXPLORER_PKG}"
 
-yarn --cwd "${REACT_DIR}/a2ui_explorer" add \
-  "react@^18.3.1" \
-  "react-dom@^18.3.1" \
-  "@types/react@^18.3.1" \
-  "@types/react-dom@^18.3.1"
+yarn --cwd "${REPO_ROOT}" install
+DEPS_SWAPPED=true
 
 # Run unit tests under real React 18
 echo "=== Running unit tests under React 18 ==="

--- a/renderers/react/scripts/test-react18.sh
+++ b/renderers/react/scripts/test-react18.sh
@@ -23,12 +23,13 @@ REACT_PKG="${REACT_DIR}/package.json"
 EXPLORER_PKG="${REACT_DIR}/a2ui_explorer/package.json"
 ROOT_LOCK="${REPO_ROOT}/yarn.lock"
 
-TRACKED_FILES=("${REACT_PKG}" "${EXPLORER_PKG}" "${ROOT_LOCK}")
+# Dependency files temporarily modified during React 18 testing
+SWAPPED_FILES=("${REACT_PKG}" "${EXPLORER_PKG}" "${ROOT_LOCK}")
 
 echo "=== Testing @a2ui/react with React 18 ==="
 
-# Preflight: ensure no uncommitted changes in tracked dependency files
-if ! git -C "${REPO_ROOT}" diff --quiet HEAD -- "${TRACKED_FILES[@]}"; then
+# Preflight: ensure no uncommitted changes in dependency files
+if ! git -C "${REPO_ROOT}" diff --quiet HEAD -- "${SWAPPED_FILES[@]}"; then
   echo "Error: Uncommitted changes detected in package.json or yarn.lock."
   echo "Please commit or stash your changes before running the React 18 test matrix."
   exit 1
@@ -39,18 +40,14 @@ DEPS_SWAPPED=false
 cleanup() {
   trap - EXIT INT TERM
   echo "=== Restoring original React 19 dependencies ==="
-  git -C "${REPO_ROOT}" checkout -- "${TRACKED_FILES[@]}"
+  git -C "${REPO_ROOT}" checkout -- "${SWAPPED_FILES[@]}"
   if [[ "${DEPS_SWAPPED}" == "true" ]]; then
     yarn --cwd "${REPO_ROOT}" install
   fi
 }
 trap cleanup EXIT INT TERM
 
-# Ensure dependencies are built first
-echo "=== Building @a2ui/react ==="
-yarn --cwd "${REACT_DIR}" build
-
-# Temporarily swap devDependencies to React 18
+# Temporarily swap devDependencies to React 18 before building
 echo "=== Swapping to React 18 dependencies ==="
 yarn --cwd "${REACT_DIR}" add -D \
   "react@^18.3.1" \
@@ -67,12 +64,8 @@ yarn --cwd "${REACT_DIR}/a2ui_explorer" add \
 
 DEPS_SWAPPED=true
 
-# Run unit tests under real React 18
-echo "=== Running unit tests under React 18 ==="
-yarn --cwd "${REACT_DIR}" test:unit
-
-# Run integration tests under real React 18
-echo "=== Running integration tests under React 18 ==="
-TZ=UTC yarn --cwd "${REACT_DIR}" test:integration
+# Run test suite under real React 18 (wireit handles build, test:unit, and test:integration)
+echo "=== Running tests under React 18 ==="
+TZ=UTC yarn --cwd "${REACT_DIR}" test
 
 echo "=== React 18 test matrix passed successfully! ==="

--- a/renderers/react/scripts/test-react18.sh
+++ b/renderers/react/scripts/test-react18.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REACT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${REACT_DIR}/../.." && pwd)"
+
+echo "=== Testing @a2ui/react with React 18 ==="
+
+# Save backups so we restore the exact starting state
+cp "${REACT_DIR}/package.json" "${REACT_DIR}/package.json.bak"
+cp "${REACT_DIR}/a2ui_explorer/package.json" "${REACT_DIR}/a2ui_explorer/package.json.bak"
+cp "${REPO_ROOT}/yarn.lock" "${REPO_ROOT}/yarn.lock.bak"
+
+cleanup() {
+  echo "=== Restoring original React 19 dependencies ==="
+  if [[ -f "${REACT_DIR}/package.json.bak" ]]; then
+    mv -f "${REACT_DIR}/package.json.bak" "${REACT_DIR}/package.json"
+  fi
+  if [[ -f "${REACT_DIR}/a2ui_explorer/package.json.bak" ]]; then
+    mv -f "${REACT_DIR}/a2ui_explorer/package.json.bak" "${REACT_DIR}/a2ui_explorer/package.json"
+  fi
+  if [[ -f "${REPO_ROOT}/yarn.lock.bak" ]]; then
+    mv -f "${REPO_ROOT}/yarn.lock.bak" "${REPO_ROOT}/yarn.lock"
+  fi
+  yarn --cwd "${REPO_ROOT}" install
+}
+trap cleanup EXIT INT TERM
+
+# Ensure dependencies are built first
+echo "=== Building @a2ui/react ==="
+yarn --cwd "${REACT_DIR}" build
+
+# Temporarily swap devDependencies to React 18
+echo "=== Swapping to React 18 dependencies ==="
+yarn --cwd "${REACT_DIR}" add -D \
+  "react@^18.3.1" \
+  "react-dom@^18.3.1" \
+  "@types/react@^18.3.1" \
+  "@types/react-dom@^18.3.1" \
+  "@testing-library/react@^14.3.1"
+
+yarn --cwd "${REACT_DIR}/a2ui_explorer" add \
+  "react@^18.3.1" \
+  "react-dom@^18.3.1" \
+  "@types/react@^18.3.1" \
+  "@types/react-dom@^18.3.1"
+
+# Run unit tests under real React 18
+echo "=== Running unit tests under React 18 ==="
+yarn --cwd "${REACT_DIR}" test:unit
+
+# Run integration tests under real React 18
+echo "=== Running integration tests under React 18 ==="
+TZ=UTC yarn --cwd "${REACT_DIR}" test:integration
+
+echo "=== React 18 test matrix passed successfully! ==="

--- a/renderers/react/tests/setup.ts
+++ b/renderers/react/tests/setup.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-
-
 import '@testing-library/jest-dom/vitest';
 import {beforeAll} from 'vitest';
 import {initializeDefaultCatalog} from '../src';

--- a/renderers/react/tests/setup.ts
+++ b/renderers/react/tests/setup.ts
@@ -14,34 +14,7 @@
  * limitations under the License.
  */
 
-import Module from 'module';
 
-if (process.env.REACT_VERSION === '18') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const originalResolve = (Module as any)._resolveFilename;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Module as any)._resolveFilename = function (
-    request: string,
-    parent: any,
-    isMain: boolean,
-    options: any,
-  ) {
-    if (request === 'react') return originalResolve.call(this, 'react-18', parent, isMain, options);
-    if (request === 'react/jsx-runtime')
-      return originalResolve.call(this, 'react-18/jsx-runtime', parent, isMain, options);
-    if (request === 'react/jsx-dev-runtime')
-      return originalResolve.call(this, 'react-18/jsx-dev-runtime', parent, isMain, options);
-    if (request === 'react-dom')
-      return originalResolve.call(this, 'react-dom-18', parent, isMain, options);
-    if (request === 'react-dom/client')
-      return originalResolve.call(this, 'react-dom-18/client', parent, isMain, options);
-    if (request === 'react-dom/server')
-      return originalResolve.call(this, 'react-dom-18/server', parent, isMain, options);
-    if (request === '@testing-library/react')
-      return originalResolve.call(this, '@testing-library/react-18', parent, isMain, options);
-    return originalResolve.call(this, request, parent, isMain, options);
-  };
-}
 
 import '@testing-library/jest-dom/vitest';
 import {beforeAll} from 'vitest';

--- a/renderers/react/vitest.config.ts
+++ b/renderers/react/vitest.config.ts
@@ -17,34 +17,8 @@
 import {defineConfig} from 'vitest/config';
 import path from 'path';
 import react from '@vitejs/plugin-react';
-import {createRequire} from 'module';
-
-const require = createRequire(import.meta.url);
-const isReact18 = process.env.REACT_VERSION === '18';
-
-const getReact18Aliases = () => {
-  if (!isReact18) return [];
-  return [
-    {find: /^react-dom\/client$/, replacement: require.resolve('react-dom-18/client')},
-    {find: /^react-dom\/server$/, replacement: require.resolve('react-dom-18/server')},
-    {find: /^react-dom$/, replacement: require.resolve('react-dom-18')},
-    {find: /^react\/jsx-dev-runtime$/, replacement: require.resolve('react-18/jsx-dev-runtime')},
-    {find: /^react\/jsx-runtime$/, replacement: require.resolve('react-18/jsx-runtime')},
-    {find: /^react$/, replacement: require.resolve('react-18')},
-    {find: /^@testing-library\/react$/, replacement: require.resolve('@testing-library/react-18')},
-  ];
-};
-
 export default defineConfig({
-  plugins: [react(isReact18 ? {jsxImportSource: 'react-18'} : {})],
-  server: {
-    deps: {
-      inline: [true],
-    },
-  },
-  ssr: {
-    alias: getReact18Aliases(),
-  },
+  plugins: [react()],
   test: {
     globals: true,
     environment: 'jsdom',
@@ -58,13 +32,12 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: [
-      ...getReact18Aliases(),
-      {find: '@', replacement: path.resolve(process.cwd(), 'src/v0_8')},
-      {find: '@a2ui/react/v0_9', replacement: path.resolve(process.cwd(), 'src/v0_9/index.ts')},
-      {find: '@a2ui/react/v0_8', replacement: path.resolve(process.cwd(), 'src/v0_8/index.ts')},
-      {find: '@a2ui/react/styles', replacement: path.resolve(process.cwd(), 'src/styles/index.ts')},
-      {find: '@a2ui/react', replacement: path.resolve(process.cwd(), 'src/index.ts')},
-    ],
+    alias: {
+      '@': path.resolve(process.cwd(), 'src/v0_8'),
+      '@a2ui/react/v0_9': path.resolve(process.cwd(), 'src/v0_9/index.ts'),
+      '@a2ui/react/v0_8': path.resolve(process.cwd(), 'src/v0_8/index.ts'),
+      '@a2ui/react/styles': path.resolve(process.cwd(), 'src/styles/index.ts'),
+      '@a2ui/react': path.resolve(process.cwd(), 'src/index.ts'),
+    },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,13 +320,10 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
-    "@testing-library/react-18": "npm:@testing-library/react@^14.3.1"
     "@types/markdown-it": "npm:^14.1.2"
     "@types/node": "npm:^25.9.3"
     "@types/react": "npm:^19.2.17"
-    "@types/react-18": "npm:@types/react@^18.3.1"
     "@types/react-dom": "npm:^19.2.3"
-    "@types/react-dom-18": "npm:@types/react-dom@^18.3.1"
     "@vitejs/plugin-react": "npm:^6.0.2"
     clsx: "npm:^2.1.1"
     eslint: "npm:^10.4.1"
@@ -341,9 +338,7 @@ __metadata:
     prettier: "npm:^3.8.4"
     puppeteer: "npm:^25.1.0"
     react: "npm:^19.2.7"
-    react-18: "npm:react@^18.3.1"
     react-dom: "npm:^19.2.7"
-    react-dom-18: "npm:react-dom@^18.3.1"
     tsup: "npm:^8.5.1"
     tsx: "npm:^4.22.4"
     typescript: "npm:5.9.3"
@@ -10392,22 +10387,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^9.0.0":
-  version: 9.3.4
-  resolution: "@testing-library/dom@npm:9.3.4"
-  dependencies:
-    "@babel/code-frame": "npm:^7.10.4"
-    "@babel/runtime": "npm:^7.12.5"
-    "@types/aria-query": "npm:^5.0.1"
-    aria-query: "npm:5.1.3"
-    chalk: "npm:^4.1.0"
-    dom-accessibility-api: "npm:^0.5.9"
-    lz-string: "npm:^1.5.0"
-    pretty-format: "npm:^27.0.2"
-  checksum: 10c0/147da340e8199d7f98f3a4ad8aa22ed55b914b83957efa5eb22bfea021a979ebe5a5182afa9c1e5b7a5f99a7f6744a5a4d9325ae46ec3b33b5a15aed8750d794
-  languageName: node
-  linkType: hard
-
 "@testing-library/jest-dom@npm:^6.9.1":
   version: 6.9.1
   resolution: "@testing-library/jest-dom@npm:6.9.1"
@@ -10419,20 +10398,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     redent: "npm:^3.0.0"
   checksum: 10c0/4291ebd2f0f38d14cefac142c56c337941775a5807e2a3d6f1a14c2fbd6be76a18e498ed189e95bedc97d9e8cf1738049bc76c85b5bc5e23fae7c9e10f7b3a12
-  languageName: node
-  linkType: hard
-
-"@testing-library/react-18@npm:@testing-library/react@^14.3.1":
-  version: 14.3.1
-  resolution: "@testing-library/react@npm:14.3.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-    "@testing-library/dom": "npm:^9.0.0"
-    "@types/react-dom": "npm:^18.0.0"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10c0/1ccf4eb1510500cc20a805cb0244c9098dca28a8745173a8f71ea1274d63774f0b7898a35c878b43c797b89c13621548909ff37843b835c1a27ee1efbbdd098c
   languageName: node
   linkType: hard
 
@@ -11220,7 +11185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0":
+"@types/prop-types@npm:^15.0.0":
   version: 15.7.15
   resolution: "@types/prop-types@npm:15.7.15"
   checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
@@ -11238,25 +11203,6 @@ __metadata:
   version: 1.2.7
   resolution: "@types/range-parser@npm:1.2.7"
   checksum: 10c0/361bb3e964ec5133fa40644a0b942279ed5df1949f21321d77de79f48b728d39253e5ce0408c9c17e4e0fd95ca7899da36841686393b9f7a1e209916e9381a3c
-  languageName: node
-  linkType: hard
-
-"@types/react-18@npm:@types/react@^18.3.1":
-  version: 18.3.31
-  resolution: "@types/react@npm:18.3.31"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.2.2"
-  checksum: 10c0/44180549dd045f536ececd39e39aacdf828e76adc1c4a90b132f453e23cc370c4648d9102ae401172ebd8fd8b1977a901a39e214e53ec77171b27514b588c179
-  languageName: node
-  linkType: hard
-
-"@types/react-dom-18@npm:@types/react-dom@^18.3.1, @types/react-dom@npm:^18.0.0":
-  version: 18.3.7
-  resolution: "@types/react-dom@npm:18.3.7"
-  peerDependencies:
-    "@types/react": ^18.0.0
-  checksum: 10c0/8bd309e2c3d1604a28a736a24f96cbadf6c05d5288cfef8883b74f4054c961b6b3a5e997fd5686e492be903c8f3380dba5ec017eff3906b1256529cd2d39603e
   languageName: node
   linkType: hard
 
@@ -12465,15 +12411,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:5.1.3":
-  version: 5.1.3
-  resolution: "aria-query@npm:5.1.3"
-  dependencies:
-    deep-equal: "npm:^2.0.5"
-  checksum: 10c0/edcbc8044c4663d6f88f785e983e6784f98cb62b4ba1e9dd8d61b725d0203e4cfca38d676aee984c31f354103461102a3d583aa4fbe4fd0a89b679744f4e5faf
-  languageName: node
-  linkType: hard
-
 "aria-query@npm:5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -12490,7 +12427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-buffer-byte-length@npm:^1.0.0, array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
+"array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
   version: 1.0.2
   resolution: "array-buffer-byte-length@npm:1.0.2"
   dependencies:
@@ -13113,18 +13050,6 @@ __metadata:
     es-errors: "npm:^1.3.0"
     function-bind: "npm:^1.1.2"
   checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
-  languageName: node
-  linkType: hard
-
-"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "call-bind@npm:1.0.9"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.2"
-    es-define-property: "npm:^1.0.1"
-    get-intrinsic: "npm:^1.3.0"
-    set-function-length: "npm:^1.2.2"
-  checksum: 10c0/a6621f6da1444481919ce3b4983dff725691e0754d3507ae483ce56e54985f2da7d6f1df512c56dbf28660745cf1ca52553f1fc9aef5557f3ce353ef14fab714
   languageName: node
   linkType: hard
 
@@ -14572,32 +14497,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:^2.0.5":
-  version: 2.2.3
-  resolution: "deep-equal@npm:2.2.3"
-  dependencies:
-    array-buffer-byte-length: "npm:^1.0.0"
-    call-bind: "npm:^1.0.5"
-    es-get-iterator: "npm:^1.1.3"
-    get-intrinsic: "npm:^1.2.2"
-    is-arguments: "npm:^1.1.1"
-    is-array-buffer: "npm:^3.0.2"
-    is-date-object: "npm:^1.0.5"
-    is-regex: "npm:^1.1.4"
-    is-shared-array-buffer: "npm:^1.0.2"
-    isarray: "npm:^2.0.5"
-    object-is: "npm:^1.1.5"
-    object-keys: "npm:^1.1.1"
-    object.assign: "npm:^4.1.4"
-    regexp.prototype.flags: "npm:^1.5.1"
-    side-channel: "npm:^1.0.4"
-    which-boxed-primitive: "npm:^1.0.2"
-    which-collection: "npm:^1.0.1"
-    which-typed-array: "npm:^1.1.13"
-  checksum: 10c0/a48244f90fa989f63ff5ef0cc6de1e4916b48ea0220a9c89a378561960814794a5800c600254482a2c8fd2e49d6c2e196131dc983976adb024c94a42dfe4949f
-  languageName: node
-  linkType: hard
-
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -15236,23 +15135,6 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
-  languageName: node
-  linkType: hard
-
-"es-get-iterator@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "es-get-iterator@npm:1.1.3"
-  dependencies:
-    call-bind: "npm:^1.0.2"
-    get-intrinsic: "npm:^1.1.3"
-    has-symbols: "npm:^1.0.3"
-    is-arguments: "npm:^1.1.1"
-    is-map: "npm:^2.0.2"
-    is-set: "npm:^2.0.2"
-    is-string: "npm:^1.0.7"
-    isarray: "npm:^2.0.5"
-    stop-iteration-iterator: "npm:^1.0.0"
-  checksum: 10c0/ebd11effa79851ea75d7f079405f9d0dc185559fd65d986c6afea59a0ff2d46c2ed8675f19f03dce7429d7f6c14ff9aede8d121fbab78d75cfda6a263030bac0
   languageName: node
   linkType: hard
 
@@ -16832,7 +16714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.2, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -18238,17 +18120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arguments@npm:^1.1.1":
-  version: 1.2.0
-  resolution: "is-arguments@npm:1.2.0"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/6377344b31e9fcb707c6751ee89b11f132f32338e6a782ec2eac9393b0cbd32235dad93052998cda778ee058754860738341d8114910d50ada5615912bb929fc
-  languageName: node
-  linkType: hard
-
-"is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
+"is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
   version: 3.0.5
   resolution: "is-array-buffer@npm:3.0.5"
   dependencies:
@@ -18450,7 +18322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.2, is-map@npm:^2.0.3":
+"is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
   checksum: 10c0/2c4d431b74e00fdda7162cd8e4b763d6f6f217edf97d4f8538b94b8702b150610e2c64961340015fe8df5b1fcee33ccd2e9b62619c4a8a3a155f8de6d6d355fc
@@ -18530,7 +18402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.4, is-regex@npm:^1.2.1":
+"is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
   dependencies:
@@ -18542,14 +18414,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-set@npm:^2.0.2, is-set@npm:^2.0.3":
+"is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 10c0/f73732e13f099b2dc879c2a12341cfc22ccaca8dd504e6edae26484bd5707a35d503fba5b4daad530a9b088ced1ae6c9d8200fd92e09b428fe14ea79ce8080b7
   languageName: node
   linkType: hard
 
-"is-shared-array-buffer@npm:^1.0.2, is-shared-array-buffer@npm:^1.0.4":
+"is-shared-array-buffer@npm:^1.0.4":
   version: 1.0.4
   resolution: "is-shared-array-buffer@npm:1.0.4"
   dependencies:
@@ -18565,7 +18437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-string@npm:^1.0.7, is-string@npm:^1.1.1":
+"is-string@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-string@npm:1.1.1"
   dependencies:
@@ -19922,7 +19794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -22045,16 +21917,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.1.5":
-  version: 1.1.6
-  resolution: "object-is@npm:1.1.6"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-  checksum: 10c0/506af444c4dce7f8e31f34fc549e2fb8152d6b9c4a30c6e62852badd7f520b579c679af433e7a072f9d78eb7808d230dc12e1cf58da9154dfbf8813099ea0fe0
-  languageName: node
-  linkType: hard
-
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -23449,27 +23311,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-18@npm:react@^18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
-  languageName: node
-  linkType: hard
-
-"react-dom-18@npm:react-dom@^18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
-  peerDependencies:
-    react: ^18.3.1
-  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:^19.2.7":
   version: 19.2.7
   resolution: "react-dom@npm:19.2.7"
@@ -23790,7 +23631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
+"regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
   dependencies:
@@ -24638,15 +24479,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
-  languageName: node
-  linkType: hard
-
 "scheduler@npm:^0.27.0":
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
@@ -24961,16 +24793,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel-list@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "side-channel-list@npm:1.0.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.4"
-  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
-  languageName: node
-  linkType: hard
-
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -24993,19 +24815,6 @@ __metadata:
     object-inspect: "npm:^1.13.3"
     side-channel-map: "npm:^1.0.1"
   checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
-  languageName: node
-  linkType: hard
-
-"side-channel@npm:^1.0.4":
-  version: 1.1.1
-  resolution: "side-channel@npm:1.1.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.4"
-    side-channel-list: "npm:^1.0.1"
-    side-channel-map: "npm:^1.0.1"
-    side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 
@@ -25386,7 +25195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stop-iteration-iterator@npm:^1.0.0, stop-iteration-iterator@npm:^1.1.0":
+"stop-iteration-iterator@npm:^1.1.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
   dependencies:
@@ -27450,7 +27259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-boxed-primitive@npm:^1.0.2, which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
+"which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
   dependencies:
@@ -27484,7 +27293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-collection@npm:^1.0.1, which-collection@npm:^1.0.2":
+"which-collection@npm:^1.0.2":
   version: 1.0.2
   resolution: "which-collection@npm:1.0.2"
   dependencies:
@@ -27493,21 +27302,6 @@ __metadata:
     is-weakmap: "npm:^2.0.2"
     is-weakset: "npm:^2.0.3"
   checksum: 10c0/3345fde20964525a04cdf7c4a96821f85f0cc198f1b2ecb4576e08096746d129eb133571998fe121c77782ac8f21cbd67745a3d35ce100d26d4e684c142ea1f2
-  languageName: node
-  linkType: hard
-
-"which-typed-array@npm:^1.1.13":
-  version: 1.1.22
-  resolution: "which-typed-array@npm:1.1.22"
-  dependencies:
-    available-typed-arrays: "npm:^1.0.7"
-    call-bind: "npm:^1.0.9"
-    call-bound: "npm:^1.0.4"
-    for-each: "npm:^0.3.5"
-    get-proto: "npm:^1.0.1"
-    gopd: "npm:^1.2.0"
-    has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/e59db184a4e78b461fac3b05fafc1e7badbbedafbf04a967ee1de73717f1f9723a79699e7b5de71d449541cb5da8353efc01a4f8a72a152479850e54fa196c40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary & Rationale

Follow-up to #2544 addressing code review feedback from @ditman:
1. **Reverted Browser Sandbox Configuration**: Reverted `ChromeHeadlessNoSandbox` in `renderers/react/a2ui_explorer/karma.conf.cjs` back to standard `browsers: [ChromeHeadless]`.
2. **Removed Synthetic Module Aliasing**:
   - Removed synthetic npm alias devDependencies (`react-18`, `react-dom-18`, `@types/react-18`, `@types/react-dom-18`, `@testing-library/react-18`).
   - Removed `createRequire`, `require.resolve`, `ssr.alias`, and regex import replacement from `vitest.config.ts`.
   - Removed `Module._resolveFilename` CommonJS hook from `tests/setup.ts`.
   - Removed `react18Aliases` from `karma.conf.cjs`.
3. **React 18 Compatibility Matrix**:
   - Added `renderers/react/scripts/test-react18.sh` which temporarily switches `@a2ui/react` and `@a2ui/react-explorer` to React 18 (`react@^18.3.1`, `react-dom@^18.3.1`, `@testing-library/react@^14.3.1`), executes the unit and integration test suites, and restores original React 19 dependencies upon completion.
   - Includes an upfront git preflight check to prevent running with uncommitted dependency changes, resets traps on cleanup, and restores original files atomically via `git checkout`.
   - Swaps dependencies using standard `yarn add` commands.
   - Added a `Test React 18 Compatibility` step in `.github/workflows/web_ci.yml` under the `ci-renderers` job.
   - Added script target `"test:react18": "./scripts/test-react18.sh"` in `renderers/react/package.json`.
4. **Tooling & Formatting**:
   - Added `renderers/react/a2ui_explorer/src/generated/**` to `.prettierignore`, matching Angular and Lit explorer generated paths.

### Verification

- Ran standard test suite: `yarn workspace @a2ui/react test` (475 unit tests, 132 integration tests under React 19).
- Ran React 18 matrix test: `yarn workspace @a2ui/react test:react18` (475 unit tests, 132 integration tests under React 18).
- Ran dependency lint: `yarn lint:deps` (0 errors).
- Ran lint and format checks across `@a2ui/react` and `@a2ui/react-explorer`.

Addresses feedback on #2544