### PR TITLE
fix(web_core): accept function calls that omit `args` (v0.9)

### DIFF
--- a/renderers/web_core/src/v0_9/rendering/data-context.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.test.ts
@@ -229,6 +229,33 @@ describe('DataContext', () => {
     assert.strictEqual(result, 3);
   });
 
+  it('resolves function calls that omit args', () => {
+    // The spec requires only `call`, so an argument-less call is valid.
+    let receivedArgs: unknown;
+    const fnInvoker = (name: string, args: Record<string, any>) => {
+      receivedArgs = args;
+      return name === 'now' ? 'noon' : null;
+    };
+    const ctx = createTestDataContext(model, '/user', fnInvoker);
+
+    assert.strictEqual(ctx.resolveDynamicValue({call: 'now'} as any), 'noon');
+    assert.deepStrictEqual(receivedArgs, {});
+  });
+
+  it('subscribes to function calls that omit args', () => {
+    let receivedArgs: unknown;
+    const fnInvoker = (name: string, args: Record<string, any>) => {
+      receivedArgs = args;
+      return name === 'now' ? 'noon' : null;
+    };
+    const ctx = createTestDataContext(model, '/user', fnInvoker);
+
+    const sub = ctx.subscribeDynamicValue({call: 'now'} as any, () => {});
+    assert.strictEqual(sub.value, 'noon');
+    assert.deepStrictEqual(receivedArgs, {});
+    sub.unsubscribe();
+  });
+
   it('dispatches generic error on function call without invoker synchronously', () => {
     let dispatchedError: any = null;
     const ctx = createTestDataContext(

--- a/renderers/web_core/src/v0_9/rendering/data-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.ts
@@ -126,7 +126,7 @@ export class DataContext {
       const call = value as FunctionCall;
       const args: Record<string, any> = {};
 
-      for (const [key, argVal] of Object.entries(call.args)) {
+      for (const [key, argVal] of Object.entries(call.args ?? {})) {
         args[key] = this.resolveDynamicValue(argVal);
       }
 
@@ -228,7 +228,7 @@ export class DataContext {
       const call = value as FunctionCall;
       const argSignals: Record<string, Signal<any>> = {};
 
-      for (const [key, argVal] of Object.entries(call.args)) {
+      for (const [key, argVal] of Object.entries(call.args ?? {})) {
         argSignals[key] = this.resolveSignal(argVal);
       }
 

--- a/renderers/web_core/src/v0_9/schema/common-types.ts
+++ b/renderers/web_core/src/v0_9/schema/common-types.ts
@@ -28,7 +28,7 @@ export type DataBindingType = z.infer<typeof DataBindingSchema>;
 export const FunctionCallSchema = z
   .object({
     'call': z.string().describe('The name of the function to call.'),
-    'args': z.record(z.any()).describe('Arguments passed to the function.'),
+    'args': z.record(z.any()).optional().describe('Arguments passed to the function.'),
     'returnType': z
       .enum(['string', 'number', 'boolean', 'array', 'object', 'any', 'void'])
       .default('boolean'),

--- a/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
+++ b/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
@@ -26,6 +26,7 @@ import {
   UpdateDataModelMessageSchema,
   DeleteSurfaceMessageSchema,
 } from './server-to-client.js';
+import {FunctionCallSchema} from './common-types.js';
 
 const currentDir = typeof __dirname !== 'undefined' ? __dirname : resolve('src/v0_9/schema');
 const specPathCandidate1 = resolve(currentDir, '../../../../../specification/v0_9/json');
@@ -223,5 +224,26 @@ describe('A2UI Schema Verification v0.9 & v0.9.1', () => {
       deleteSurface: {surfaceId: 'surface-2'},
     };
     assert.deepStrictEqual(A2uiMessageSchema.parse(msgV091), msgV091);
+  });
+
+  it('keeps FunctionCall required fields aligned with the spec', () => {
+    const specDefs = JSON.parse(
+      readFileSync(join(SPEC_DIR_V0_9, 'common_types.json'), 'utf-8'),
+    ).$defs;
+    const generated = zodToJsonSchema(FunctionCallSchema, {
+      target: 'jsonSchema2019-09',
+    }) as {required?: string[]};
+
+    assert.deepStrictEqual(
+      [...(generated.required ?? [])].sort(),
+      [...specDefs.FunctionCall.required].sort(),
+    );
+  });
+
+  it('accepts a function call that omits args, as the spec allows', () => {
+    assert.deepStrictEqual(FunctionCallSchema.parse({call: 'now'}), {
+      call: 'now',
+      returnType: 'boolean',
+    });
   });
 });


### PR DESCRIPTION
## Problem
`common_types.json#/$defs/FunctionCall` requires only `call`, but the Zod
schema marked `args` as required. So a spec-valid `{"call": "now"}`:
- failed validation, and
- crashed `DataContext` with a raw `TypeError` from
  `Object.entries(undefined)` on both the sync and reactive resolve paths.
Swift already models `args` as optional, so web_core was the outlier.
## Fix
- `FunctionCallSchema`: `args` is now `.optional()`, matching the JSON schema.
- `DataContext`: default to `{}` in `resolveDynamicValue` and `resolveSignal`.
  The optional type makes removing either guard a compile error.
## Tests
Four added, each confirmed to fail before the fix:
- `data-context.test.ts`: argument-less calls resolve on the sync and
  reactive paths, and the invoker receives `{}`.
- `verify-schema.test.ts`: `FunctionCall.required` matches the spec JSON, and
  an argument-less call parses. The existing parity suite only compares
  `server_to_client` definitions, which is why this drift went unnoticed.