### PR TITLE
fix(python): run the shared data model conformance suite, and fix what it finds

### DIFF
--- a/agent_sdks/python/a2ui_core/CHANGELOG.md
+++ b/agent_sdks/python/a2ui_core/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Unreleased
 
+- `DataModel` now runs the shared `conformance/core/data_model.yaml` suite,
+  alongside the Dart client and `web_core`. It was the only implementation of
+  the data model measured solely by its own tests.
+- **Writing through a primitive is rejected instead of destroying it.** With
+  `/user/name` holding a string, `set('/user/name/first', 'Alice')` replaced
+  that string with `{"first": "Alice"}` and reported nothing. The Dart client
+  and `web_core` both raise for the same write. Auto-vivification now fills in
+  absent and null segments only, and a primitive in the way raises
+  `A2uiDataError`.
+- Added `A2uiDataError`, the `DataError` category of the shared suite. Writes
+  that address a list with a non-numeric segment raised a bare `ValueError`,
+  which is outside the `A2uiError` hierarchy consumers catch.
+- A trailing slash no longer addresses a child under an empty key: `/foo/` and
+  `/foo` are the same path, as they are in the Dart client and `web_core`.
+- An observer is only notified when the value it watches actually changes. The
+  cascade reaches every ancestor and descendant of the written path, so an
+  observer of `/a/b` woke up whenever anything under `/a` moved, and rewriting
+  a value with itself notified everyone.
+
 ## 0.1.1
 
 - Enable type checks across `a2ui_core` (#1816).

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/__init__.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/__init__.py
@@ -21,3 +21,4 @@ from a2ui.core.exceptions import A2uiCatalogError as A2uiCatalogError
 from a2ui.core.exceptions import A2uiIntegrityError as A2uiIntegrityError
 from a2ui.core.exceptions import A2uiRecursionError as A2uiRecursionError
 from a2ui.core.exceptions import A2uiCompileError as A2uiCompileError
+from a2ui.core.exceptions import A2uiDataError as A2uiDataError

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/exceptions.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/exceptions.py
@@ -73,3 +73,13 @@ class A2uiCompileError(A2uiError):
     """Exception raised when compiling or translating alternative UI formats/DSLs."""
 
     pass
+
+
+class A2uiDataError(A2uiError):
+    """Exception raised when a JSON Pointer write cannot be applied.
+
+    The `DataError` category of `conformance/core/data_model.yaml`, matching
+    `A2uiDataError` in the Dart client and `A2uiDataError` in `web_core`.
+    """
+
+    pass

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/state/data_model.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/state/data_model.py
@@ -16,6 +16,7 @@ import copy
 import re
 from typing import Any, Callable, Dict, List, Optional, Set
 from ..common.events import Subscription
+from ..exceptions import A2uiDataError
 
 # Regex to check if path segment is numeric (representing array index)
 NUMERIC_PATTERN = re.compile(r"^(?:0|[1-9][0-9]*)$")
@@ -27,6 +28,9 @@ class DataModel:
     def __init__(self, initial_data: Optional[Dict[str, Any]] = None):
         self._data = copy.deepcopy(initial_data or {})
         self._listeners: Dict[str, Set[Callable[[Any], None]]] = {}
+        # The value each watched path last reported, so that a write which
+        # leaves a watched path alone does not wake its observers.
+        self._last_values: Dict[str, Any] = {}
 
     @staticmethod
     def _parse_pointer(path: str) -> List[str]:
@@ -38,6 +42,12 @@ class DataModel:
             return [t.replace("~1", "/").replace("~0", "~") for t in path.split("/")]
 
         tokens = path[1:].split("/")
+        # `/foo/` addresses `/foo`, not a child under an empty key. RFC 6901
+        # would read the empty token as a key of its own, but no A2UI
+        # implementation exposes one, and both the Dart client and web_core
+        # normalise the trailing slash away.
+        if len(tokens) > 1 and tokens[-1] == "":
+            tokens.pop()
         return [t.replace("~1", "/").replace("~0", "~") for t in tokens]
 
     @staticmethod
@@ -103,19 +113,41 @@ class DataModel:
             is_next_numeric = bool(NUMERIC_PATTERN.match(next_token))
 
             if isinstance(current, dict):
-                if token not in current or not isinstance(current[token], (dict, list)):
+                existing = current.get(token)
+                # Only an absent or null segment is filled in. A primitive is a
+                # value someone put there, and writing a path through it would
+                # destroy it silently.
+                if existing is not None and not isinstance(existing, (dict, list)):
+                    raise A2uiDataError(
+                        f"Cannot set path '{path}': segment '{token}' is a "
+                        "primitive value."
+                    )
+                if token not in current or existing is None:
                     current[token] = [] if is_next_numeric else {}
                 current = current[token]
-            elif isinstance(current, list) and NUMERIC_PATTERN.match(token):
+            elif isinstance(current, list):
+                if not NUMERIC_PATTERN.match(token):
+                    raise A2uiDataError(
+                        f"Cannot use non-numeric segment '{token}' on a list."
+                    )
                 idx = int(token)
                 # Expand array if index exceeds size
                 while len(current) <= idx:
                     current.append(None)
-                if current[idx] is None or not isinstance(current[idx], (dict, list)):
+                existing = current[idx]
+                if existing is not None and not isinstance(existing, (dict, list)):
+                    raise A2uiDataError(
+                        f"Cannot set path '{path}': segment '{token}' is a "
+                        "primitive value."
+                    )
+                if existing is None:
                     current[idx] = [] if is_next_numeric else {}
                 current = current[idx]
             else:
-                raise ValueError(f"Cannot traverse path segment: {token} in {path}")
+                raise A2uiDataError(
+                    f"Cannot set path '{path}': intermediate segment '{token}' "
+                    "is a primitive."
+                )
 
         # Set final leaf value
         last_token = tokens[-1]
@@ -124,13 +156,22 @@ class DataModel:
                 current.pop(last_token, None)
             else:
                 current[last_token] = copy.deepcopy(value)
-        elif isinstance(current, list) and NUMERIC_PATTERN.match(last_token):
+        elif isinstance(current, list):
+            if not NUMERIC_PATTERN.match(last_token):
+                raise A2uiDataError(
+                    f"Cannot use non-numeric segment '{last_token}' on a list."
+                )
             idx = int(last_token)
             while len(current) <= idx:
                 current.append(None)
             current[idx] = copy.deepcopy(value)
         else:
-            raise ValueError(f"Leaf segment is not a container: {last_token}")
+            # The parent resolved to a primitive, so there is nothing to write
+            # into. Dropping the write would hide a malformed path.
+            raise A2uiDataError(
+                f"Cannot set path '{path}': '{last_token}' is a property of a "
+                "primitive value."
+            )
 
         # Trigger notification cascade
         self._trigger_cascade(tokens)
@@ -143,18 +184,29 @@ class DataModel:
 
         # Return subscription armed with unsubscription and initial value
         initial = self.get(norm_path)
+        self._last_values[norm_path] = copy.deepcopy(initial)
         return Subscription(
             lambda: self._listeners.get(norm_path, set()).discard(on_change),
             initial_value=initial,
         )
 
     def _trigger_listeners(self, path: str, value: Any) -> None:
-        if path in self._listeners:
-            for listener in list(self._listeners[path]):
-                try:
-                    listener(value)
-                except Exception:
-                    pass
+        listeners = self._listeners.get(path)
+        if not listeners:
+            return
+        # A write that stores the same value, or that replaces a container
+        # without touching this path, is not a change to report. The cascade
+        # reaches every ancestor and descendant of the written path, so without
+        # this an observer of `/a/b` wakes up whenever anything under `/a`
+        # moves.
+        if path in self._last_values and self._last_values[path] == value:
+            return
+        self._last_values[path] = copy.deepcopy(value)
+        for listener in list(listeners):
+            try:
+                listener(value)
+            except Exception:
+                pass
 
     def _trigger_cascade(self, tokens: List[str]) -> None:
         """Notifies listeners cascading both bubble-up (parents) and cascade-down (children)."""
@@ -173,3 +225,4 @@ class DataModel:
     def dispose(self) -> None:
         """Disposes of the data model and all its listeners."""
         self._listeners.clear()
+        self._last_values.clear()

--- a/agent_sdks/python/a2ui_core/tests/conformance/test_data_model_conformance.py
+++ b/agent_sdks/python/a2ui_core/tests/conformance/test_data_model_conformance.py
@@ -1,0 +1,166 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs the shared `conformance/core/data_model.yaml` suite against `DataModel`.
+
+Two mappings, both documented in the suite header: `op: delete` maps to
+`set(path, None)`, since Python has no `undefined`; `watch` attaches one
+observer per entry, so a repeated path attaches a second.
+"""
+
+import copy
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+import pytest
+import yaml
+
+from a2ui.core.exceptions import (
+    A2uiCatalogError,
+    A2uiCompileError,
+    A2uiDataError,
+    A2uiError,
+    A2uiIntegrityError,
+    A2uiParseError,
+    A2uiRecursionError,
+    A2uiValidationError,
+)
+from a2ui.core.state import DataModel
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")
+)
+SUITE_PATH = os.path.join(REPO_ROOT, "conformance", "core", "data_model.yaml")
+
+_ERROR_CATEGORIES = {
+    "DataError": A2uiDataError,
+    "ValidationError": A2uiValidationError,
+    "CatalogError": A2uiCatalogError,
+    "IntegrityError": A2uiIntegrityError,
+    "RecursionError": A2uiRecursionError,
+    "ParseError": A2uiParseError,
+    "CompileError": A2uiCompileError,
+}
+
+
+def load_suite() -> List[Dict[str, Any]]:
+    with open(SUITE_PATH, encoding="utf-8") as handle:
+        return [case for case in yaml.safe_load(handle) if case]
+
+
+SUITE = load_suite()
+
+
+def test_suite_is_not_empty() -> None:
+    assert SUITE
+
+
+class Observer:
+    """One `watch` entry: counts notifications and keeps the last value seen."""
+
+    def __init__(self, model: DataModel, path: str) -> None:
+        self.path = path
+        self.count = 0
+        self.value: Any = None
+        self._subscription = model.subscribe(path, self._on_change)
+        self.value = self._subscription.value
+
+    def _on_change(self, value: Any) -> None:
+        self.count += 1
+        self.value = value
+
+    def reset_count(self) -> None:
+        self.count = 0
+
+
+@pytest.mark.parametrize("case", SUITE, ids=[c["name"] for c in SUITE])
+def test_conformance_case(case: Dict[str, Any]) -> None:
+    # The suite is shared across cases, so deep copy before mutating.
+    model = DataModel(copy.deepcopy(case.get("initial")) or {})
+    try:
+        observers = [Observer(model, path) for path in case.get("watch", [])]
+
+        for index, step in enumerate(case.get("steps", [])):
+            reason = f"{case['name']} step {index} ({step['op']})"
+            for observer in observers:
+                observer.reset_count()
+
+            expect_error = step.get("expect_error")
+            if expect_error is not None:
+                category = _ERROR_CATEGORIES.get(
+                    expect_error.get("category"), A2uiError
+                )
+                with pytest.raises(category) as caught:
+                    _apply_op(model, step)
+                message = expect_error.get("message")
+                if message is not None:
+                    assert re.search(message, str(caught.value)), reason
+                continue
+
+            _apply_op(model, step)
+            _check_notifications(step, observers, reason)
+            _check_watched_values(step, observers, reason)
+    finally:
+        model.dispose()
+
+
+def _apply_op(model: DataModel, step: Dict[str, Any]) -> None:
+    op = step["op"]
+    if op == "get":
+        actual = model.get(step["path"])
+        if "expect" in step:
+            assert actual == step["expect"]
+        if step.get("expect_absent"):
+            assert actual is None
+        expect_type = step.get("expect_type")
+        if expect_type == "list":
+            assert isinstance(actual, list)
+        elif expect_type == "object":
+            assert isinstance(actual, dict)
+    elif op == "set":
+        model.set(step["path"], step.get("value"))
+    elif op == "delete":
+        # Python has no `undefined`; removal is a write of None, which `set`
+        # turns into a key removal.
+        model.set(step["path"], None)
+    elif op == "dispose":
+        model.dispose()
+    else:
+        raise AssertionError(f"unknown op: {op}")
+
+
+def _check_notifications(
+    step: Dict[str, Any], observers: List[Observer], reason: str
+) -> None:
+    expected: Optional[List[str]] = step.get("expect_notified")
+    if expected is None:
+        return
+    notified: List[str] = []
+    for observer in observers:
+        notified.extend([observer.path] * observer.count)
+    assert sorted(notified) == sorted(expected), reason
+
+
+def _check_watched_values(
+    step: Dict[str, Any], observers: List[Observer], reason: str
+) -> None:
+    expected: Optional[Dict[str, Any]] = step.get("expect_values")
+    if expected is None:
+        return
+    for path, value in expected.items():
+        matching = [o for o in observers if o.path == path]
+        assert matching, f"{reason}: no observer watches {path}"
+        for observer in matching:
+            assert observer.value == value, f"{reason}: {path}"


### PR DESCRIPTION
# Description

`conformance/core/data_model.yaml` is the one dataset every implementation of the data model is measured against. The Dart client and `web_core` run it; the Python client did not, and measured itself solely by its own tests. That is how four divergences survived. Wiring the harness up fails 7 of the suite's 37 cases, and this fixes all seven.

**Writing through a primitive destroyed it.** With `/user/name` holding a string, `set('/user/name/first', 'Alice')` replaced that string with `{"first": "Alice"}` and reported nothing. Auto-vivification treated anything that was not a `dict` or a `list` as free to overwrite, so a malformed path from the agent did not fail — it deleted whatever the write passed through. It now fills in absent and null segments only. `web_core` was made to reject the same write in #2499, and Dart does since #2439.

**Rejected list writes raised a bare `ValueError`**, outside the `A2uiError` hierarchy a consumer catches — so code that catches `A2uiError` around a write catches those errors on Dart and web and misses them on Python. The suite names that category `DataError`, so this adds `A2uiDataError` next to the other six and raises it from every rejected write.

**A trailing slash addressed a child under an empty key.** `set('/foo/', 'bar')` stored `{"foo": {"": "bar"}}`, so `get('/foo')` did not return what had just been written to it. RFC 6901 does read the empty token as a key of its own, but no A2UI implementation exposes one and the other two normalise it away.

**Observers were notified whether or not their value changed.** The cascade reaches every ancestor and descendant of the written path, so an observer of `/a/b` woke up whenever anything under `/a` moved, and rewriting a value with itself woke everyone. Each watched path now remembers what it last reported.

Two mappings the harness makes, both documented in the suite header: `op: delete` is `set(path, None)`, since Python has no `undefined`; `watch` attaches one observer per entry. The header also excludes what cannot hold across languages — prototype pollution, the `undefined` distinction, leading-zero indices, the auto-vivify index cap — so none of the seven asks Python to imitate another runtime.

Fixes #2622.

Suites: 37/37 conformance cases, 248 in `a2ui_core`, 600 in `a2ui_agent`. `pyink --check` and `mypy` clean.

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

The last one is unticked rather than assumed: that script drives the `restaurant_finder` Flutter sample against a live model and needs an API key I do not have. Nothing here reaches it — the change is confined to the Python data model and its tests. Happy to be told otherwise.

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/tree/main/samples

