### PR TITLE
fix(swift): stop a malformed path from deleting what it is written through

### DIFF
--- a/swift/core/Sources/A2UICore/Extensions/JSONValue+Path.swift
+++ b/swift/core/Sources/A2UICore/Extensions/JSONValue+Path.swift
@@ -142,6 +142,17 @@ extension JSONValue {
   }
 
   /// Recursively updates a node at the given path components.
+  ///
+  /// Auto-vivification fills in absent and null nodes only. A path that runs
+  /// through a value which is neither an object nor an array — a string where
+  /// an object was expected, a non-numeric key on an array — leaves the tree
+  /// untouched rather than growing a container over what is already there.
+  ///
+  /// Note that the write is then dropped without a word, which is not what the
+  /// other clients do: Dart, `web_core` and the Python client all raise for
+  /// these paths, and `conformance/core/data_model.yaml` says they should.
+  /// `DataModel.set` cannot report a rejected write today, so this stops the
+  /// data loss and leaves the reporting to be settled separately.
   static func update(
     node: JSONValue?,
     components: ArraySlice<String>,
@@ -206,22 +217,18 @@ extension JSONValue {
         }
         return .array(array)
       } else {
-        if newValue == nil && isLastComponent { return node }
-        var dict: OrderedDictionary<String, JSONValue> = [:]
-        if isLastComponent {
-          if let newValue { dict[key] = newValue }
-        } else {
-          dict[key] = update(
-            node: nil,
-            components: remainingComponents,
-            newValue: newValue
-          )
-        }
-        return .object(dict)
+        // A non-numeric key does not address an element of an array. Building
+        // an object here would replace the whole array with it, so a single
+        // malformed path from the agent would delete every element. The array
+        // is left as it is; see the note on `update` about reporting.
+        return node
       }
 
     default:
       if newValue == nil { return node }
+      // Only an absent or null node is filled in. Anything else is a value
+      // someone put there, and growing a container over it would delete it.
+      if let node, node != .null { return node }
       if let index = Int(key), index >= 0 {
         // Auto-vivify an array for any numeric key, matching
         // web_core's isNumeric() auto-vivification rule.

--- a/swift/core/Tests/A2UIConformanceTests/DataModelConformanceTests.swift
+++ b/swift/core/Tests/A2UIConformanceTests/DataModelConformanceTests.swift
@@ -1,0 +1,118 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import A2UICore
+import Foundation
+import OrderedJSON
+import Testing
+
+/// Runs the shared `conformance/core/data_model.yaml` suite against
+/// ``DataModel``, the way the Dart client and `web_core` already do.
+///
+/// Two shapes of case are out of reach today. Both skips are derived from the
+/// case itself rather than from a list of names, so neither can quietly grow as
+/// the suite does:
+///
+/// * Cases carrying `watch` need one observer per path. `DataModel` publishes
+///   the whole tree through `dataPublisher` and has nothing to attach to a
+///   single path.
+/// * Cases carrying `expect_error` need `set` to report a rejected write, and
+///   its signature has no way to. Those paths no longer destroy what they run
+///   through — see `JSONValue.update` — but they are dropped in silence, which
+///   is not what the suite asks for.
+///
+/// `op: delete` maps to `set(path, value: nil)`, as the suite header allows for
+/// languages without `undefined`.
+@MainActor
+struct DataModelConformanceTests {
+  @Test func dataModelConformance() throws {
+    let rawYAML = try ConformanceTestHelper.loadYAML(filename: "core/data_model.yaml")
+    let cases = (rawYAML as? [[String: Any]]) ?? []
+    #expect(!cases.isEmpty, "core/data_model.yaml should hold test cases")
+
+    var executed = 0
+    var needObservers = 0
+    var needErrorReporting = 0
+
+    for testCase in cases {
+      let name = testCase["name"] as? String ?? "<unnamed>"
+      let steps = testCase["steps"] as? [[String: Any]] ?? []
+
+      if testCase["watch"] != nil {
+        needObservers += 1
+        continue
+      }
+      if steps.contains(where: { $0["expect_error"] != nil }) {
+        needErrorReporting += 1
+        continue
+      }
+      executed += 1
+
+      let initial =
+        testCase["initial"].map { ConformanceTestHelper.toJSONValue($0) } ?? .object([:])
+      let model = DataModel(initial: initial)
+
+      for (index, step) in steps.enumerated() {
+        let operation = step["op"] as? String ?? ""
+        let path = step["path"] as? String ?? "/"
+        let location = "\(name) step \(index) (\(operation) \(path))"
+
+        switch operation {
+        case "get":
+          let actual = model.get(path)
+          if let expected = step["expect"] {
+            #expect(
+              actual == ConformanceTestHelper.toJSONValue(expected),
+              "\(location): got \(actual.map { "\($0)" } ?? "nil")"
+            )
+          }
+          if (step["expect_absent"] as? Bool) == true {
+            #expect(
+              actual == nil || actual == .null,
+              "\(location): expected nothing, got \(actual.map { "\($0)" } ?? "nil")"
+            )
+          }
+          if let expectedType = step["expect_type"] as? String {
+            let matches =
+              (expectedType == "list" && actual?.arrayValue != nil)
+              || (expectedType == "object" && actual?.objectValue != nil)
+            #expect(
+              matches,
+              "\(location): expected a \(expectedType), got \(actual.map { "\($0)" } ?? "nil")"
+            )
+          }
+        case "set":
+          model.set(path, value: step["value"].map { ConformanceTestHelper.toJSONValue($0) })
+        case "delete":
+          model.set(path, value: nil)
+        case "dispose":
+          break
+        default:
+          Issue.record("\(location): unknown op")
+        }
+      }
+    }
+
+    #expect(executed > 0, "no case of the suite could be executed")
+    // Recorded rather than merely skipped, so the two gaps stay visible in the
+    // test output instead of looking like full coverage.
+    print(
+      """
+      core/data_model.yaml: \(executed) executed, \
+      \(needObservers) need a per-path observer API, \
+      \(needErrorReporting) need `set` to report a rejected write
+      """
+    )
+  }
+}

--- a/swift/core/Tests/A2UIConformanceTests/DataModelPointerConformanceTests.swift
+++ b/swift/core/Tests/A2UIConformanceTests/DataModelPointerConformanceTests.swift
@@ -48,6 +48,52 @@ struct DataModelPointerConformanceTests {
     #expect(list?[2] == .string("c"))
   }
 
+  @Test func primitiveInTheWaySurvives() {
+    let dataModel = DataModel(
+      initial: .object(["user": .object(["name": .string("Alice")])])
+    )
+
+    dataModel.set("/user/name/first", value: .string("Bob"))
+
+    // Growing an object over "Alice" would delete it, which is what a
+    // malformed path from the agent used to do.
+    #expect(dataModel.get("/user/name")?.stringValue == "Alice")
+    #expect(dataModel.get("/user/name/first") == nil)
+  }
+
+  @Test func primitiveListElementSurvives() {
+    let dataModel = DataModel(
+      initial: .object(["items": .array([.string("a"), .string("b")])])
+    )
+
+    dataModel.set("/items/0/foo", value: .string("bar"))
+
+    #expect(dataModel.get("/items")?.arrayValue == [.string("a"), .string("b")])
+  }
+
+  @Test func nonNumericKeyLeavesTheListAlone() {
+    let dataModel = DataModel(
+      initial: .object(["items": .array([.string("a"), .string("b")])])
+    )
+
+    dataModel.set("/items/foo", value: .string("bar"))
+    dataModel.set("/items/foo/bar", value: .string("value"))
+
+    // Either write used to replace the whole array with an object, taking
+    // every element with it.
+    #expect(dataModel.get("/items")?.arrayValue == [.string("a"), .string("b")])
+  }
+
+  @Test func nullIsStillFilledIn() {
+    let dataModel = DataModel(initial: .object(["slot": .null]))
+
+    dataModel.set("/slot/name", value: .string("Alice"))
+
+    // Null is absence, not a value someone put there, so it is still grown
+    // into a container.
+    #expect(dataModel.get("/slot/name")?.stringValue == "Alice")
+  }
+
   @Test func rootReplacement() {
     let dataModel = DataModel(initial: .object(["a": .integer(1)]))
 

--- a/swift/core/Tests/A2UICoreTests/JSONValuePathTests.swift
+++ b/swift/core/Tests/A2UICoreTests/JSONValuePathTests.swift
@@ -99,10 +99,15 @@ struct JSONValuePathTests {
     #expect(value == .string("hello"))
   }
 
-  @Test func subscriptSetAutoVivifiesArrayFromPrimitive() {
+  @Test func subscriptSetLeavesAPrimitiveAlone() {
     var value: JSONValue = "primitive"
     value["0/name"] = "Alice"
-    #expect(value.arrayValue?.count == 1)
-    #expect(value["0/name"]?.stringValue == "Alice")
+
+    // Was `subscriptSetAutoVivifiesArrayFromPrimitive`, which pinned the
+    // opposite: the string was replaced by `[{"name": "Alice"}]` and lost.
+    // `conformance/core/data_model.yaml` calls that write an error
+    // (`test_data_model_rejects_write_through_primitive`), and the Dart client,
+    // `web_core` and the Python client all reject it.
+    #expect(value == .string("primitive"))
   }
 }


### PR DESCRIPTION
# Description

Running `conformance/core/data_model.yaml` against the Swift `DataModel` executes 19 of its 37 cases. All 19 pass. The four that fail are the four that write a path through a value which is not a container, and each destroys data:

```
/user/name is "Alice"     set /user/name/first  ->  {"name": {"first": ...}}   "Alice" gone
/items is ["a","b","c"]   set /items/0/foo      ->  [{"foo": ...},"b","c"]     "a" gone
/items is ["a","b","c"]   set /items/foo        ->  {"foo": ...}               array gone
/items is ["a","b","c"]   set /items/foo/bar    ->  {"foo": {"bar": ...}}      array gone
```

The last two are the ones that matter most: one non-numeric segment in a path an agent emits replaces an entire array with an object.

`JSONValue.update` auto-vivified over anything that was not an object or an array, and its array branch built an object when the key did not parse as an index — returning that object in place of the array. It now fills in absent and null nodes only and leaves any other value where it is. Null still counts as absence, so ordinary auto-vivification is unchanged: `numericAutoVivification` and the sparse-array tests pass exactly as before.

**This was pinned, which is why nothing caught it.** `subscriptSetAutoVivifiesArrayFromPrimitive` asserted that writing `0/name` over the string `"primitive"` replaces the string — the opposite of `test_data_model_rejects_write_through_primitive` in the shared suite, which Dart, `web_core` and Python all honour. A local unit test and the shared suite disagreed, and only the local one was running. It is updated rather than deleted, and now says what it holds and why.

**What this deliberately does not do** is make those four cases pass. That needs `set` to be able to report a rejected write, and `public func set(_ path: String, value: JSONValue?)` returns Void. Stopping the data loss does not need that decision; reporting does, and it changes public API. Same for the 14 cases written against per-path observers, which `DataModel` does not offer. Both questions are in #2625.

The new harness therefore skips those two shapes — by their shape, not by a list of names, so neither skip can quietly grow — and prints what it left out on every run:

```
core/data_model.yaml: 19 executed, 14 need a per-path observer API, 4 need `set` to report a rejected write
```

Fixes the data loss in #2625; the two API questions there stay open.

427 tests, `swift-format lint` clean. One pre-existing failure unrelated to this change: `formatters()` expects `99.99` and reads `US$ 99,99` on a machine whose locale uses a decimal comma — it fails identically on an unmodified checkout, and should pass on CI.

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

Two boxes left honest rather than ticked: `swift/` has no CHANGELOG.md to update — say the word if one should be started — and `e2e_test.sh` drives the `restaurant_finder` Flutter sample against a live model with an API key I do not have. Nothing here reaches it.

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/tree/main/samples
