### PR TITLE
docs(spec,blueprint): support cross-version surface updates and catalog compatibility

### DIFF
--- a/blueprints/modules/a2ui_core.blueprint.md
+++ b/blueprints/modules/a2ui_core.blueprint.md
@@ -380,7 +380,7 @@ When a surface is created with `sendDataModel: true`, the renderer is responsibl
 3.  The **Transport Layer** (e.g., A2A, MCP) calls `getRendererDataModel()` before sending any message to the agent.
 4.  If a non-empty data model map is returned, it is included in the transport's metadata field (e.g., `A2uiRendererDataModel` in A2A metadata).
 
-- **Surface Lifecycle**: It is an error to receive a `createSurface` message for a `surfaceId` that is already active; `surfaceId` must be globally unique per client session. The processor MUST throw an error or report a validation failure if this occurs.
+- **Surface Lifecycle**: It is an error to receive a `createSurface` message for a `surfaceId` that is already active; `surfaceId` must be globally unique per client session. The processor MUST throw an error or report a validation failure if this occurs. Surfaces are long-lived state containers that may receive updates across messages of different protocol versions (e.g., a v1.0 `updateComponents` updating a surface created via v0.9), provided each component resolves to a catalog compatible with the incoming message's protocol version.
 - **Component Lifecycle**: If an `updateComponents` message provides an existing `id` but a _different_ `type`, the processor MUST remove the old component and create a fresh one to ensure framework renderers correctly reset their internal state.
 
 #### [Capabilities Objects](../../docs/public/concepts/glossary.md#capabilities-object)

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -492,16 +492,22 @@ This structure is designed to be both flexible and strictly validated.
 
 #### Mixable catalogs and component resolution logic
 
-Renderers can support components and functions from multiple catalogs simultaneously within a single surface (mixable catalogs). When a renderer advertises `supportedCatalogIds` in its capabilities, components from any of those catalogs can be combined in the same UI tree. The set of available catalogs for a surface includes both `supportedCatalogIds` and the `catalogId` of any inline catalog declared in `inlineCatalogs` (when supported by the agent). All catalog IDs specified at the component and function-call levels and at the surface-level must refer to catalogs which use the same A2UI specification version.
+Renderers can support components and functions from multiple catalogs simultaneously within a single surface (mixable catalogs). When a renderer advertises `supportedCatalogIds` in its capabilities, components from any of those catalogs can be combined in the same UI tree. The set of available catalogs for a surface includes both `supportedCatalogIds` and the `catalogId` of any inline catalog declared in `inlineCatalogs` (when supported by the agent).
+
+All catalog IDs referenced within a single `agentToRenderer` message (whether at the component, function-call, or surface level) must refer to catalogs that are compatible with that message's protocol version. While protocol v0.9 and v1.0 catalogs are incompatible due to structural changes, future protocol versions will endeavour to maintain backward compatibility with older catalog versions (for example, protocol v1.1 _may_ accept v1.0 catalogs).
+
+Furthermore, a surface created with one protocol version may be updated by subsequent messages using a different protocol version (for example, a surface created with a v0.9 message may receive updates from a v1.0 message). In such cases, components in the updating message must resolve against a catalog compatible with that message's protocol version.
 
 When resolving a component (or function call), the renderer evaluates catalog identity using the following strict resolution order:
 
-1. **Explicit Component/Function-Level `catalogId`**: The renderer checks if the component or function call explicitly specifies a `catalogId`. If provided, the component or function is resolved against that catalog.
-2. **Surface Default `catalogId`**: If the component or function call does not specify a `catalogId`, the renderer checks if a default `catalogId` was specified on the surface in the `createSurface` message. If provided, the component or function is resolved against that surface default catalog.
-3. **Resolution Error**: If neither an explicit component/function-level `catalogId` nor a surface default `catalogId` is present, resolution fails immediately with an error and the component is not rendered (or the function call is rejected).
+1. **Explicit Component/Function-Level `catalogId`**: The renderer checks if the component or function call explicitly specifies a `catalogId`. If provided, the component or function is resolved against that catalog (which must be compatible with the message's protocol version).
+2. **Surface Default `catalogId`**: If the component or function call does not specify a `catalogId`, the renderer checks if a default `catalogId` was specified on the surface in the `createSurface` message:
+   - If the surface default catalog is **compatible** with the message's protocol version, the component or function is resolved against that surface default catalog.
+   - If the surface default catalog is **incompatible** with the message's protocol version (such as a v1.0 message updating a surface whose default catalog is v0.9), fallback to the surface default is disallowed. The component or function call must explicitly specify a `catalogId` compatible with the message's protocol version.
+3. **Resolution Error**: If neither an explicit component/function-level `catalogId` nor a compatible surface default `catalogId` is present, resolution fails immediately with an error and the component is not rendered (or the function call is rejected).
 
 > [!IMPORTANT]
-> There is **no fallback** to the list of catalogs declared in `rendererCapabilities` (even if the renderer only advertises a single supported catalog). Every component and function call must resolve through either its explicit `catalogId` or the surface default `catalogId`.
+> There is **no fallback** to the list of catalogs declared in `rendererCapabilities` (even if the renderer only advertises a single supported catalog). Every component and function call must resolve through either its explicit `catalogId` or a compatible surface default `catalogId`.
 
 ### Catalog-Agnostic Accessibility Requirements
 

--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -12,7 +12,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Added an optional `catalogId` property to `ComponentCommon` and `FunctionCall` to allow individual components and function calls to explicitly declare their source catalog.
 - Retained `catalogId` on `createSurface` as an optional parameter that defines the default catalog for that surface.
 - Added extensibility metadata support via `$defs/Extensions` in `common_types.json`, allowing `ComponentCommon`, `createSurface`, and `ComponentDefinition` to convey arbitrary extension key-value pairs (with Unicode UAX #31 keys and reserved `a2ui_` namespace).
-- Defined explicit component and function call resolution logic: the renderer checks the component-level (or function call-level) `catalogId` first, then falls back to the surface default `catalogId`. If neither is defined, the renderer errors out and does not render the component (or rejects the function call). There is no fallback to catalogs declared in capabilities. Available catalogs for a surface include both `supportedCatalogIds` and any negotiated `inlineCatalogs`, and all mixed catalogs must use the same A2UI specification version.
+- Defined explicit component and function call resolution logic: the renderer checks the component-level (or function call-level) `catalogId` first, then falls back to the surface default `catalogId` (if compatible with the message's protocol version). If neither is defined or compatible, the renderer errors out and does not render the component (or rejects the function call). There is no fallback to catalogs declared in capabilities. Available catalogs for a surface include both `supportedCatalogIds` and any negotiated `inlineCatalogs`. All catalogs referenced within a single message must be compatible with that message's protocol version, and surfaces can receive updates across protocol versions when components specify compatible catalog IDs.
 - The `theme` property in the catalog and surface creation message is removed, along with `primaryColor`, to separate layout from branding.
 - Components and initial data model states can be defined directly within the `createSurface` parameters. This allows for the creation of entire UIs in a single message, rather than a create followed by separate updates.
 - The `functions` field in catalog meta-schemas (`catalog_definition.json`) is now formalized as a JSON object map of function name to its definition, matching the map structure used in catalog files.
@@ -91,8 +91,8 @@ Version 1.0 differs from 0.9 in the following ways:
 
 - Defined strict component and function catalog resolution logic:
   1. Check the component's (or function call's) explicit `catalogId`.
-  2. If not present, check the surface's default `catalogId` provided in `createSurface`.
-  3. If neither exists, report an error and do not render the component (or fail the function call). There is no fallback to catalogs advertised in capabilities. Available catalogs include `supportedCatalogIds` and negotiated `inlineCatalogs`, and all mixed catalogs must use the same A2UI specification version.
+  2. If not present, check the surface's default `catalogId` provided in `createSurface` (only if compatible with the message's protocol version).
+  3. If neither exists or is compatible, report an error and do not render the component (or fail the function call). There is no fallback to catalogs advertised in capabilities. Available catalogs include `supportedCatalogIds` and negotiated `inlineCatalogs`. All catalogs referenced within a message must be compatible with that message's protocol version.
 - Explicitly specified that `surfaceId` must be globally unique per renderer session. Creating a surface with an ID that already exists (without first deleting it) is an error.
 - Enforced runtime lookup of function execution boundaries and return types. If a renderer receives a remote call to a function configured as `rendererOnly` or if the function is unregistered, it rejects the call and returns an error with the code `INVALID_FUNCTION_CALL`.
 - Enforced catalog entity naming compliance with Unicode Standard Annex #31 (UAX #31).
@@ -134,11 +134,11 @@ This section outlines the steps required to migrate existing applications and co
 
 ### For renderers
 
-- Implement multi-catalog mixing by supporting components and function calls from any catalog in `supportedCatalogIds` or negotiated `inlineCatalogs`. All catalogs mixed within a surface must use the same A2UI specification version.
-- Implement component and function resolution order: (1) explicit component/call `catalogId`, (2) surface default `catalogId`, (3) error if neither exists (no fallback to capabilities).
+- Implement multi-catalog mixing by supporting components and function calls from any catalog in `supportedCatalogIds` or negotiated `inlineCatalogs`. All catalogs referenced within a message must be compatible with that message's protocol version. Surfaces can receive updates across protocol versions, provided components resolve to compatible catalogs.
+- Implement component and function resolution order: (1) explicit component/call `catalogId`, (2) surface default `catalogId` (if compatible), (3) error if neither exists or is compatible (no fallback to capabilities).
 - Implement function execution by adding support for parsing `callRendererFunction` messages from the agent, checking authorized callers in the catalog (`allowedCallers`), rejecting invalid calls with `INVALID_FUNCTION_CALL`, and returning `rendererFunctionResponse` messages.
 - Implement renderer-initiated function calls by sending `callAgentFunction` messages to the agent and handling incoming `agentFunctionResponse` messages.
-- Support simultaneous version handling during session initialization by inspecting the `version` property (e.g., `"v1.0"`) to route payloads to version-specific controllers.
+- Support multi-version surface handling: ensure the underlying `SurfaceGroupModel` allows a surface to be updated across messages of different protocol versions, verifying that components resolve to catalogs compatible with the updating message.
 - Enforce surface uniqueness by raising an error if `createSurface` is received for an existing `surfaceId`.
 - Update error reporting to handle `functionCallId` and enforce mutual exclusivity with `surfaceId`.
 - Enforce Unicode identifier naming by verifying that all catalog entity names (components, functions, prop keys) conform to UAX #31 identifier rules.


### PR DESCRIPTION
## Overview & Rationale

This PR refines the **A2UI v1.0 protocol specification**, the **Evolution Guide**, and the **Core SDK Architecture Blueprint** to:
1. Clarify that component catalog compatibility is evaluated at the **message level** rather than enforcing that every catalog on a surface must use the exact same specification version.
2. Explicitly permit a single UI surface (`surfaceId`) to receive updates across different protocol versions over its lifetime (e.g. a surface created by a `v0.9` message can be updated by `v1.0` messages).
3. Specify conditional surface default fallback: components in an update message can fall back to the surface's default catalog only if that default catalog is *compatible* with the message's protocol version. If incompatible, components must explicitly provide a `catalogId`.

---

### Key Changes:

1. **Protocol Specification (`specification/v1_0/docs/a2ui_protocol.md`)**:
   - Updated **Mixable catalogs and component resolution logic**:
     - Clarified that all catalogs referenced within an `agentToRenderer` message must be compatible with that message's protocol version.
     - Documented that a surface created with one protocol version may be updated by subsequent messages of a different protocol version.
     - Updated resolution order: fallback to the surface default catalog is only permitted when the default catalog is compatible with the message's protocol version; otherwise, an explicit compatible `catalogId` is required.

2. **Evolution Guide (`specification/v1_0/docs/evolution_guide.md`)**:
   - Updated resolution logic in the overview and Section 2.7 (Processing rules).
   - Updated Section 3 (`For renderers`) to instruct renderers to support multi-version surface handling in `SurfaceGroupModel`.

3. **Core SDK Architecture Blueprint (`blueprints/modules/a2ui_core.blueprint.md`)**:
   - Updated the **Surface Lifecycle** section to note that surfaces are long-lived state containers that may receive updates across messages of different protocol versions.

---

### Verification:

- `python3 blueprints/validate_blueprints.py` passed.
- `python3 specification/scripts/validate.py` passed across v0.8, v0.9, and v1.0.
- Prettier formatting verified via `yarn prettier --config .prettierrc --check`.