### PR TITLE
fix: eliminate lockfile bypass in renderer release scripts 

### DIFF
--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "wireit",
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "prepublishOnly": "node -e \"console.error('Error: Do not publish this package directly. Use yarn publish:package instead.'); process.exit(1);\"",
     "publish:package": "yarn build && npm publish dist/ --access public",
     "demo": "yarn workspace @a2ui/angular-explorer dev",
     "test": "wireit",

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -21,8 +21,8 @@
   ],
   "scripts": {
     "build": "wireit",
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `cd dist && yarn npm publish`'); process.exit(1); }\"",
-    "publish:package": "yarn build && cd dist && touch yarn.lock && yarn install && yarn npm publish --access public",
+    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "publish:package": "yarn build && npm publish dist/ --access public",
     "demo": "yarn workspace @a2ui/angular-explorer dev",
     "test": "wireit",
     "test:unit": "wireit",

--- a/renderers/docs/web_publishing.md
+++ b/renderers/docs/web_publishing.md
@@ -112,8 +112,7 @@ actual publishing will be sent automatically. Publishing normally takes around
 A2UI web packages depend on each other via `workspace:*` links during development. When `publish_npm.mjs` invokes a package's `publish:package` target, the following preparation steps occur:
 
 1. **Build & Metadata Transformation**: `prepare-publish.mjs` copies build output into `dist/`, replaces internal `workspace:` protocols with absolute semantic version ranges (e.g., `^0.10.3`), and strips development scripts/dependencies.
-2. **Boundary Isolation**: Because the root workspace config excludes `dist/` (`!**/dist`), an empty `yarn.lock` is initialized inside `dist/` to establish it as an independent package boundary.
-3. **Clean Upload**: `yarn npm publish --access public` executes strictly inside `dist/`, ensuring only clean production assets are uploaded.
+2. **Clean Upload**: `npm publish dist/ --access public` publishes the packaged artifacts directly from `dist/`, ensuring only clean production assets are uploaded without executing dynamic dependency resolution or modifying lockfiles.
 
 ---
 

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -47,8 +47,8 @@
   },
   "type": "module",
   "scripts": {
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `cd dist && yarn npm publish`'); process.exit(1); }\"",
-    "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && cd dist && touch yarn.lock && yarn install && yarn npm publish --access public",
+    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "build": "wireit",
     "build:tsc": "wireit",
     "dev": "yarn serve --watch",

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -47,7 +47,7 @@
   },
   "type": "module",
   "scripts": {
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "prepublishOnly": "node -e \"console.error('Error: Do not publish this package directly. Use yarn publish:package instead.'); process.exit(1);\"",
     "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "build": "wireit",
     "build:tsc": "wireit",

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -38,7 +38,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --ignore-path ../.gitignore --write .",
     "format:check": "prettier --ignore-path ../.gitignore --check .",
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "prepublishOnly": "node -e \"console.error('Error: Do not publish this package directly. Use yarn publish:package instead.'); process.exit(1);\"",
     "publish:package": "yarn build && node ../../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "test": "wireit",
     "clean": "wireit"

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -38,8 +38,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --ignore-path ../.gitignore --write .",
     "format:check": "prettier --ignore-path ../.gitignore --check .",
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `cd dist && yarn npm publish`'); process.exit(1); }\"",
-    "publish:package": "yarn build && node ../../scripts/prepare-publish.mjs && cd dist && touch yarn.lock && yarn install && yarn npm publish --access public",
+    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "publish:package": "yarn build && node ../../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "test": "wireit",
     "clean": "wireit"
   },

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -74,8 +74,8 @@
     "*.css"
   ],
   "scripts": {
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `cd dist && yarn npm publish`'); process.exit(1); }\"",
-    "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && cd dist && touch yarn.lock && yarn install && yarn npm publish --access public",
+    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "build": "wireit",
     "demo": "yarn workspace @a2ui/react-explorer dev",
     "test": "wireit",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -74,7 +74,7 @@
     "*.css"
   ],
   "scripts": {
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "prepublishOnly": "node -e \"console.error('Error: Do not publish this package directly. Use yarn publish:package instead.'); process.exit(1);\"",
     "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "build": "wireit",
     "demo": "yarn workspace @a2ui/react-explorer dev",

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "scripts": {
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "prepublishOnly": "node -e \"console.error('Error: Do not publish this package directly. Use yarn publish:package instead.'); process.exit(1);\"",
     "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "prepack": "yarn build",
     "prepare": "yarn build",

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -58,8 +58,8 @@
     "src"
   ],
   "scripts": {
-    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `cd dist && yarn npm publish`'); process.exit(1); }\"",
-    "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && cd dist && touch yarn.lock && yarn install && yarn npm publish --access public",
+    "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `yarn build` then `npm publish dist/`'); process.exit(1); }\"",
+    "publish:package": "yarn build && node ../scripts/prepare-publish.mjs && npm publish dist/ --access public",
     "prepack": "yarn build",
     "prepare": "yarn build",
     "build": "wireit",


### PR DESCRIPTION
# Description

This PR fixes a security vulnerability in the release scripts of all web renderer packages (`web_core`, `angular`, `lit`, `react`, and `markdown-it`).

Previously, the `publish:package` script entered `dist/`, created an empty `yarn.lock`, and ran `yarn install`. Because `dist/` is excluded from workspaces, this bypassed the repository's root lockfile and caused Yarn to install unpinned dependencies from npm during publishing, exposing the maintainer's machine to potential supply chain risks.

This PR replaces that sequence with `npm publish dist/ --access public`. It publishes the pre-built output directory directly without modifying lockfiles or running unpinned dependency installations. It also updates the `prepublishOnly` safety script to prevent direct publishing, and updates the web publishing documentation.

Fixes #2581

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
