### PR TITLE
fix(docs): update CopilotKit skill link to skills/copilotkit/SKILL.md

### DIFF
--- a/docs/public/guides/a2ui-with-any-agent-framework.md
+++ b/docs/public/guides/a2ui-with-any-agent-framework.md
@@ -41,7 +41,7 @@ before it modifies your app. It covers AG-UI framework adapters, supported
 and end-to-end verification for AG-UI + A2UI apps.
 
 If your app uses CopilotKit for A2UI rendering, also load the
-[CopilotKit `a2ui-renderer` skill](https://github.com/CopilotKit/CopilotKit/blob/main/skills/a2ui-renderer/SKILL.md)
+[CopilotKit `copilotkit` skill](https://github.com/CopilotKit/CopilotKit/blob/main/skills/copilotkit/SKILL.md)
 for CopilotKit v2 runtime, provider, theme, and catalog conventions.
 
 ## 1. Set up AG-UI


### PR DESCRIPTION
## Summary

Resolves #2611.

Upstream CopilotKit removed their dedicated `skills/a2ui-renderer/` folder in commit `db096f05` and consolidated skills into `skills/copilotkit/SKILL.md`. This resulted in CI failures across pull requests running the Markdown link checker (`lychee-action` in `.github/workflows/docs.yml`) due to an external 404.

This PR updates the CopilotKit skill reference in `docs/public/guides/a2ui-with-any-agent-framework.md` to point to the active CopilotKit skill file:
- `https://github.com/CopilotKit/CopilotKit/blob/main/skills/copilotkit/SKILL.md` (HTTP 200)

## Pre-launch Checklist
- [x] I read the [Contributors Guide](https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md).
- [x] My code changes have tests.
