### PR TITLE
fix(python_core): guard DataModel and MessageProcessor against prototype pollution

### DIFF
--- a/agent_sdks/python/a2ui_core/src/a2ui/core/state/__init__.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/state/__init__.py
@@ -15,7 +15,7 @@
 from ..common.events import EventSource, Signal
 from .component_model import ComponentModel
 from .component_node import ComponentNode
-from .data_model import DataModel
+from .data_model import FORBIDDEN_KEYS, DataModel
 from .surface_components_model import SurfaceComponentsModel
 from .surface_group_model import SurfaceGroupModel
 from .surface_model import SurfaceModel
@@ -26,6 +26,7 @@ __all__ = [
     "ComponentNode",
     "DataModel",
     "EventSource",
+    "FORBIDDEN_KEYS",
     "Signal",
     "SurfaceComponentsModel",
     "SurfaceGroupModel",

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/state/data_model.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/state/data_model.py
@@ -22,6 +22,11 @@ NUMERIC_PATTERN = re.compile(r"^(?:0|[1-9][0-9]*)$")
 
 # Keys forbidden in path resolution to prevent prototype pollution vulnerabilities.
 FORBIDDEN_KEYS = frozenset({"__proto__", "constructor", "prototype"})
+UNESCAPE_PATTERN = re.compile(r"~([01])")
+
+
+def _unescape_match(m: re.Match[str]) -> str:
+    return "/" if m.group(1) == "1" else "~"
 
 
 class DataModel:
@@ -46,7 +51,7 @@ class DataModel:
         else:
             raw_tokens = path[1:].split("/")
 
-        tokens = [t.replace("~1", "/").replace("~0", "~") for t in raw_tokens]
+        tokens = [UNESCAPE_PATTERN.sub(_unescape_match, t) for t in raw_tokens]
         for token in tokens:
             if token in FORBIDDEN_KEYS:
                 raise ValueError(f"Forbidden path segment '{token}' in path '{path}'.")

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/state/data_model.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/state/data_model.py
@@ -20,6 +20,9 @@ from ..common.events import Subscription
 # Regex to check if path segment is numeric (representing array index)
 NUMERIC_PATTERN = re.compile(r"^(?:0|[1-9][0-9]*)$")
 
+# Keys forbidden in path resolution to prevent prototype pollution vulnerabilities.
+FORBIDDEN_KEYS = frozenset({"__proto__", "constructor", "prototype"})
+
 
 class DataModel:
     """An atomic RFC 6901 JSON Pointer reactive store."""
@@ -30,15 +33,24 @@ class DataModel:
 
     @staticmethod
     def _parse_pointer(path: str) -> List[str]:
-        """Splits a JSON Pointer path into individual unescaped tokens."""
+        """Splits a JSON Pointer path into individual unescaped tokens.
+
+        Raises:
+            ValueError: If path contains forbidden segments ('__proto__', 'constructor', 'prototype').
+        """
         if not path or path == "/":
             return []
         if not path.startswith("/"):
             # Support relative scope path resolution
-            return [t.replace("~1", "/").replace("~0", "~") for t in path.split("/")]
+            raw_tokens = path.split("/")
+        else:
+            raw_tokens = path[1:].split("/")
 
-        tokens = path[1:].split("/")
-        return [t.replace("~1", "/").replace("~0", "~") for t in tokens]
+        tokens = [t.replace("~1", "/").replace("~0", "~") for t in raw_tokens]
+        for token in tokens:
+            if token in FORBIDDEN_KEYS:
+                raise ValueError(f"Forbidden path segment '{token}' in path '{path}'.")
+        return tokens
 
     @staticmethod
     def _build_pointer(tokens: List[str]) -> str:

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/validating/integrity_checker.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/validating/integrity_checker.py
@@ -24,6 +24,7 @@ MAX_FUNC_CALL_DEPTH = 5
 RELAXED_PATH_PATTERN = re.compile(
     r"^(?:(?:\/(?:[^~\/]|~[01])*)*|(?:[^~\/]|~[01])+(?:\/(?:[^~\/]|~[01])*)*)$"
 )
+FORBIDDEN_PATH_SEGMENTS = frozenset({"__proto__", "constructor", "prototype"})
 
 
 def get_component_references(
@@ -155,6 +156,25 @@ def validate_recursion_and_paths(data: Any) -> None:
                             )
                         ],
                     )
+                raw_segments = (
+                    path[1:].split("/") if path.startswith("/") else path.split("/")
+                )
+                for raw_seg in raw_segments:
+                    seg = raw_seg.replace("~1", "/").replace("~0", "~")
+                    if seg in FORBIDDEN_PATH_SEGMENTS:
+                        raise A2uiValidationError(
+                            f"Forbidden path segment '{seg}' in path '{path}'",
+                            details=[
+                                A2uiErrorDetail(
+                                    path="path",
+                                    code="forbidden_path_segment",
+                                    message=(
+                                        f"Forbidden path segment '{seg}' in path"
+                                        f" '{path}'"
+                                    ),
+                                )
+                            ],
+                        )
 
             is_func_v08 = "functionCall" in item and isinstance(
                 item["functionCall"], dict

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/validating/integrity_checker.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/validating/integrity_checker.py
@@ -25,6 +25,11 @@ RELAXED_PATH_PATTERN = re.compile(
     r"^(?:(?:\/(?:[^~\/]|~[01])*)*|(?:[^~\/]|~[01])+(?:\/(?:[^~\/]|~[01])*)*)$"
 )
 FORBIDDEN_PATH_SEGMENTS = frozenset({"__proto__", "constructor", "prototype"})
+UNESCAPE_PATTERN = re.compile(r"~([01])")
+
+
+def _unescape_match(m: re.Match[str]) -> str:
+    return "/" if m.group(1) == "1" else "~"
 
 
 def get_component_references(
@@ -160,7 +165,7 @@ def validate_recursion_and_paths(data: Any) -> None:
                     path[1:].split("/") if path.startswith("/") else path.split("/")
                 )
                 for raw_seg in raw_segments:
-                    seg = raw_seg.replace("~1", "/").replace("~0", "~")
+                    seg = UNESCAPE_PATTERN.sub(_unescape_match, raw_seg)
                     if seg in FORBIDDEN_PATH_SEGMENTS:
                         raise A2uiValidationError(
                             f"Forbidden path segment '{seg}' in path '{path}'",

--- a/agent_sdks/python/a2ui_core/tests/test_processing.py
+++ b/agent_sdks/python/a2ui_core/tests/test_processing.py
@@ -741,3 +741,41 @@ def test_message_processor_json_catalog_theme_validation():
                 "theme": {"primaryColor": "red"},  # Must match hex color regex!
             },
         }])
+
+
+def test_message_processor_rejects_prototype_pollution_in_update_data_model(
+    real_catalog_09,
+):
+    processor = MessageProcessor(catalogs=[real_catalog_09], strict_mode=False)
+    processor.process_messages([{
+        "version": SPEC_VERSION,
+        "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": real_catalog_09.catalog_id,
+        },
+    }])
+
+    surface = processor.model.get_surface("s1")
+    assert surface is not None
+
+    with pytest.raises(ValueError, match="Forbidden path segment '__proto__'"):
+        processor.process_messages([{
+            "version": SPEC_VERSION,
+            "updateDataModel": {
+                "surfaceId": "s1",
+                "path": "/__proto__/polluted",
+                "value": "hacked",
+            },
+        }])
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'constructor'"):
+        processor.process_messages([{
+            "version": SPEC_VERSION,
+            "updateDataModel": {
+                "surfaceId": "s1",
+                "path": "/constructor/prototype/polluted",
+                "value": "hacked",
+            },
+        }])
+
+    assert surface.data_model.get("/") == {}

--- a/agent_sdks/python/a2ui_core/tests/test_state.py
+++ b/agent_sdks/python/a2ui_core/tests/test_state.py
@@ -271,3 +271,73 @@ def test_component_node_lifecycle():
     # Double dispose is idempotent
     node.dispose()
     assert len(cleanup_executed) == 1
+
+
+# ==============================================================================
+# Security Tests: Prototype Pollution Protection
+# ==============================================================================
+
+
+def test_data_model_prevents_prototype_pollution_proto():
+    dm = DataModel()
+
+    with pytest.raises(ValueError, match="Forbidden path segment '__proto__'"):
+        dm.set("/__proto__/polluted", "hacked")
+
+    with pytest.raises(ValueError, match="Forbidden path segment '__proto__'"):
+        dm.get("/__proto__/polluted")
+
+    with pytest.raises(ValueError, match="Forbidden path segment '__proto__'"):
+        dm.has_path("/__proto__/polluted")
+
+    with pytest.raises(ValueError, match="Forbidden path segment '__proto__'"):
+        dm.subscribe("/__proto__/polluted", lambda _: None)
+
+    assert dm.get("/") == {}
+
+
+def test_data_model_prevents_prototype_pollution_constructor():
+    dm = DataModel()
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'constructor'"):
+        dm.set("/constructor/prototype/polluted", "hacked")
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'constructor'"):
+        dm.get("/constructor/prototype/polluted")
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'constructor'"):
+        dm.has_path("/constructor/prototype/polluted")
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'constructor'"):
+        dm.subscribe("/constructor/prototype/polluted", lambda _: None)
+
+    assert dm.get("/") == {}
+
+
+def test_data_model_prevents_prototype_pollution_prototype():
+    dm = DataModel()
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'prototype'"):
+        dm.set("/user/prototype/polluted", "hacked")
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'prototype'"):
+        dm.get("/user/prototype/polluted")
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'prototype'"):
+        dm.has_path("/user/prototype/polluted")
+
+    with pytest.raises(ValueError, match="Forbidden path segment 'prototype'"):
+        dm.subscribe("/user/prototype/polluted", lambda _: None)
+
+    assert dm.get("/") == {}
+
+
+def test_data_model_allows_valid_similar_path_segments():
+    dm = DataModel()
+
+    # Segments containing substrings of forbidden keys should still be allowed
+    dm.set("/user/prototype_name", "test_proto")
+    dm.set("/constructor_args/value", 123)
+
+    assert dm.get("/user/prototype_name") == "test_proto"
+    assert dm.get("/constructor_args/value") == 123

--- a/agent_sdks/python/a2ui_core/tests/test_state.py
+++ b/agent_sdks/python/a2ui_core/tests/test_state.py
@@ -341,3 +341,14 @@ def test_data_model_allows_valid_similar_path_segments():
 
     assert dm.get("/user/prototype_name") == "test_proto"
     assert dm.get("/constructor_args/value") == 123
+
+
+def test_data_model_escaped_pointer_tokens():
+    dm = DataModel()
+    # RFC 6901: ~0 represents '~' and ~1 represents '/'
+    dm.set("/a~1b", "slash_key")
+    dm.set("/m~0n", "tilde_key")
+
+    assert dm.get("/a~1b") == "slash_key"
+    assert dm.get("/m~0n") == "tilde_key"
+    assert dm.get("/") == {"a/b": "slash_key", "m~n": "tilde_key"}

--- a/agent_sdks/python/a2ui_core/tests/test_validating.py
+++ b/agent_sdks/python/a2ui_core/tests/test_validating.py
@@ -475,3 +475,16 @@ def test_validator_rejects_forbidden_path_segments():
             A2uiValidatorError, match=f"Forbidden path segment '{forbidden}'"
         ):
             validator.validate_protocol_envelope(msg)
+
+
+def test_validator_accepts_escaped_path_segments():
+    validator = A2uiValidator()
+    msg = [{
+        "version": "v0.9",
+        "updateDataModel": {
+            "surfaceId": "s1",
+            "path": "/a~1b/m~0n",
+            "value": 123,
+        },
+    }]
+    validator.validate_protocol_envelope(msg)

--- a/agent_sdks/python/a2ui_core/tests/test_validating.py
+++ b/agent_sdks/python/a2ui_core/tests/test_validating.py
@@ -457,3 +457,21 @@ def test_validator_config_parameter():
         validator.validate(catalog, payload, config=strict_config)
 
     validator.validate(catalog, payload, config=relaxed_config)
+
+
+def test_validator_rejects_forbidden_path_segments():
+    validator = A2uiValidator()
+
+    for forbidden in ["__proto__", "constructor", "prototype"]:
+        msg = [{
+            "version": "v0.9",
+            "updateDataModel": {
+                "surfaceId": "s1",
+                "path": f"/{forbidden}/key",
+                "value": 1,
+            },
+        }]
+        with pytest.raises(
+            A2uiValidatorError, match=f"Forbidden path segment '{forbidden}'"
+        ):
+            validator.validate_protocol_envelope(msg)


### PR DESCRIPTION
# Description

This PR fixes a prototype pollution security vulnerability in the Python SDK (`a2ui_core`).

### What was the problem?
When an agent sent an `updateDataModel` message with paths like `/__proto__/isAdmin` or `/constructor/prototype/role`, the Python `DataModel` accepted it without checking. 

When this data was sent to web clients, it could pollute JavaScript's `Object.prototype`, which is a security risk. Also, `web_core` (TypeScript) already blocked these paths, but Python did not.

### What changed?
1. **Forbidden Key Check:** Added checks in Python `DataModel` to block dangerous path segments: `__proto__`, `constructor`, and `prototype`.
2. **Message Validation:** Added checks in `MessageProcessor` and `integrity_checker` so incoming messages with these paths are safely rejected with an error.
3. **Tests:** Added unit tests to make sure these dangerous paths are rejected while normal keys (like `/user/prototype_name`) still work fine.

Fixes #2577

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
