### PR TITLE
fix(angular): guard v0.8 icon component against non-string names 

### DIFF
--- a/renderers/angular/src/v0_8/components/icon.spec.ts
+++ b/renderers/angular/src/v0_8/components/icon.spec.ts
@@ -25,17 +25,22 @@ describe('Icon Component', () => {
   let component: Icon;
   let fixture: ComponentFixture<Icon>;
   let mockTheme: Theme;
+  let mockDataModelValue: unknown = null;
 
   beforeEach(async () => {
     mockTheme = new Theme();
     mockTheme.components = {Icon: 'icon-class'} as any;
+    mockDataModelValue = null;
 
     await TestBed.configureTestingModule({
       imports: [Icon],
       providers: [
         {
           provide: MessageProcessor,
-          useValue: {resolvePrimitive: (p: any) => p?.literalString || p},
+          useValue: {
+            resolvePrimitive: (p: any) => p?.literalString || p,
+            getData: (_comp: unknown, _path: string, _surfaceId: unknown) => mockDataModelValue,
+          },
         },
         {provide: Theme, useValue: mockTheme},
         {provide: Catalog, useValue: {}},
@@ -95,5 +100,67 @@ describe('Icon Component', () => {
     const spanEl = fixture.debugElement.query(By.css('.g-icon'));
     expect(spanEl).toBeTruthy();
     expect(spanEl.nativeElement.textContent).toBe('arrow_forward');
+  });
+
+  it('should NOT render anything and NOT throw if name resolves to an array from DataModel', () => {
+    mockDataModelValue = [1, 2, 3];
+    fixture.componentRef.setInput('name', {path: '/bad_array'});
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    const spanEl = fixture.debugElement.query(By.css('.g-icon'));
+    expect(spanEl).toBeFalsy();
+
+    const sectionEl = fixture.debugElement.query(By.css('section'));
+    expect(sectionEl).toBeFalsy();
+  });
+
+  it('should NOT render anything and NOT throw if name resolves to an object from DataModel', () => {
+    mockDataModelValue = {malicious: true};
+    fixture.componentRef.setInput('name', {path: '/bad_object'});
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    const spanEl = fixture.debugElement.query(By.css('.g-icon'));
+    expect(spanEl).toBeFalsy();
+
+    const sectionEl = fixture.debugElement.query(By.css('section'));
+    expect(sectionEl).toBeFalsy();
+  });
+
+  it('should NOT render anything and NOT throw if name resolves to a number from DataModel', () => {
+    mockDataModelValue = 12345;
+    fixture.componentRef.setInput('name', {path: '/bad_number'});
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    const spanEl = fixture.debugElement.query(By.css('.g-icon'));
+    expect(spanEl).toBeFalsy();
+
+    const sectionEl = fixture.debugElement.query(By.css('section'));
+    expect(sectionEl).toBeFalsy();
+  });
+
+  it('should NOT render anything and NOT throw if name resolves to a boolean from DataModel', () => {
+    mockDataModelValue = true;
+    fixture.componentRef.setInput('name', {path: '/bad_bool'});
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    const spanEl = fixture.debugElement.query(By.css('.g-icon'));
+    expect(spanEl).toBeFalsy();
+
+    const sectionEl = fixture.debugElement.query(By.css('section'));
+    expect(sectionEl).toBeFalsy();
+  });
+
+  it('should render icon name if name resolves to a valid string from DataModel', () => {
+    mockDataModelValue = 'starBorder';
+    fixture.componentRef.setInput('name', {path: '/valid_icon'});
+    fixture.detectChanges();
+
+    const spanEl = fixture.debugElement.query(By.css('.g-icon'));
+    expect(spanEl).toBeTruthy();
+    expect(spanEl.nativeElement.textContent).toBe('star_border');
+
+    const sectionEl = fixture.debugElement.query(By.css('section'));
+    expect(sectionEl).toBeTruthy();
+    expect(sectionEl.nativeElement.className).toBe('icon-class');
   });
 });

--- a/renderers/angular/src/v0_8/components/icon.ts
+++ b/renderers/angular/src/v0_8/components/icon.ts
@@ -49,11 +49,12 @@ export class Icon extends DynamicComponent<IconNode> {
   // g-icon uses snake_case for the icon names. We convert camelCase and TitleCase here.
   protected readonly resolvedName = computed(() => {
     const rawName = this.resolvePrimitive(this.name());
-    if (!rawName) return '';
+    if (typeof rawName !== 'string' || !rawName) return '';
     return this.toSnakeCase(rawName);
   });
 
   private toSnakeCase(str: string): string {
+    if (typeof str !== 'string') return '';
     return str
       .replace(/^[A-Z]/, letter => letter.toLowerCase())
       .replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);


### PR DESCRIPTION
# Description

In Angular v0.8, the `Icon` component dynamically resolves its `name` attribute from the `DataModel` when given a path (e.g. `{"path": "/icon_name"}`).

Previously, there was no check to verify if the resolved value was actually a string before passing it to `toSnakeCase()`. If an agent set the path to a non-string value (such as an array `[1, 2, 3]`, object `{}`, or number `123`), `str.replace()` threw an unhandled `TypeError: str.replace is not a function`. Inside an Angular `computed()` signal during change detection, this crashed the rendering cycle and caused the UI to freeze (Denial of Service).

### What this PR changes:
- **`icon.ts`**: Adds type verification (`typeof rawName !== 'string' || !rawName`) so non-string values safely return an empty string `""` without crashing. Also adds a defensive check in `toSnakeCase`.
- **`icon.spec.ts`**: Adds unit tests ensuring non-string values (arrays, objects, numbers, booleans) and valid strings from the DataModel are handled properly.

Fixes #2578

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
